### PR TITLE
ci: install viewer npm deps before unit tests

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -41,10 +41,23 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install dependencies
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: viewer/package-lock.json
+
+      - name: Install Python dependencies
         run: |
           pip install uv
           uv pip install --system -e ".[dev]"
+
+      - name: Install viewer npm dependencies
+        # tests/test_viewer_*.py shell out to `node` against viewer TypeScript
+        # sources that import npm packages (e.g. `yaml` in artifacts.ts).
+        # Without `viewer/node_modules` populated the viewer harness fails
+        # with ERR_MODULE_NOT_FOUND.
+        run: npm ci --prefix viewer
 
       - name: Run unit tests
         run: pytest tests/ -x -q


### PR DESCRIPTION
## Problem

`tests/test_viewer_*.py` shell out to `node --experimental-strip-types` against viewer TypeScript sources that import npm packages (e.g. `yaml` in `viewer/src/lib/server/artifacts.ts`). Without `viewer/node_modules` populated, node's module resolver fails with `ERR_MODULE_NOT_FOUND` and **all 22 viewer tests fail**.

Until now this was masked by an unrelated `test_runner_progress` failure paired with pytest's `-x` flag, which stopped before the viewer tests ran. Fixing that test in #10 (commit b18646c) made the viewer failures visible. This PR gives them what they need.

## Repro

```bash
# On main, before this PR
pytest tests/test_viewer_server_artifacts.py
# 22 failed: ERR_MODULE_NOT_FOUND: Cannot find package 'yaml'

cd viewer && npm install && cd ..
pytest tests/test_viewer_server_artifacts.py
# all pass
```

## Fix

Add `actions/setup-node@v4` and `npm ci --prefix viewer` to the `tier1-unit` job. Cache npm by `viewer/package-lock.json` for fast reruns. The expensive `tier4-regression` job is unchanged - it doesn't currently run pytest.

## Out of scope

- Expanding the workflow's `paths` filter to include `viewer/**` (would also fire the 90-min `tier4-regression` job on viewer-only PRs - separate decision).
- The 28 dependabot vulnerabilities reported on push - separate cleanup track.