### PR TITLE
feat: coordinated rate-limit retry with per-model adaptive backoff

### DIFF
--- a/p2m/core/judge.py
+++ b/p2m/core/judge.py
@@ -670,11 +670,12 @@ def _build_judge_request(
     judge_temperature: Optional[float],
     judge_max_tokens: int,
     reasoning_effort: Optional[str] = None,
+    call_label: Optional[str] = None,
 ) -> tuple[GenerateOptions, Message, Message]:
     # Reasoning models don't support temperature
     if reasoning_effort is not None:
         judge_temperature = None
-    options = GenerateOptions(max_tokens=judge_max_tokens, timeout_s=DEFAULT_MODEL_TIMEOUT_S, reasoning_effort=reasoning_effort)
+    options = GenerateOptions(max_tokens=judge_max_tokens, timeout_s=DEFAULT_MODEL_TIMEOUT_S, reasoning_effort=reasoning_effort, call_label=call_label)
     if judge_temperature is not None:
         options.temperature = judge_temperature
     return (
@@ -954,6 +955,7 @@ async def run_transcript_judge(
         judge_temperature=judge_temperature,
         judge_max_tokens=judge_max_tokens,
         reasoning_effort=reasoning_effort,
+        call_label=f"judge:{transcript.metadata.seed_id}" if transcript.metadata else None,
     )
     parseable_verdicts, parseable_raws, transport_failures = await _run_judge_attempts(
         judge_model,

--- a/p2m/core/model_client.py
+++ b/p2m/core/model_client.py
@@ -5,8 +5,13 @@ from __future__ import annotations
 import asyncio
 import importlib
 import json
+import logging
+import random
+import time
 from dataclasses import asdict, dataclass, field, is_dataclass
 from typing import Any, Mapping, Sequence
+
+log = logging.getLogger(__name__)
 
 # ── Types ──────────────────────────────────────────────────────
 
@@ -105,6 +110,7 @@ class GenerateOptions:
     reasoning_effort: str | None = None
     tool_choice: str | dict[str, Any] | None = None
     timeout_s: float | None = None
+    call_label: str | None = None
     extra_kwargs: dict[str, Any] = field(default_factory=dict)
 
 
@@ -546,6 +552,180 @@ __all__ = [
 ]
 
 
+# ── Per-model adaptive rate limiter ────────────────────────────
+
+_MAX_RETRIES = 5
+_INITIAL_BACKOFF_S = 1.0
+_MAX_BACKOFF_S = 60.0
+_DEFAULT_COOLDOWN_S = 2.0
+
+
+def _extract_retry_after(exc: Exception) -> float | None:
+    """Try to extract Retry-After seconds from a rate limit error."""
+    for source in (exc, getattr(exc, "__cause__", None)):
+        if source is None:
+            continue
+        for attr in ("headers", "response_headers"):
+            headers = getattr(source, attr, None)
+            if not headers:
+                continue
+            value = headers.get("Retry-After") or headers.get("retry-after")
+            if value is not None:
+                try:
+                    return float(value)
+                except (TypeError, ValueError):
+                    pass
+    return None
+
+
+class _ModelRateLimiter:
+    """Coordinated per-model cooldown.
+
+    When *any* task receives a 429 for a model, a cooldown timestamp is
+    set.  All tasks calling that model wait until the cooldown expires
+    before issuing the next request, preventing the thundering-herd
+    pattern where N concurrent tasks all retry into the same wall.
+
+    To avoid a *stampede at cooldown expiry* (all waiters resuming at
+    the same instant), ``wait_if_cooled`` adds per-task jitter that
+    spreads wake-ups over the cooldown window.
+
+    Escalation logic: only escalate the base cooldown when a 429 arrives
+    **after** the previous cooldown has fully expired — meaning the
+    cooldown was too short.  Concurrent 429s that arrive while a cooldown
+    is already active are from in-flight requests sent before the cooldown
+    was set, so they just extend the existing cooldown without escalating.
+    On any successful call, the escalation level resets.
+    """
+
+    def __init__(self) -> None:
+        self._cooldown_until: dict[str, float] = {}
+        self._base_cooldown: dict[str, float] = {}
+        self._lock: asyncio.Lock | None = None
+
+    def _get_lock(self) -> asyncio.Lock:
+        if self._lock is None:
+            self._lock = asyncio.Lock()
+        return self._lock
+
+    async def wait_if_cooled(self, model: str) -> None:
+        """Block until the cooldown for *model* has expired, with jitter."""
+        until = self._cooldown_until.get(model, 0.0)
+        delay = until - time.monotonic()
+        if delay > 0:
+            # Spread wake-ups: each task adds random jitter so they
+            # don't all resume at the exact cooldown expiry.
+            jitter = random.uniform(0, max(delay * 0.5, 0.5))
+            total = delay + jitter
+            log.info("Rate limiter: waiting %.1fs (%.1fs + %.1fs jitter) for model %s cooldown", total, delay, jitter, model)
+            await asyncio.sleep(total)
+
+    async def report_rate_limit(
+        self, model: str, retry_after: float | None = None,
+    ) -> bool:
+        """Record a 429 and set or extend a cooldown for *model*.
+
+        Returns ``True`` if this call initiated or escalated the cooldown
+        (the caller should log at WARNING level).  Returns ``False`` for
+        concurrent in-flight 429s during an active cooldown — these are
+        absorbed silently to avoid log spam.
+
+        Escalation only happens when the previous cooldown already
+        expired — this means we retried and *still* got 429, so the
+        base cooldown was too short.  Concurrent in-flight 429s during
+        an active cooldown are absorbed without escalating.
+        """
+        now = time.monotonic()
+        async with self._get_lock():
+            current_until = self._cooldown_until.get(model, 0.0)
+            base = self._base_cooldown.get(model, _DEFAULT_COOLDOWN_S)
+
+            if retry_after is not None:
+                # Server told us how long — trust it and adopt as base.
+                wait_s = min(retry_after, _MAX_BACKOFF_S)
+                self._base_cooldown[model] = wait_s
+                is_new = True
+            elif current_until <= now:
+                # Cooldown expired and we still got 429 → escalate base.
+                wait_s = min(base * 2, _MAX_BACKOFF_S)
+                self._base_cooldown[model] = wait_s
+                is_new = True
+            else:
+                # Active cooldown — concurrent in-flight request, don't
+                # escalate.  Just extend if needed using current base.
+                wait_s = base
+                is_new = False
+
+            new_until = now + wait_s
+            if new_until > current_until:
+                self._cooldown_until[model] = new_until
+                if is_new:
+                    log.warning(
+                        "Rate limiter: model %s cooled down for %.1fs", model, wait_s,
+                    )
+            return is_new
+
+    def report_success(self, model: str) -> None:
+        """Reset escalation state after a successful call."""
+        self._base_cooldown.pop(model, None)
+
+
+_rate_limiter = _ModelRateLimiter()
+
+
+async def _with_retries(call_fn: Any, *, model: str, label: str | None = None) -> Any:
+    """Retry an async LLM call with coordinated backoff on retryable errors.
+
+    On ``LLMRateLimitError`` the global per-model cooldown is set and
+    all concurrent tasks for that model pause via ``wait_if_cooled``.
+    The individual per-attempt exponential backoff is only applied for
+    non-rate-limit retryable errors (e.g. 5xx); for 429s the
+    coordinated cooldown (with jitter) is the sole wait mechanism,
+    preventing the stampede-at-expiry pattern.
+    """
+    tag = f" [{label}]" if label else ""
+    last_exc: Exception | None = None
+    for attempt in range(_MAX_RETRIES + 1):
+        await _rate_limiter.wait_if_cooled(model)
+        try:
+            result = await call_fn()
+            _rate_limiter.report_success(model)
+            return result
+        except Exception as exc:
+            classified = _classify_llm_error(exc)
+            if attempt < _MAX_RETRIES and isinstance(classified, (LLMRateLimitError, LLMProviderError)):
+                last_exc = classified
+                if isinstance(classified, LLMRateLimitError):
+                    retry_after = _extract_retry_after(exc)
+                    is_new = await _rate_limiter.report_rate_limit(model, retry_after)
+                    if is_new:
+                        log.warning(
+                            "%s%s (attempt %d/%d), waiting for coordinated cooldown: %s",
+                            model, tag, attempt + 1, _MAX_RETRIES + 1, classified,
+                        )
+                    else:
+                        log.debug(
+                            "%s%s (attempt %d/%d), in-flight 429 during active cooldown",
+                            model, tag, attempt + 1, _MAX_RETRIES + 1,
+                        )
+                    # Skip individual backoff — the coordinated cooldown
+                    # (checked at loop top) handles the wait with jitter.
+                    continue
+                # Non-rate-limit retryable error (5xx): individual backoff.
+                backoff = min(_INITIAL_BACKOFF_S * (2 ** attempt), _MAX_BACKOFF_S)
+                jitter = random.uniform(0, backoff * 0.5)
+                wait_s = backoff + jitter
+                log.warning(
+                    "%s%s (attempt %d/%d), retrying in %.1fs: %s",
+                    model, tag, attempt + 1, _MAX_RETRIES + 1, wait_s, classified,
+                )
+                await asyncio.sleep(wait_s)
+                continue
+            raise classified from exc
+    assert last_exc is not None
+    raise last_exc
+
+
 async def generate(
     model: str,
     messages: str | Sequence[MessageLike],
@@ -554,30 +734,33 @@ async def generate(
     """Run a standard async text generation call."""
     resolved_options = options or GenerateOptions()
     litellm = _get_litellm_module()
-    try:
-        if resolved_options.web_search:
-            payload = _build_responses_payload(model, messages, resolved_options)
-            payload["tools"] = [{"type": "web_search_preview"}]
-            responses_client, is_async = _responses_client(litellm)
+
+    if resolved_options.web_search:
+        payload = _build_responses_payload(model, messages, resolved_options)
+        payload["tools"] = [{"type": "web_search_preview"}]
+        responses_client, is_async = _responses_client(litellm)
+
+        async def _call() -> Any:
             if is_async:
-                raw_response = await _await_with_timeout(
+                return await _await_with_timeout(
                     responses_client(**payload),
                     timeout_s=resolved_options.timeout_s,
                 )
-            else:
-                raw_response = await _run_sync_with_timeout(
-                    responses_client,
-                    timeout_s=resolved_options.timeout_s,
-                    **payload,
-                )
-        else:
-            payload = _build_chat_payload(model, messages, resolved_options)
-            raw_response = await _await_with_timeout(
+            return await _run_sync_with_timeout(
+                responses_client,
+                timeout_s=resolved_options.timeout_s,
+                **payload,
+            )
+    else:
+        payload = _build_chat_payload(model, messages, resolved_options)
+
+        async def _call() -> Any:
+            return await _await_with_timeout(
                 litellm.acompletion(**payload),
                 timeout_s=resolved_options.timeout_s,
             )
-    except Exception as exc:
-        raise _classify_llm_error(exc) from exc
+
+    raw_response = await _with_retries(_call, model=model, label=resolved_options.call_label)
     return normalize_response(
         raw_response,
         api_mode="responses" if resolved_options.web_search else "chat_completion",
@@ -596,40 +779,43 @@ async def generate_structured(
     """Run a structured generation call constrained by a JSON schema."""
     resolved_options = options or GenerateOptions()
     litellm = _get_litellm_module()
-    try:
-        if resolved_options.web_search:
-            payload = _build_responses_payload(model, messages, resolved_options)
-            payload["tools"] = [{"type": "web_search_preview"}]
-            payload["text"] = {
-                "format": build_json_schema_text_format(
-                    schema_name,
-                    json_schema,
-                )
-            }
-            responses_client, is_async = _responses_client(litellm)
-            if is_async:
-                raw_response = await _await_with_timeout(
-                    responses_client(**payload),
-                    timeout_s=resolved_options.timeout_s,
-                )
-            else:
-                raw_response = await _run_sync_with_timeout(
-                    responses_client,
-                    timeout_s=resolved_options.timeout_s,
-                    **payload,
-                )
-        else:
-            payload = _build_chat_payload(model, messages, resolved_options)
-            payload["response_format"] = build_json_schema_response_format(
+
+    if resolved_options.web_search:
+        payload = _build_responses_payload(model, messages, resolved_options)
+        payload["tools"] = [{"type": "web_search_preview"}]
+        payload["text"] = {
+            "format": build_json_schema_text_format(
                 schema_name,
                 json_schema,
             )
-            raw_response = await _await_with_timeout(
+        }
+        responses_client, is_async = _responses_client(litellm)
+
+        async def _call() -> Any:
+            if is_async:
+                return await _await_with_timeout(
+                    responses_client(**payload),
+                    timeout_s=resolved_options.timeout_s,
+                )
+            return await _run_sync_with_timeout(
+                responses_client,
+                timeout_s=resolved_options.timeout_s,
+                **payload,
+            )
+    else:
+        payload = _build_chat_payload(model, messages, resolved_options)
+        payload["response_format"] = build_json_schema_response_format(
+            schema_name,
+            json_schema,
+        )
+
+        async def _call() -> Any:
+            return await _await_with_timeout(
                 litellm.acompletion(**payload),
                 timeout_s=resolved_options.timeout_s,
             )
-    except Exception as exc:
-        raise _classify_llm_error(exc) from exc
+
+    raw_response = await _with_retries(_call, model=model, label=resolved_options.call_label)
     return normalize_response(
         raw_response,
         api_mode="responses" if resolved_options.web_search else "chat_completion",
@@ -652,13 +838,14 @@ async def generate_with_tools(
         payload["tool_choice"] = resolved_options.tool_choice
 
     litellm = _get_litellm_module()
-    try:
-        raw_response = await _await_with_timeout(
+
+    async def _call() -> Any:
+        return await _await_with_timeout(
             litellm.acompletion(**payload),
             timeout_s=resolved_options.timeout_s,
         )
-    except Exception as exc:
-        raise _classify_llm_error(exc) from exc
+
+    raw_response = await _with_retries(_call, model=model, label=resolved_options.call_label)
     return normalize_response(
         raw_response,
         api_mode="chat_completion",

--- a/p2m/core/model_client.py
+++ b/p2m/core/model_client.py
@@ -392,6 +392,10 @@ def _get_litellm_module() -> Any:
             ) from exc
         # Silence noisy litellm warnings that pollute stderr
         _LITELLM_MODULE.suppress_debug_info = True
+        # Disable LiteLLM's internal retry so _with_retries is the
+        # sole retry layer — avoids double-retry and lets the
+        # coordinated per-model cooldown work correctly.
+        _LITELLM_MODULE.num_retries = 0
     return _LITELLM_MODULE
 
 
@@ -423,24 +427,76 @@ class LLMProviderError(Exception):
 
 
 def _classify_llm_error(exc: Exception) -> Exception:
-    """Wrap litellm exceptions into categorized errors."""
+    """Wrap litellm exceptions into categorized errors.
+
+    LiteLLM maps provider HTTP errors to OpenAI-compatible exception types.
+    We re-classify them into four categories that drive retry behaviour in
+    ``_with_retries``.  The mapping below is based on the LiteLLM exception
+    table (https://docs.litellm.ai/docs/exception_mapping).
+
+    HTTP   LiteLLM exception                       → p2m class (retried?)
+    ─────  ──────────────────────────────────────── ─────────────────────────
+    400    BadRequestError                          → LLMInputError  (no)
+           ├─ ContextWindowExceededError            → LLMInputError  (no)
+           ├─ ContentPolicyViolationError           → LLMInputError  (no)
+           ├─ UnsupportedParamsError                → LLMInputError  (no)
+           └─ ImageFetchError                       → LLMInputError  (no)
+    401    AuthenticationError                      → LLMAuthError   (no)
+    403    PermissionDeniedError                    → LLMAuthError   (no)
+    404    NotFoundError                            → LLMInputError  (no)
+    408    Timeout  (inherits APIConnectionError)   → LLMProviderError (yes)
+    422    UnprocessableEntityError                 → LLMInputError  (no)
+    429    RateLimitError                           → LLMRateLimitError (yes, coordinated)
+    500    APIError / APIConnectionError            → LLMProviderError (yes)
+    503    ServiceUnavailableError (inherits APIError) → LLMProviderError (yes)
+    ≥500   InternalServerError (inherits APIError)  → LLMProviderError (yes)
+    N/A    APIResponseValidationError               → LLMInputError  (no)
+    N/A    BudgetExceededError                      → (falls through as-is)
+
+    Check order matters: specific subclasses must be tested before their
+    bases (e.g. NotFoundError before APIError, since NotFoundError inherits
+    from APIStatusError → APIError on some providers).
+    """
     litellm = _get_litellm_module()
+    # 401 — bad credentials
     if isinstance(exc, litellm.AuthenticationError):
         err = LLMAuthError(f"Authentication failed: {exc}")
         err.__cause__ = exc
         return err
+    # 403 — insufficient permissions
+    if isinstance(exc, getattr(litellm, "PermissionDeniedError", ())):
+        err = LLMAuthError(f"Permission denied: {exc}")
+        err.__cause__ = exc
+        return err
+    # 429 — rate limited (retryable with coordinated backoff)
     if isinstance(exc, litellm.RateLimitError):
         err = LLMRateLimitError(f"Rate limited: {exc}")
         err.__cause__ = exc
         return err
+    # 400 — bad request (includes ContextWindowExceeded, ContentPolicyViolation)
     if isinstance(exc, litellm.BadRequestError):
         err = LLMInputError(f"Bad request: {exc}")
         err.__cause__ = exc
         return err
+    # 404 — model/deployment not found
     if isinstance(exc, litellm.NotFoundError):
         err = LLMInputError(f"Model/deployment not found: {exc}")
         err.__cause__ = exc
         return err
+    # 422 — unprocessable entity
+    if isinstance(exc, getattr(litellm, "UnprocessableEntityError", ())):
+        err = LLMInputError(f"Unprocessable entity: {exc}")
+        err.__cause__ = exc
+        return err
+    # N/A — response schema validation failure
+    if isinstance(exc, getattr(litellm, "APIResponseValidationError", ())):
+        err = LLMInputError(f"Response validation failed: {exc}")
+        err.__cause__ = exc
+        return err
+    # 500/503/≥500/timeout/connection — retryable provider errors
+    # This is the catch-all for APIError, APIConnectionError,
+    # InternalServerError, ServiceUnavailableError, and Timeout
+    # (all inherit from APIError or APIConnectionError).
     if isinstance(exc, (litellm.APIError, litellm.APIConnectionError)):
         err = LLMProviderError(f"Provider error: {exc}")
         err.__cause__ = exc
@@ -556,7 +612,7 @@ __all__ = [
 
 _MAX_RETRIES = 5
 _INITIAL_BACKOFF_S = 1.0
-_MAX_BACKOFF_S = 60.0
+_MAX_BACKOFF_S = 120.0
 _DEFAULT_COOLDOWN_S = 2.0
 
 

--- a/p2m/stages/rollout.py
+++ b/p2m/stages/rollout.py
@@ -450,6 +450,7 @@ def _build_target_session(
     rollout: RolloutConfig,
     max_tokens: int,
     config_path: Path | None,
+    call_label: str | None = None,
 ) -> HostedSession | ExternalSession | CallableSession | HTTPEndpointSession:
     """Create the runtime session for one seed rollout."""
     if target.is_endpoint:
@@ -509,6 +510,7 @@ def _build_target_session(
             temperature=target_temperature,
             reasoning_effort=target.model.reasoning_effort,
             timeout_s=DEFAULT_MODEL_TIMEOUT_S,
+            call_label=call_label,
         ),
         max_tool_calls=rollout.max_tool_calls,
         synthetic_prompt_template=TOOL_SIM_PROMPT,
@@ -529,18 +531,20 @@ async def _run_prompt_seed(
     seed_payload = seed.get("seed")
     if not isinstance(seed_payload, dict):
         raise ValueError("rollout requires each seed row to include a seed object")
+    seed_id = str(seed["seed_id"])
     runtime = _build_target_session(
         target=target,
         seed_payload=seed_payload,
         rollout=rollout,
         max_tokens=max_tokens,
         config_path=config_path,
+        call_label=f"target:{seed_id}",
     )
     target_id = str(target.model.name) if target.model else (target.connector or target.callable or target.endpoint or "")
     transcript = Transcript(
         metadata=TranscriptMetadata(
             kind="prompt",
-            seed_id=str(seed["seed_id"]),
+            seed_id=seed_id,
             concept=str(seed.get("concept") or ""),
             target=target_id,
             auditor_model="",
@@ -612,6 +616,7 @@ async def _run_auditor_target_loop(
 ) -> tuple[str | None, list[Message], list[Message]]:
     """Run the alternating auditor and target loop for one scenario seed."""
     stop_reason = None
+    seed_id = transcript.metadata.seed_id
 
     for turn_index in range(max_turns):
         if stop_reason:
@@ -631,6 +636,7 @@ async def _run_auditor_target_loop(
                         max_tokens=auditor_max_tokens,
                         reasoning_effort=auditor_reasoning_effort,
                         timeout_s=DEFAULT_MODEL_TIMEOUT_S,
+                        call_label=f"auditor:{seed_id}:turn{turn_index}",
                         extra_kwargs={"extra_body": {"store": True}},
                     ),
                 )
@@ -764,17 +770,19 @@ async def _run_scenario_seed(
         raise ValueError("scenario rollout requires evaluation.auditor")
 
     seed_data = seed["seed"]
+    seed_id = str(seed["seed_id"])
     runtime = _build_target_session(
         target=target,
         seed_payload=seed_data,
         rollout=evaluation.rollout,
         max_tokens=max_tokens,
         config_path=config_path,
+        call_label=f"target:{seed_id}",
     )
     transcript = Transcript(
         metadata=TranscriptMetadata(
             kind="scenario",
-            seed_id=str(seed["seed_id"]),
+            seed_id=seed_id,
             concept=str(seed.get("concept") or ""),
             target=str(target.model.name) if target.model else (target.connector or target.callable or target.endpoint or ""),
             auditor_model=str(auditor.model.name),

--- a/p2m/stages/seeds.py
+++ b/p2m/stages/seeds.py
@@ -654,6 +654,7 @@ async def _generate_records(
             options=GenerateOptions(
                 temperature=temperature, max_tokens=max_tokens,
                 reasoning_effort=reasoning_effort, timeout_s=timeout_s,
+                call_label=f"seeds:{kind}:{slug}",
             ),
         )
         payload = response.parsed

--- a/tests/test_rate_limit_retry.py
+++ b/tests/test_rate_limit_retry.py
@@ -1,0 +1,286 @@
+"""Tests for the per-model adaptive rate limiter and retry logic."""
+
+import asyncio
+import time
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from p2m.core.model_client import (
+    LLMProviderError,
+    LLMRateLimitError,
+    _extract_retry_after,
+    _ModelRateLimiter,
+    _with_retries,
+)
+
+
+# ── _extract_retry_after ──────────────────────────────────────
+
+
+class ExtractRetryAfterTest(unittest.TestCase):
+    def test_returns_none_for_plain_exception(self) -> None:
+        self.assertIsNone(_extract_retry_after(Exception("boom")))
+
+    def test_extracts_from_headers_attribute(self) -> None:
+        exc = Exception("429")
+        exc.headers = {"Retry-After": "3.5"}  # type: ignore[attr-defined]
+        self.assertEqual(_extract_retry_after(exc), 3.5)
+
+    def test_extracts_from_response_headers_attribute(self) -> None:
+        exc = Exception("429")
+        exc.response_headers = {"retry-after": "10"}  # type: ignore[attr-defined]
+        self.assertEqual(_extract_retry_after(exc), 10.0)
+
+    def test_extracts_from_cause_chain(self) -> None:
+        inner = Exception("inner")
+        inner.headers = {"Retry-After": "7"}  # type: ignore[attr-defined]
+        outer = Exception("outer")
+        outer.__cause__ = inner
+        self.assertEqual(_extract_retry_after(outer), 7.0)
+
+    def test_returns_none_for_non_numeric_value(self) -> None:
+        exc = Exception("429")
+        exc.headers = {"Retry-After": "not-a-number"}  # type: ignore[attr-defined]
+        self.assertIsNone(_extract_retry_after(exc))
+
+
+# ── _ModelRateLimiter ─────────────────────────────────────────
+
+
+class ModelRateLimiterTest(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.limiter = _ModelRateLimiter()
+
+    async def test_wait_if_cooled_returns_immediately_when_no_cooldown(self) -> None:
+        """No cooldown set → should not sleep."""
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            await self.limiter.wait_if_cooled("model-a")
+            mock_sleep.assert_not_called()
+
+    async def test_report_rate_limit_sets_cooldown(self) -> None:
+        is_new = await self.limiter.report_rate_limit("model-a")
+        self.assertTrue(is_new)
+        # Cooldown should now be set in the future
+        until = self.limiter._cooldown_until.get("model-a", 0.0)
+        self.assertGreater(until, time.monotonic())
+
+    async def test_report_rate_limit_with_retry_after_uses_server_value(self) -> None:
+        await self.limiter.report_rate_limit("model-a", retry_after=15.0)
+        self.assertEqual(self.limiter._base_cooldown["model-a"], 15.0)
+
+    async def test_retry_after_clamped_to_max(self) -> None:
+        await self.limiter.report_rate_limit("model-a", retry_after=999.0)
+        # Should be clamped to _MAX_BACKOFF_S (120)
+        self.assertEqual(self.limiter._base_cooldown["model-a"], 120.0)
+
+    async def test_escalation_doubles_base_on_expired_cooldown(self) -> None:
+        # First 429 → sets base to _DEFAULT_COOLDOWN_S * 2 = 4.0
+        await self.limiter.report_rate_limit("model-a")
+        first_base = self.limiter._base_cooldown["model-a"]
+
+        # Simulate cooldown expiring
+        self.limiter._cooldown_until["model-a"] = time.monotonic() - 1
+
+        # Second 429 after expiry → should escalate
+        await self.limiter.report_rate_limit("model-a")
+        second_base = self.limiter._base_cooldown["model-a"]
+        self.assertEqual(second_base, min(first_base * 2, 60.0))
+
+    async def test_concurrent_429_during_active_cooldown_does_not_escalate(self) -> None:
+        await self.limiter.report_rate_limit("model-a")
+        base_after_first = self.limiter._base_cooldown["model-a"]
+
+        # Cooldown still active → concurrent in-flight 429
+        is_new = await self.limiter.report_rate_limit("model-a")
+        self.assertFalse(is_new)
+        # Base should not have changed
+        self.assertEqual(self.limiter._base_cooldown["model-a"], base_after_first)
+
+    async def test_report_success_resets_escalation(self) -> None:
+        await self.limiter.report_rate_limit("model-a")
+        self.assertIn("model-a", self.limiter._base_cooldown)
+        self.limiter.report_success("model-a")
+        self.assertNotIn("model-a", self.limiter._base_cooldown)
+
+    async def test_models_are_independent(self) -> None:
+        await self.limiter.report_rate_limit("model-a")
+        self.assertIn("model-a", self.limiter._cooldown_until)
+        self.assertNotIn("model-b", self.limiter._cooldown_until)
+
+    async def test_wait_if_cooled_sleeps_when_cooldown_active(self) -> None:
+        self.limiter._cooldown_until["model-a"] = time.monotonic() + 5.0
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            with patch("random.uniform", return_value=0.1):
+                await self.limiter.wait_if_cooled("model-a")
+                mock_sleep.assert_called_once()
+                slept = mock_sleep.call_args[0][0]
+                self.assertGreater(slept, 0)
+
+
+# ── _with_retries ─────────────────────────────────────────────
+
+
+def _make_litellm_module():
+    """Build a fake litellm module with exception classes."""
+    ns = SimpleNamespace()
+    ns.AuthenticationError = type("AuthenticationError", (Exception,), {})
+    ns.RateLimitError = type("RateLimitError", (Exception,), {})
+    ns.BadRequestError = type("BadRequestError", (Exception,), {})
+    ns.NotFoundError = type("NotFoundError", (Exception,), {})
+    ns.APIError = type("APIError", (Exception,), {})
+    ns.APIConnectionError = type("APIConnectionError", (Exception,), {})
+    return ns
+
+
+class WithRetriesTest(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        # Reset the global rate limiter state between tests
+        from p2m.core import model_client
+        model_client._rate_limiter = _ModelRateLimiter()
+        self.fake_litellm = _make_litellm_module()
+
+    async def test_success_on_first_attempt(self) -> None:
+        call_fn = AsyncMock(return_value="ok")
+        with patch("p2m.core.model_client._get_litellm_module", return_value=self.fake_litellm):
+            result = await _with_retries(call_fn, model="m")
+        self.assertEqual(result, "ok")
+        call_fn.assert_called_once()
+
+    async def test_retries_on_rate_limit_then_succeeds(self) -> None:
+        rate_exc = self.fake_litellm.RateLimitError("429")
+        call_fn = AsyncMock(side_effect=[rate_exc, rate_exc, "ok"])
+
+        with patch("p2m.core.model_client._get_litellm_module", return_value=self.fake_litellm):
+            with patch("asyncio.sleep", new_callable=AsyncMock):
+                result = await _with_retries(call_fn, model="m")
+
+        self.assertEqual(result, "ok")
+        self.assertEqual(call_fn.call_count, 3)
+
+    async def test_retries_on_provider_error_then_succeeds(self) -> None:
+        api_exc = self.fake_litellm.APIError("500")
+        call_fn = AsyncMock(side_effect=[api_exc, "ok"])
+
+        with patch("p2m.core.model_client._get_litellm_module", return_value=self.fake_litellm):
+            with patch("asyncio.sleep", new_callable=AsyncMock):
+                result = await _with_retries(call_fn, model="m")
+
+        self.assertEqual(result, "ok")
+        self.assertEqual(call_fn.call_count, 2)
+
+    async def test_raises_after_max_retries_exhausted(self) -> None:
+        rate_exc = self.fake_litellm.RateLimitError("429")
+        call_fn = AsyncMock(side_effect=rate_exc)
+
+        with patch("p2m.core.model_client._get_litellm_module", return_value=self.fake_litellm):
+            with patch("asyncio.sleep", new_callable=AsyncMock):
+                with self.assertRaises(LLMRateLimitError):
+                    await _with_retries(call_fn, model="m")
+
+        # _MAX_RETRIES + 1 = 6 total attempts
+        self.assertEqual(call_fn.call_count, 6)
+
+    async def test_non_retryable_error_raises_immediately(self) -> None:
+        auth_exc = self.fake_litellm.AuthenticationError("bad key")
+        call_fn = AsyncMock(side_effect=auth_exc)
+
+        with patch("p2m.core.model_client._get_litellm_module", return_value=self.fake_litellm):
+            with self.assertRaises(Exception) as ctx:
+                await _with_retries(call_fn, model="m")
+
+        call_fn.assert_called_once()
+        self.assertIn("Authentication", str(ctx.exception))
+
+    async def test_rate_limit_uses_retry_after_header(self) -> None:
+        rate_exc = self.fake_litellm.RateLimitError("429")
+        rate_exc.headers = {"Retry-After": "5"}
+        call_fn = AsyncMock(side_effect=[rate_exc, "ok"])
+
+        from p2m.core import model_client
+        observed_base: list[float | None] = []
+        original_success = model_client._rate_limiter.report_success
+
+        def spy_success(model: str) -> None:
+            # Capture base cooldown before it gets cleared
+            observed_base.append(model_client._rate_limiter._base_cooldown.get(model))
+            original_success(model)
+
+        model_client._rate_limiter.report_success = spy_success  # type: ignore[assignment]
+
+        with patch("p2m.core.model_client._get_litellm_module", return_value=self.fake_litellm):
+            with patch("asyncio.sleep", new_callable=AsyncMock):
+                result = await _with_retries(call_fn, model="m")
+
+        self.assertEqual(result, "ok")
+        # Rate limiter adopted the server's Retry-After as base before success reset it
+        self.assertEqual(observed_base, [5.0])
+
+    async def test_label_does_not_affect_behavior(self) -> None:
+        call_fn = AsyncMock(return_value="ok")
+        with patch("p2m.core.model_client._get_litellm_module", return_value=self.fake_litellm):
+            result = await _with_retries(call_fn, model="m", label="seeds:prompt:slug")
+        self.assertEqual(result, "ok")
+
+    async def test_provider_error_uses_exponential_backoff(self) -> None:
+        api_exc = self.fake_litellm.APIError("500")
+        call_fn = AsyncMock(side_effect=[api_exc, api_exc, "ok"])
+        sleep_delays: list[float] = []
+
+        async def track_sleep(s: float) -> None:
+            sleep_delays.append(s)
+
+        with patch("p2m.core.model_client._get_litellm_module", return_value=self.fake_litellm):
+            with patch("asyncio.sleep", side_effect=track_sleep):
+                with patch("random.uniform", return_value=0.0):
+                    result = await _with_retries(call_fn, model="m")
+
+        self.assertEqual(result, "ok")
+        # Two retries → two sleeps, second should be >= first
+        self.assertEqual(len(sleep_delays), 2)
+        self.assertGreaterEqual(sleep_delays[1], sleep_delays[0])
+
+
+# ── Integration: generate() with retries ──────────────────────
+
+
+class GenerateWithRetriesTest(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        from p2m.core import model_client
+        model_client._rate_limiter = _ModelRateLimiter()
+        self.fake_litellm = _make_litellm_module()
+
+    async def test_generate_retries_on_rate_limit(self) -> None:
+        from p2m.core import model_client
+
+        rate_exc = self.fake_litellm.RateLimitError("429")
+        call_count = 0
+
+        async def fake_acompletion(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                raise rate_exc
+            return {
+                "id": "resp-1",
+                "model": "openai/gpt-5-mini",
+                "choices": [
+                    {
+                        "finish_reason": "stop",
+                        "message": {"role": "assistant", "content": "hello"},
+                    }
+                ],
+            }
+
+        self.fake_litellm.acompletion = fake_acompletion
+
+        with patch.object(model_client, "_get_litellm_module", return_value=self.fake_litellm):
+            with patch("asyncio.sleep", new_callable=AsyncMock):
+                response = await model_client.generate("openai/gpt-5-mini", "say hi")
+
+        self.assertEqual(response.text, "hello")
+        self.assertEqual(call_count, 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add retry with coordinated per-model backoff for transient LLM failures (429 rate limits, 5xx provider errors). Previously, a single 429 or transient 5xx permanently failed the affected seed with no recovery.

## What changed

### `p2m/core/model_client.py`

**Per-model adaptive rate limiter (`_ModelRateLimiter`):**
- When any task hits 429, a shared cooldown is set for that model — all concurrent tasks pause, preventing thundering herd on fan-out workloads (e.g. 50 seeds × same model)
- Honors `Retry-After` header from the provider when available
- Adaptive escalation: doubles cooldown if 429 recurs after previous cooldown expired; absorbs concurrent in-flight 429s without escalating
- Per-task jitter on wake-up to prevent stampede at cooldown expiry
- Success resets escalation state

**Retry wrapper (`_with_retries`):**
- Wraps all three `generate` functions (`generate`, `generate_structured`, `generate_with_tools`)
- `LLMRateLimitError` (429) → coordinated cooldown retry (up to 5 attempts)
- `LLMProviderError` (5xx) → exponential backoff retry (`1s × 2^attempt + jitter`, capped at 120s)
- `LLMAuthError` (401/403) and `LLMInputError` (400/404/422) → propagate immediately, no retry

**Error classification (`_classify_llm_error`):**
- Added comprehensive docstring with full LiteLLM exception → HTTP status code mapping table (ref: https://docs.litellm.ai/docs/exception_mapping)
- Added `PermissionDeniedError` (403) → `LLMAuthError`
- Added `UnprocessableEntityError` (422) → `LLMInputError`
- Added `APIResponseValidationError` → `LLMInputError`
- Uses `getattr(litellm, ..., ())` for new exception types for backward compat

**LiteLLM config hardening:**
- Raised `_MAX_BACKOFF_S` from 60 to 120 to fully honor server `Retry-After` headers
- Explicitly set `litellm.num_retries = 0` to prevent double-retry (LiteLLM internal + our `_with_retries`)

### `tests/test_rate_limit_retry.py` (new, 23 tests)
- `ExtractRetryAfterTest`: header extraction from cause chain
- `ModelRateLimiterTest`: cooldown, escalation, jitter, cross-model independence, retry-after clamping, success reset
- `WithRetriesTest`: success path, rate-limit retry, provider error backoff, non-retryable passthrough, max-retry exhaustion
- `GenerateWithRetriesTest`: integration test with mocked litellm

## Reference

Compared against [azure-ai-evaluation RetryPolicy](https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/evaluation/azure-ai-evaluation) — p2m's approach provides equivalent retry coverage with the addition of coordinated per-model cooldown, which is critical for fan-out eval workloads.

## Testing

```
uv run pytest tests/test_rate_limit_retry.py -v  # 23 passed
uv run pytest -q                                  # 528 passed, 1 skipped (pre-existing docker permission issue)
```