### PR TITLE
feat: centralized logging with --verbose/--quiet/--log-file/--output json CLI flags

### DIFF
--- a/p2m/cli.py
+++ b/p2m/cli.py
@@ -17,6 +17,7 @@ from rich.table import Table
 
 from p2m.core.io import load_json, load_jsonl, get_permissible_flag
 from p2m.core.judge import get_verdict_dimension, infer_judge_status, is_valid_event_flag
+from p2m.logging_config import configure_logging
 from p2m.stages import STAGE_NAMES
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -490,8 +491,17 @@ def _subrisk_metric_map(rows: Iterable[dict[str, Any]], metric: str) -> dict[str
     ),
 )
 @click.version_option(version="0.1.0", prog_name="p2m")
-def cli():
+@click.option("-v", "--verbose", is_flag=True, help="Enable debug-level logging.")
+@click.option("-q", "--quiet", is_flag=True, help="Suppress info-level output; show only warnings and errors.")
+@click.option(
+    "--log-file",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Write all log output to a file (in addition to stderr).",
+)
+def cli(verbose: bool, quiet: bool, log_file: Path | None):
     """Safety evaluation workflows for pipeline runs, artifacts, and post-hoc analysis."""
+    configure_logging(verbose=verbose, quiet=quiet, log_file=log_file)
 
 
 @cli.command(short_help="Run a pipeline from a YAML config")

--- a/p2m/cli.py
+++ b/p2m/cli.py
@@ -499,12 +499,25 @@ def _subrisk_metric_map(rows: Iterable[dict[str, Any]], metric: str) -> dict[str
     default=None,
     help="Write all log output to a file (in addition to stderr).",
 )
+@click.option(
+    "--output",
+    "output_format",
+    type=click.Choice(["text", "json"], case_sensitive=False),
+    default="text",
+    show_default=True,
+    help="Log output format. Use 'json' for CI pipelines.",
+)
 @click.pass_context
-def cli(ctx: click.Context, verbose: bool, quiet: bool, log_file: Path | None):
+def cli(ctx: click.Context, verbose: bool, quiet: bool, log_file: Path | None, output_format: str):
     """Safety evaluation workflows for pipeline runs, artifacts, and post-hoc analysis."""
     ctx.ensure_object(dict)
     ctx.obj["logging_configured"] = True
-    configure_logging(verbose=verbose, quiet=quiet, log_file=log_file)
+    configure_logging(
+        verbose=verbose,
+        quiet=quiet,
+        log_file=log_file,
+        json_output=(output_format == "json"),
+    )
 
 
 @cli.command(short_help="Run a pipeline from a YAML config")
@@ -535,6 +548,14 @@ def cli(ctx: click.Context, verbose: bool, quiet: bool, log_file: Path | None):
     default=None,
     help="Write all log output to a file (in addition to stderr).",
 )
+@click.option(
+    "--output",
+    "output_format",
+    type=click.Choice(["text", "json"], case_sensitive=False),
+    default="text",
+    show_default=True,
+    help="Log output format. Use 'json' for CI pipelines.",
+)
 @click.pass_context
 def run(
     ctx: click.Context,
@@ -544,12 +565,18 @@ def run(
     verbose: bool,
     quiet: bool,
     log_file: Path | None,
+    output_format: str,
 ):
     """Run the evaluation pipeline."""
     # Re-configure logging if flags were passed on the subcommand
     # (e.g. `p2m run --verbose` instead of `p2m --verbose run`).
-    if verbose or quiet or log_file:
-        configure_logging(verbose=verbose, quiet=quiet, log_file=log_file)
+    if verbose or quiet or log_file or output_format != "text":
+        configure_logging(
+            verbose=verbose,
+            quiet=quiet,
+            log_file=log_file,
+            json_output=(output_format == "json"),
+        )
     runner = _load_runner_module()
     rc = runner.run_pipeline(
         config=str(config),

--- a/p2m/cli.py
+++ b/p2m/cli.py
@@ -499,8 +499,11 @@ def _subrisk_metric_map(rows: Iterable[dict[str, Any]], metric: str) -> dict[str
     default=None,
     help="Write all log output to a file (in addition to stderr).",
 )
-def cli(verbose: bool, quiet: bool, log_file: Path | None):
+@click.pass_context
+def cli(ctx: click.Context, verbose: bool, quiet: bool, log_file: Path | None):
     """Safety evaluation workflows for pipeline runs, artifacts, and post-hoc analysis."""
+    ctx.ensure_object(dict)
+    ctx.obj["logging_configured"] = True
     configure_logging(verbose=verbose, quiet=quiet, log_file=log_file)
 
 
@@ -524,12 +527,29 @@ def cli(verbose: bool, quiet: bool, log_file: Path | None):
     show_envvar=True,
 )
 @click.option("--strict", is_flag=True, help="Fail on malformed JSONL inputs instead of skipping bad rows.")
+@click.option("-v", "--verbose", is_flag=True, help="Enable debug-level logging.")
+@click.option("-q", "--quiet", is_flag=True, help="Suppress info-level output; show only warnings and errors.")
+@click.option(
+    "--log-file",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Write all log output to a file (in addition to stderr).",
+)
+@click.pass_context
 def run(
+    ctx: click.Context,
     config: Path,
     force_stage: tuple[str, ...],
     strict: bool,
+    verbose: bool,
+    quiet: bool,
+    log_file: Path | None,
 ):
     """Run the evaluation pipeline."""
+    # Re-configure logging if flags were passed on the subcommand
+    # (e.g. `p2m run --verbose` instead of `p2m --verbose run`).
+    if verbose or quiet or log_file:
+        configure_logging(verbose=verbose, quiet=quiet, log_file=log_file)
     runner = _load_runner_module()
     rc = runner.run_pipeline(
         config=str(config),

--- a/p2m/config.py
+++ b/p2m/config.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from pathlib import Path
-import sys
 from typing import Any
 
+import logging
 import re
 import yaml
+
+log = logging.getLogger(__name__)
 
 from p2m.core.config_model import (
     DEFAULT_AUDITOR_MAX_TURNS,
@@ -455,7 +457,7 @@ def _parse_top_level_factors(raw: Any) -> list[dict[str, Any]] | None:
     if not isinstance(raw, list):
         raise ValueError("factors must be a list")
     if len(raw) > 10:
-        print("warning: factors defines more than 10 factors", file=sys.stderr)
+        log.warning("factors defines more than 10 factors")
 
     factors: list[dict[str, Any]] = []
     seen_names: set[str] = set()
@@ -491,7 +493,7 @@ def _parse_top_level_factors(raw: Any) -> list[dict[str, Any]] | None:
             if len(levels_raw) == 1:
                 raise ValueError("single-level factor adds no variation")
             if len(levels_raw) > 20:
-                print(f"warning: factor '{name}' defines more than 20 levels", file=sys.stderr)
+                log.warning("factor '%s' defines more than 20 levels", name)
             levels = []
             seen_level_names: set[str] = set()
             for level_index, level_raw in enumerate(levels_raw, start=1):

--- a/p2m/config.py
+++ b/p2m/config.py
@@ -493,7 +493,7 @@ def _parse_top_level_factors(raw: Any) -> list[dict[str, Any]] | None:
             if len(levels_raw) == 1:
                 raise ValueError("single-level factor adds no variation")
             if len(levels_raw) > 20:
-                log.warning("factor '%s' defines more than 20 levels", name)
+                log.warning(f"factor '{name}' defines more than 20 levels")
             levels = []
             seen_level_names: set[str] = set()
             for level_index, level_raw in enumerate(levels_raw, start=1):

--- a/p2m/core/async_utils.py
+++ b/p2m/core/async_utils.py
@@ -3,9 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import inspect
+import logging
+import time
 from collections.abc import Awaitable, Callable, Sequence
 from typing import Any, TypeVar
+
+log = logging.getLogger(__name__)
 
 ItemT = TypeVar("ItemT")
 ResultT = TypeVar("ResultT")
@@ -46,3 +51,32 @@ async def gather_limited(
             return await worker(item)
 
     return await asyncio.gather(*(_guard(item) for item in items))
+
+
+@contextlib.asynccontextmanager
+async def log_heartbeat(message: str, *, interval: float = 15.0):
+    """Async context manager that logs a heartbeat while a long operation runs.
+
+    Usage::
+
+        async with log_heartbeat("Converting policy"):
+            result = await slow_llm_call(...)
+
+    Logs "{message} (still working, {elapsed}s elapsed)" every *interval*
+    seconds until the block exits.
+    """
+    start = time.monotonic()
+
+    async def _beat():
+        while True:
+            await asyncio.sleep(interval)
+            elapsed = time.monotonic() - start
+            log.info(f"{message} (still working, {elapsed:.0f}s elapsed)")
+
+    task = asyncio.create_task(_beat())
+    try:
+        yield
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task

--- a/p2m/core/model_client.py
+++ b/p2m/core/model_client.py
@@ -587,6 +587,20 @@ def _get_value(obj: Any, key: str) -> Any:
 
 # ── Public API ─────────────────────────────────────────────────
 
+
+def _log_response(label: str, model: str, response: "ModelResponse", elapsed: float, **extra: object) -> None:
+    """Log a compact one-line summary of an LLM call at DEBUG level."""
+    usage = response.usage
+    if usage and usage.prompt_tokens is not None:
+        tokens = f"{usage.prompt_tokens}+{usage.completion_tokens or 0} tokens"
+    else:
+        tokens = "? tokens"
+    parts = [f"model={model}"]
+    for key, value in extra.items():
+        parts.append(f"{key}={value}")
+    parts.extend([f"{elapsed:.1f}s", tokens, f"finish={response.finish_reason or '?'}"])
+    log.debug(f"{label}: {', '.join(parts)}")
+
 __all__ = [
     "build_llm_call_trace",
     "GenerateOptions",
@@ -791,7 +805,7 @@ async def generate(
     resolved_options = options or GenerateOptions()
     litellm = _get_litellm_module()
     api_mode = "responses" if resolved_options.web_search else "chat_completion"
-    log.debug(f"generate: model={model}, api_mode={api_mode}")
+    t0 = time.monotonic()
 
     if resolved_options.web_search:
         payload = _build_responses_payload(model, messages, resolved_options)
@@ -819,11 +833,13 @@ async def generate(
             )
 
     raw_response = await _with_retries(_call, model=model, label=resolved_options.call_label)
-    return normalize_response(
+    result = normalize_response(
         raw_response,
         api_mode="responses" if resolved_options.web_search else "chat_completion",
         request_payload=payload,
     )
+    _log_response("generate", model, result, time.monotonic() - t0, api_mode=api_mode)
+    return result
 
 
 async def generate_structured(
@@ -838,7 +854,7 @@ async def generate_structured(
     resolved_options = options or GenerateOptions()
     litellm = _get_litellm_module()
     api_mode = "responses" if resolved_options.web_search else "chat_completion"
-    log.debug(f"generate_structured: model={model}, schema={schema_name}, api_mode={api_mode}")
+    t0 = time.monotonic()
 
     if resolved_options.web_search:
         payload = _build_responses_payload(model, messages, resolved_options)
@@ -876,11 +892,13 @@ async def generate_structured(
             )
 
     raw_response = await _with_retries(_call, model=model, label=resolved_options.call_label)
-    return normalize_response(
+    result = normalize_response(
         raw_response,
         api_mode="responses" if resolved_options.web_search else "chat_completion",
         request_payload=payload,
     )
+    _log_response("generate_structured", model, result, time.monotonic() - t0, api_mode=api_mode, schema=schema_name)
+    return result
 
 
 async def generate_with_tools(
@@ -892,7 +910,7 @@ async def generate_with_tools(
 ) -> ModelResponse:
     """Run a tool-capable chat completion."""
     resolved_options = options or GenerateOptions()
-    log.debug(f"generate_with_tools: model={model}, tools={len(tools)}")
+    t0 = time.monotonic()
     payload = _build_chat_payload(model, messages, resolved_options)
     payload["tools"] = tools
     if resolved_options.tool_choice is not None:
@@ -907,8 +925,10 @@ async def generate_with_tools(
         )
 
     raw_response = await _with_retries(_call, model=model, label=resolved_options.call_label)
-    return normalize_response(
+    result = normalize_response(
         raw_response,
         api_mode="chat_completion",
         request_payload=payload,
     )
+    _log_response("generate_with_tools", model, result, time.monotonic() - t0, tools=len(tools))
+    return result

--- a/p2m/core/model_client.py
+++ b/p2m/core/model_client.py
@@ -247,6 +247,7 @@ def normalize_response(
             _get_value(choice, "finish_reason")
             or _get_value(raw_response, "stop_reason")
             or _get_value(_get_value(raw_response, "incomplete_details"), "reason")
+            or _get_value(raw_response, "status")
         ),
         status=_get_value(raw_response, "status"),
         incomplete_details=_get_value(raw_response, "incomplete_details"),
@@ -514,10 +515,17 @@ def _first_choice(raw_response: Any) -> Any:
 def _normalize_usage(raw_usage: Any) -> UsageStats | None:
     if raw_usage is None:
         return None
+    # Chat Completions API uses prompt_tokens/completion_tokens;
+    # Responses API uses input_tokens/output_tokens.
+    prompt = _coerce_int(_get_value(raw_usage, "prompt_tokens")) or _coerce_int(_get_value(raw_usage, "input_tokens"))
+    completion = _coerce_int(_get_value(raw_usage, "completion_tokens")) or _coerce_int(_get_value(raw_usage, "output_tokens"))
+    total = _coerce_int(_get_value(raw_usage, "total_tokens"))
+    if total is None and prompt is not None and completion is not None:
+        total = prompt + completion
     return UsageStats(
-        prompt_tokens=_coerce_int(_get_value(raw_usage, "prompt_tokens")),
-        completion_tokens=_coerce_int(_get_value(raw_usage, "completion_tokens")),
-        total_tokens=_coerce_int(_get_value(raw_usage, "total_tokens")),
+        prompt_tokens=prompt,
+        completion_tokens=completion,
+        total_tokens=total,
         raw=raw_usage,
     )
 

--- a/p2m/core/model_client.py
+++ b/p2m/core/model_client.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 import asyncio
 import importlib
 import json
+import logging
 from dataclasses import asdict, dataclass, field, is_dataclass
 from typing import Any, Mapping, Sequence
+
+log = logging.getLogger(__name__)
 
 # ── Types ──────────────────────────────────────────────────────
 
@@ -554,6 +557,8 @@ async def generate(
     """Run a standard async text generation call."""
     resolved_options = options or GenerateOptions()
     litellm = _get_litellm_module()
+    api_mode = "responses" if resolved_options.web_search else "chat_completion"
+    log.debug(f"generate: model={model}, api_mode={api_mode}")
     try:
         if resolved_options.web_search:
             payload = _build_responses_payload(model, messages, resolved_options)
@@ -596,6 +601,8 @@ async def generate_structured(
     """Run a structured generation call constrained by a JSON schema."""
     resolved_options = options or GenerateOptions()
     litellm = _get_litellm_module()
+    api_mode = "responses" if resolved_options.web_search else "chat_completion"
+    log.debug(f"generate_structured: model={model}, schema={schema_name}, api_mode={api_mode}")
     try:
         if resolved_options.web_search:
             payload = _build_responses_payload(model, messages, resolved_options)
@@ -646,6 +653,7 @@ async def generate_with_tools(
 ) -> ModelResponse:
     """Run a tool-capable chat completion."""
     resolved_options = options or GenerateOptions()
+    log.debug(f"generate_with_tools: model={model}, tools={len(tools)}")
     payload = _build_chat_payload(model, messages, resolved_options)
     payload["tools"] = tools
     if resolved_options.tool_choice is not None:

--- a/p2m/core/transcript.py
+++ b/p2m/core/transcript.py
@@ -7,6 +7,8 @@ Supports append-only event log with multiple views.
 import json
 import logging
 from dataclasses import dataclass, field
+
+log = logging.getLogger(__name__)
 from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Union
@@ -288,7 +290,7 @@ def _transcript_from_dict(data: Dict[str, Any]) -> "Transcript":
         try:
             llm_calls.append(LLMCallTrace(**call_data))
         except Exception:
-            logging.warning("Skipping malformed LLM call trace in transcript")
+            log.warning("Skipping malformed LLM call trace in transcript")
             continue
     return Transcript(
         metadata=_metadata_from_dict(data),
@@ -524,7 +526,7 @@ class Transcript(BaseModel):
                 try:
                     transcripts.append(_transcript_from_dict(json.loads(line)))
                 except Exception:
-                    logging.warning("Skipping malformed JSONL line in %s", path)
+                    log.warning("Skipping malformed JSONL line in %s", path)
         return transcripts
 
 

--- a/p2m/core/transcript.py
+++ b/p2m/core/transcript.py
@@ -526,7 +526,7 @@ class Transcript(BaseModel):
                 try:
                     transcripts.append(_transcript_from_dict(json.loads(line)))
                 except Exception:
-                    log.warning("Skipping malformed JSONL line in %s", path)
+                    log.warning(f"Skipping malformed JSONL line in {path}")
         return transcripts
 
 

--- a/p2m/logging_config.py
+++ b/p2m/logging_config.py
@@ -63,11 +63,14 @@ def configure_logging(
 
     # Keep LiteLLM debug noise suppressed regardless of verbosity.
     # Errors from LiteLLM are caught and wrapped by p2m's own modules.
+    # The OpenAI SDK logs every retry at INFO; suppress to avoid flooding.
     logging.getLogger("LiteLLM").setLevel(logging.WARNING)
     logging.getLogger("LiteLLM Router").setLevel(logging.WARNING)
     logging.getLogger("LiteLLM Proxy").setLevel(logging.WARNING)
     logging.getLogger("litellm").setLevel(logging.WARNING)
     logging.getLogger("httpx").setLevel(logging.WARNING)
+    logging.getLogger("openai").setLevel(logging.WARNING)
+    logging.getLogger("httpcore").setLevel(logging.WARNING)
 
 
 def _make_stderr_console():

--- a/p2m/logging_config.py
+++ b/p2m/logging_config.py
@@ -1,0 +1,77 @@
+"""Centralized logging configuration for p2m."""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+from rich.logging import RichHandler
+
+
+def configure_logging(
+    *,
+    verbose: bool = False,
+    quiet: bool = False,
+    log_file: Path | None = None,
+) -> None:
+    """Set up the root logger for the p2m process.
+
+    Level mapping:
+        default  → INFO   (shows progress messages, warnings, errors)
+        --verbose → DEBUG  (adds extra detail from core modules)
+        --quiet   → WARNING (only warnings and errors)
+
+    The interactive stderr handler uses ``sys.__stderr__`` to bypass
+    OTel/Phoenix wrappers that can silently drop message bodies.
+    """
+    if verbose:
+        level = logging.DEBUG
+    elif quiet:
+        level = logging.WARNING
+    else:
+        level = logging.INFO
+
+    root = logging.getLogger()
+    root.setLevel(level)
+
+    # Remove any existing handlers to avoid duplicate output on
+    # repeated calls (e.g. in tests).
+    root.handlers.clear()
+
+    # Interactive stderr handler — write to the unwrapped original stderr
+    # so OTel/Phoenix auto-instrumentation cannot swallow our output.
+    console_handler = RichHandler(
+        console=_make_stderr_console(),
+        show_time=False,
+        show_path=False,
+        markup=False,
+        rich_tracebacks=False,
+    )
+    console_handler.setLevel(level)
+    root.addHandler(console_handler)
+
+    # Optional file handler for persistent logs.
+    if log_file is not None:
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        file_handler = logging.FileHandler(log_file, encoding="utf-8")
+        file_handler.setLevel(logging.DEBUG)
+        file_handler.setFormatter(
+            logging.Formatter("%(asctime)s %(levelname)-8s %(name)s — %(message)s")
+        )
+        root.addHandler(file_handler)
+
+    # Keep LiteLLM debug noise suppressed regardless of verbosity.
+    # Errors from LiteLLM are caught and wrapped by p2m's own modules.
+    logging.getLogger("LiteLLM").setLevel(logging.WARNING)
+    logging.getLogger("LiteLLM Router").setLevel(logging.WARNING)
+    logging.getLogger("LiteLLM Proxy").setLevel(logging.WARNING)
+    logging.getLogger("litellm").setLevel(logging.WARNING)
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+
+
+def _make_stderr_console():
+    """Build a Rich Console on the unwrapped stderr."""
+    from rich.console import Console
+
+    return Console(stderr=True, file=sys.__stderr__)

--- a/p2m/logging_config.py
+++ b/p2m/logging_config.py
@@ -2,11 +2,28 @@
 
 from __future__ import annotations
 
+import json as json_module
 import logging
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 from rich.logging import RichHandler
+
+
+class _JsonFormatter(logging.Formatter):
+    """Emit one JSON object per log record for CI pipeline consumption."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload = {
+            "timestamp": datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        if record.exc_info and record.exc_info[1] is not None:
+            payload["exception"] = self.formatException(record.exc_info)
+        return json_module.dumps(payload, ensure_ascii=False)
 
 
 def configure_logging(
@@ -14,6 +31,7 @@ def configure_logging(
     verbose: bool = False,
     quiet: bool = False,
     log_file: Path | None = None,
+    json_output: bool = False,
 ) -> None:
     """Set up the root logger for the p2m process.
 
@@ -41,13 +59,17 @@ def configure_logging(
 
     # Interactive stderr handler — write to the unwrapped original stderr
     # so OTel/Phoenix auto-instrumentation cannot swallow our output.
-    console_handler = RichHandler(
-        console=_make_stderr_console(),
-        show_time=False,
-        show_path=False,
-        markup=False,
-        rich_tracebacks=False,
-    )
+    if json_output:
+        console_handler = logging.StreamHandler(sys.__stderr__)
+        console_handler.setFormatter(_JsonFormatter())
+    else:
+        console_handler = RichHandler(
+            console=_make_stderr_console(),
+            show_time=False,
+            show_path=False,
+            markup=False,
+            rich_tracebacks=False,
+        )
     console_handler.setLevel(level)
     root.addHandler(console_handler)
 

--- a/p2m/runner.py
+++ b/p2m/runner.py
@@ -309,7 +309,7 @@ def run_pipeline(
         ctx = _load_context(config=config)
         ctx["strict"] = strict
     except (ConfigError, ValueError) as exc:
-        print(f"[config error] {exc}", file=sys.stderr)
+        log.error("[config error] %s", exc)
         return 1
 
     requested_force_stages = set(force_stages or [])
@@ -317,7 +317,7 @@ def run_pipeline(
     invalid_forced = sorted(requested_force_stages.difference(configured_stage_names))
     if invalid_forced:
         joined = ", ".join(invalid_forced)
-        print(f"[config error] --force-stage stage(s) not present in config: {joined}", file=sys.stderr)
+        log.error("[config error] --force-stage stage(s) not present in config: %s", joined)
         return 1
 
     # Cascade: forcing an upstream stage logically invalidates every stage

--- a/p2m/runner.py
+++ b/p2m/runner.py
@@ -309,7 +309,7 @@ def run_pipeline(
         ctx = _load_context(config=config)
         ctx["strict"] = strict
     except (ConfigError, ValueError) as exc:
-        log.error("[config error] %s", exc)
+        log.error(f"[config error] {exc}")
         return 1
 
     requested_force_stages = set(force_stages or [])
@@ -317,7 +317,7 @@ def run_pipeline(
     invalid_forced = sorted(requested_force_stages.difference(configured_stage_names))
     if invalid_forced:
         joined = ", ".join(invalid_forced)
-        log.error("[config error] --force-stage stage(s) not present in config: %s", joined)
+        log.error(f"[config error] --force-stage stage(s) not present in config: {joined}")
         return 1
 
     # Cascade: forcing an upstream stage logically invalidates every stage
@@ -393,7 +393,7 @@ def run_pipeline(
             # Print just that message; suppress the multi-screen litellm/httpx
             # traceback unless the user opts into verbose output.
             ok = False
-            log.error("[error] %s", exc)
+            log.error(f"[error] {exc}")
             if os.environ.get("P2M_VERBOSE_ERRORS") == "1":
                 log.debug("Full traceback:", exc_info=True)
             else:
@@ -406,7 +406,7 @@ def run_pipeline(
         if ok:
             _print_stage_done(stage_name, elapsed, stage_result.get("_summary"))
         else:
-            log.error("%s failed (%.1fs)", stage_name, elapsed)
+            log.error(f"{stage_name} failed ({elapsed:.1f}s)")
 
         if manifest is not None and module.SCOPE == "run":
             manifest.stages[stage_name] = "completed" if ok else "failed"
@@ -438,7 +438,7 @@ def run_pipeline(
                 log.info(f"\n  Inspect results:")
                 log.info(f"    uv run p2m results status {suite_id} {run_id}")
     else:
-        log.error("pipeline failed at %s (%.1fs)", failed_stage, total_elapsed)
+        log.error(f"pipeline failed at {failed_stage} ({total_elapsed:.1f}s)")
 
     if manifest is None:
         return 0 if failed_stage is None else 1

--- a/p2m/runner.py
+++ b/p2m/runner.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 import shutil
 import socket
 import sys
 import time
-import traceback
 import warnings
 from datetime import datetime, timezone
 from pathlib import Path
@@ -34,6 +34,8 @@ from p2m.core.model_client import (
 from p2m.stages import STAGES
 
 load_dotenv()
+
+log = logging.getLogger(__name__)
 
 
 def _load_context(
@@ -86,21 +88,6 @@ def _write_manifest(manifest: RunManifest, run_root: Path) -> None:
     write_json(manifest_path, manifest.to_dict())
 
 
-def _progress(line: str) -> None:
-    """Write a runner progress line to the original stderr.
-
-    Phoenix/OTel auto-instrumentation can replace sys.stderr with a
-    wrapper that drops message bodies (passing only trailing newlines)
-    after the second target invocation; the wrapper persists across
-    stage boundaries until the next runtime is closed. The runner's
-    progress lines all share this hazard, so we route them through
-    sys.__stderr__ which the interpreter keeps as the unwrapped
-    original. No effect on processes that don't touch sys.stderr.
-    """
-    sys.__stderr__.write(line + "\n")
-    sys.__stderr__.flush()
-
-
 def _print_stage_start(stage_name: str, ctx: dict[str, Any], raw_cfg: dict[str, Any]) -> None:
     """Print a human-readable stage header."""
     risk = ctx.get("risk") or ctx.get("concept") or ""
@@ -112,9 +99,9 @@ def _print_stage_start(stage_name: str, ctx: dict[str, Any], raw_cfg: dict[str, 
         if isinstance(raw_cfg.get("model"), dict):
             policy_model = raw_cfg["model"].get("name", "")
         model_suffix = f" ({policy_model})" if policy_model else ""
-        _progress(f'  Generating behavior taxonomy for "{label}"{model_suffix}')
+        log.info(f'  Generating behavior taxonomy for "{label}"{model_suffix}')
     elif stage_name == "systematization":
-        _progress(f"  Refining policy structure...")
+        log.info(f"  Refining policy structure...")
     elif stage_name == "design":
         level_count = raw_cfg.get("level_count")
         factor_count = 0
@@ -130,11 +117,11 @@ def _print_stage_start(stage_name: str, ctx: dict[str, Any], raw_cfg: dict[str, 
             design_model = raw_cfg["model"].get("name", "")
         model_suffix = f" ({design_model})" if design_model else ""
         if level_count and factor_count:
-            _progress(f"  Designing seed-coverage grid: {total_factors} factors x {level_count} levels each{model_suffix}...")
+            log.info(f"  Designing seed-coverage grid: {total_factors} factors x {level_count} levels each{model_suffix}...")
         elif factor_count:
-            _progress(f"  Designing seed-coverage grid: {total_factors} factors{model_suffix}...")
+            log.info(f"  Designing seed-coverage grid: {total_factors} factors{model_suffix}...")
         else:
-            _progress(f"  Designing seed-coverage grid (behavior factor only){model_suffix}...")
+            log.info(f"  Designing seed-coverage grid (behavior factor only){model_suffix}...")
     elif stage_name == "seeds":
         prompt_budget = 0
         scenario_budget = 0
@@ -173,7 +160,7 @@ def _print_stage_start(stage_name: str, ctx: dict[str, Any], raw_cfg: dict[str, 
                 seed_models.add(kind_cfg["model"].get("name", ""))
         seed_models.discard("")
         model_suffix = f" ({', '.join(sorted(seed_models))})" if seed_models else ""
-        _progress(f"  Generating test cases{detail}{model_suffix}...")
+        log.info(f"  Generating test cases{detail}{model_suffix}...")
     elif stage_name == "rollout":
         target = ctx.get("target")
         target_name = ""
@@ -185,11 +172,11 @@ def _print_stage_start(stage_name: str, ctx: dict[str, Any], raw_cfg: dict[str, 
         if isinstance(raw_cfg.get("auditor"), dict) and isinstance(raw_cfg["auditor"].get("model"), dict):
             auditor_name = raw_cfg["auditor"]["model"].get("name", "")
         if auditor_name and target_name:
-            _progress(f"  Running test cases (auditor: {auditor_name} \u2192 target: {target_name})...")
+            log.info(f"  Running test cases (auditor: {auditor_name} \u2192 target: {target_name})...")
         elif target_name:
-            _progress(f"  Running test cases against target ({target_name})...")
+            log.info(f"  Running test cases against target ({target_name})...")
         else:
-            _progress(f"  Running test cases against target...")
+            log.info(f"  Running test cases against target...")
     elif stage_name == "judge":
         eval_cfg = ctx.get("evaluation")
         judge_model_obj = eval_cfg.judge.model if eval_cfg else None
@@ -202,11 +189,11 @@ def _print_stage_start(stage_name: str, ctx: dict[str, Any], raw_cfg: dict[str, 
         else:
             judge_model = ""
         if judge_model:
-            _progress(f"  Scoring transcripts with judge ({judge_model})...")
+            log.info(f"  Scoring transcripts with judge ({judge_model})...")
         else:
-            _progress(f"  Scoring transcripts...")
+            log.info(f"  Scoring transcripts...")
     else:
-        _progress(f"  {stage_name}...")
+        log.info(f"  {stage_name}...")
 
 
 def _print_stage_done(stage_name: str, elapsed: float, summary: dict[str, Any] | None) -> None:
@@ -220,18 +207,18 @@ def _print_stage_done(stage_name: str, elapsed: float, summary: dict[str, Any] |
         if len(names) > 3:
             preview += f", ... (+{count - 3} more)"
         if preview:
-            _progress(f"  \u2713 Generated {count} behaviors: {preview} ({elapsed:.1f}s)")
+            log.info(f"  \u2713 Generated {count} behaviors: {preview} ({elapsed:.1f}s)")
         else:
-            _progress(f"  \u2713 Generated policy ({elapsed:.1f}s)")
+            log.info(f"  \u2713 Generated policy ({elapsed:.1f}s)")
     elif stage_name == "design":
         factor_sizes = s.get("factor_sizes") or {}
         if factor_sizes:
             sizes_text = ", ".join(
                 f"{name}={size}" for name, size in factor_sizes.items()
             )
-            _progress(f"  \u2713 Designed coverage grid ({sizes_text}) ({elapsed:.1f}s)")
+            log.info(f"  \u2713 Designed coverage grid ({sizes_text}) ({elapsed:.1f}s)")
         else:
-            _progress(f"  \u2713 Designed coverage grid ({elapsed:.1f}s)")
+            log.info(f"  \u2713 Designed coverage grid ({elapsed:.1f}s)")
     elif stage_name == "seeds":
         total = s.get("total", 0)
         prompts = s.get("prompts", 0)
@@ -242,7 +229,7 @@ def _print_stage_done(stage_name: str, elapsed: float, summary: dict[str, Any] |
         if scenarios:
             parts.append(f"{scenarios} scenario{'s' if scenarios != 1 else ''}")
         detail = " (" + ", ".join(parts) + ")" if parts else ""
-        _progress(f"  \u2713 Generated {total} test cases{detail} ({elapsed:.1f}s)")
+        log.info(f"  \u2713 Generated {total} test cases{detail} ({elapsed:.1f}s)")
     elif stage_name == "rollout":
         count = s.get("count", 0)
         cached = s.get("cached_count", 0)
@@ -253,7 +240,7 @@ def _print_stage_done(stage_name: str, elapsed: float, summary: dict[str, Any] |
             extra = f" ({cached} cached)"
         else:
             extra = ""
-        _progress(f"  \u2713 Completed {count} rollouts{extra} ({elapsed:.1f}s)")
+        log.info(f"  \u2713 Completed {count} rollouts{extra} ({elapsed:.1f}s)")
     elif stage_name == "judge":
         count = s.get("count", 0)
         failures = s.get("failures", 0)
@@ -270,9 +257,9 @@ def _print_stage_done(stage_name: str, elapsed: float, summary: dict[str, Any] |
             extra += f", {failures} failures"
         if errors:
             extra += f", {errors} errors"
-        _progress(f"  \u2713 Scored {count} transcripts{cache_extra}{extra} ({elapsed:.1f}s)")
+        log.info(f"  \u2713 Scored {count} transcripts{cache_extra}{extra} ({elapsed:.1f}s)")
     else:
-        _progress(f"  {stage_name} done ({elapsed:.1f}s)")
+        log.info(f"  {stage_name} done ({elapsed:.1f}s)")
 
 
 def run_pipeline(
@@ -365,7 +352,7 @@ def run_pipeline(
         if module.SCOPE == "suite" and module.SUITE_OUTPUT and stage_name not in requested_force_stages:
             output_path = Path(ctx["suite_root"]) / module.SUITE_OUTPUT
             if output_path.exists():
-                _progress(f"  Skipping {stage_name} (output already exists, use --force-stage {stage_name} to regenerate)")
+                log.info(f"  Skipping {stage_name} (output already exists, use --force-stage {stage_name} to regenerate)")
                 continue
 
         stages_to_run.append((stage_name, module, raw_cfg))
@@ -406,20 +393,20 @@ def run_pipeline(
             # Print just that message; suppress the multi-screen litellm/httpx
             # traceback unless the user opts into verbose output.
             ok = False
-            _progress(f"  [error] {exc}")
+            log.error("[error] %s", exc)
             if os.environ.get("P2M_VERBOSE_ERRORS") == "1":
-                traceback.print_exc(file=sys.stderr)
+                log.debug("Full traceback:", exc_info=True)
             else:
-                _progress("  (set P2M_VERBOSE_ERRORS=1 to see the full traceback)")
+                log.info("(set P2M_VERBOSE_ERRORS=1 to see the full traceback)")
         except Exception:  # noqa: BLE001
             ok = False
-            traceback.print_exc(file=sys.stderr)
+            log.error("Unexpected error", exc_info=True)
 
         elapsed = time.monotonic() - stage_start
         if ok:
             _print_stage_done(stage_name, elapsed, stage_result.get("_summary"))
         else:
-            _progress(f"  {stage_name} failed ({elapsed:.1f}s)")
+            log.error("%s failed (%.1fs)", stage_name, elapsed)
 
         if manifest is not None and module.SCOPE == "run":
             manifest.stages[stage_name] = "completed" if ok else "failed"
@@ -435,23 +422,23 @@ def run_pipeline(
 
     total_elapsed = time.monotonic() - pipeline_start
     if failed_stage is None:
-        _progress(f"  pipeline completed ({total_elapsed:.1f}s)")
+        log.info(f"  pipeline completed ({total_elapsed:.1f}s)")
         if run_root is not None:
-            _progress(f"\n  Results:")
+            log.info(f"\n  Results:")
             scores_path = run_root / "scores.jsonl"
             metrics_path = run_root / "metrics.json"
             if scores_path.exists():
-                _progress(f"    Scores:  {scores_path}")
+                log.info(f"    Scores:  {scores_path}")
             if metrics_path.exists():
-                _progress(f"    Metrics: {metrics_path}")
-            _progress(f"    Run dir: {run_root}")
+                log.info(f"    Metrics: {metrics_path}")
+            log.info(f"    Run dir: {run_root}")
             suite_id = ctx.get('suite_id', '')
             run_id = ctx.get('run_id', '')
             if suite_id and run_id:
-                _progress(f"\n  Inspect results:")
-                _progress(f"    uv run p2m results status {suite_id} {run_id}")
+                log.info(f"\n  Inspect results:")
+                log.info(f"    uv run p2m results status {suite_id} {run_id}")
     else:
-        _progress(f"  pipeline failed at {failed_stage} ({total_elapsed:.1f}s)")
+        log.error("pipeline failed at %s (%.1fs)", failed_stage, total_elapsed)
 
     if manifest is None:
         return 0 if failed_stage is None else 1

--- a/p2m/runner.py
+++ b/p2m/runner.py
@@ -101,7 +101,7 @@ def _print_stage_start(stage_name: str, ctx: dict[str, Any], raw_cfg: dict[str, 
         model_suffix = f" ({policy_model})" if policy_model else ""
         log.info(f'  Generating behavior taxonomy for "{label}"{model_suffix}')
     elif stage_name == "systematization":
-        log.info(f"  Refining policy structure...")
+        log.info(f"Refining policy structure...")
     elif stage_name == "design":
         level_count = raw_cfg.get("level_count")
         factor_count = 0
@@ -117,11 +117,11 @@ def _print_stage_start(stage_name: str, ctx: dict[str, Any], raw_cfg: dict[str, 
             design_model = raw_cfg["model"].get("name", "")
         model_suffix = f" ({design_model})" if design_model else ""
         if level_count and factor_count:
-            log.info(f"  Designing seed-coverage grid: {total_factors} factors x {level_count} levels each{model_suffix}...")
+            log.info(f"Designing seed-coverage grid: {total_factors} factors x {level_count} levels each{model_suffix}...")
         elif factor_count:
-            log.info(f"  Designing seed-coverage grid: {total_factors} factors{model_suffix}...")
+            log.info(f"Designing seed-coverage grid: {total_factors} factors{model_suffix}...")
         else:
-            log.info(f"  Designing seed-coverage grid (behavior factor only){model_suffix}...")
+            log.info(f"Designing seed-coverage grid (behavior factor only){model_suffix}...")
     elif stage_name == "seeds":
         prompt_budget = 0
         scenario_budget = 0
@@ -160,7 +160,7 @@ def _print_stage_start(stage_name: str, ctx: dict[str, Any], raw_cfg: dict[str, 
                 seed_models.add(kind_cfg["model"].get("name", ""))
         seed_models.discard("")
         model_suffix = f" ({', '.join(sorted(seed_models))})" if seed_models else ""
-        log.info(f"  Generating test cases{detail}{model_suffix}...")
+        log.info(f"Generating test cases{detail}{model_suffix}...")
     elif stage_name == "rollout":
         target = ctx.get("target")
         target_name = ""
@@ -172,11 +172,11 @@ def _print_stage_start(stage_name: str, ctx: dict[str, Any], raw_cfg: dict[str, 
         if isinstance(raw_cfg.get("auditor"), dict) and isinstance(raw_cfg["auditor"].get("model"), dict):
             auditor_name = raw_cfg["auditor"]["model"].get("name", "")
         if auditor_name and target_name:
-            log.info(f"  Running test cases (auditor: {auditor_name} \u2192 target: {target_name})...")
+            log.info(f"Running test cases (auditor: {auditor_name} \u2192 target: {target_name})...")
         elif target_name:
-            log.info(f"  Running test cases against target ({target_name})...")
+            log.info(f"Running test cases against target ({target_name})...")
         else:
-            log.info(f"  Running test cases against target...")
+            log.info(f"Running test cases against target...")
     elif stage_name == "judge":
         eval_cfg = ctx.get("evaluation")
         judge_model_obj = eval_cfg.judge.model if eval_cfg else None
@@ -189,11 +189,11 @@ def _print_stage_start(stage_name: str, ctx: dict[str, Any], raw_cfg: dict[str, 
         else:
             judge_model = ""
         if judge_model:
-            log.info(f"  Scoring transcripts with judge ({judge_model})...")
+            log.info(f"Scoring transcripts with judge ({judge_model})...")
         else:
-            log.info(f"  Scoring transcripts...")
+            log.info(f"Scoring transcripts...")
     else:
-        log.info(f"  {stage_name}...")
+        log.info(f"{stage_name}...")
 
 
 def _print_stage_done(stage_name: str, elapsed: float, summary: dict[str, Any] | None) -> None:
@@ -207,18 +207,18 @@ def _print_stage_done(stage_name: str, elapsed: float, summary: dict[str, Any] |
         if len(names) > 3:
             preview += f", ... (+{count - 3} more)"
         if preview:
-            log.info(f"  \u2713 Generated {count} behaviors: {preview} ({elapsed:.1f}s)")
+            log.info(f"\u2713 Generated {count} behaviors: {preview} ({elapsed:.1f}s)")
         else:
-            log.info(f"  \u2713 Generated policy ({elapsed:.1f}s)")
+            log.info(f"\u2713 Generated policy ({elapsed:.1f}s)")
     elif stage_name == "design":
         factor_sizes = s.get("factor_sizes") or {}
         if factor_sizes:
             sizes_text = ", ".join(
                 f"{name}={size}" for name, size in factor_sizes.items()
             )
-            log.info(f"  \u2713 Designed coverage grid ({sizes_text}) ({elapsed:.1f}s)")
+            log.info(f"\u2713 Designed coverage grid ({sizes_text}) ({elapsed:.1f}s)")
         else:
-            log.info(f"  \u2713 Designed coverage grid ({elapsed:.1f}s)")
+            log.info(f"\u2713 Designed coverage grid ({elapsed:.1f}s)")
     elif stage_name == "seeds":
         total = s.get("total", 0)
         prompts = s.get("prompts", 0)
@@ -229,7 +229,7 @@ def _print_stage_done(stage_name: str, elapsed: float, summary: dict[str, Any] |
         if scenarios:
             parts.append(f"{scenarios} scenario{'s' if scenarios != 1 else ''}")
         detail = " (" + ", ".join(parts) + ")" if parts else ""
-        log.info(f"  \u2713 Generated {total} test cases{detail} ({elapsed:.1f}s)")
+        log.info(f"\u2713 Generated {total} test cases{detail} ({elapsed:.1f}s)")
     elif stage_name == "rollout":
         count = s.get("count", 0)
         cached = s.get("cached_count", 0)
@@ -240,7 +240,7 @@ def _print_stage_done(stage_name: str, elapsed: float, summary: dict[str, Any] |
             extra = f" ({cached} cached)"
         else:
             extra = ""
-        log.info(f"  \u2713 Completed {count} rollouts{extra} ({elapsed:.1f}s)")
+        log.info(f"\u2713 Completed {count} rollouts{extra} ({elapsed:.1f}s)")
     elif stage_name == "judge":
         count = s.get("count", 0)
         failures = s.get("failures", 0)
@@ -257,9 +257,9 @@ def _print_stage_done(stage_name: str, elapsed: float, summary: dict[str, Any] |
             extra += f", {failures} failures"
         if errors:
             extra += f", {errors} errors"
-        log.info(f"  \u2713 Scored {count} transcripts{cache_extra}{extra} ({elapsed:.1f}s)")
+        log.info(f"\u2713 Scored {count} transcripts{cache_extra}{extra} ({elapsed:.1f}s)")
     else:
-        log.info(f"  {stage_name} done ({elapsed:.1f}s)")
+        log.info(f"{stage_name} done ({elapsed:.1f}s)")
 
 
 def run_pipeline(
@@ -352,7 +352,7 @@ def run_pipeline(
         if module.SCOPE == "suite" and module.SUITE_OUTPUT and stage_name not in requested_force_stages:
             output_path = Path(ctx["suite_root"]) / module.SUITE_OUTPUT
             if output_path.exists():
-                log.info(f"  Skipping {stage_name} (output already exists, use --force-stage {stage_name} to regenerate)")
+                log.info(f"Skipping {stage_name} (output already exists, use --force-stage {stage_name} to regenerate)")
                 continue
 
         stages_to_run.append((stage_name, module, raw_cfg))
@@ -422,21 +422,21 @@ def run_pipeline(
 
     total_elapsed = time.monotonic() - pipeline_start
     if failed_stage is None:
-        log.info(f"  pipeline completed ({total_elapsed:.1f}s)")
+        log.info(f"pipeline completed ({total_elapsed:.1f}s)")
         if run_root is not None:
-            log.info(f"\n  Results:")
+            log.info("Results:")
             scores_path = run_root / "scores.jsonl"
             metrics_path = run_root / "metrics.json"
             if scores_path.exists():
-                log.info(f"    Scores:  {scores_path}")
+                log.info(f"  Scores:  {scores_path}")
             if metrics_path.exists():
-                log.info(f"    Metrics: {metrics_path}")
-            log.info(f"    Run dir: {run_root}")
+                log.info(f"  Metrics: {metrics_path}")
+            log.info(f"  Run dir: {run_root}")
             suite_id = ctx.get('suite_id', '')
             run_id = ctx.get('run_id', '')
             if suite_id and run_id:
-                log.info(f"\n  Inspect results:")
-                log.info(f"    uv run p2m results status {suite_id} {run_id}")
+                log.info("Inspect results:")
+                log.info(f"  uv run p2m results status {suite_id} {run_id}")
     else:
         log.error(f"pipeline failed at {failed_stage} ({total_elapsed:.1f}s)")
 

--- a/p2m/runner.py
+++ b/p2m/runner.py
@@ -99,7 +99,7 @@ def _print_stage_start(stage_name: str, ctx: dict[str, Any], raw_cfg: dict[str, 
         if isinstance(raw_cfg.get("model"), dict):
             policy_model = raw_cfg["model"].get("name", "")
         model_suffix = f" ({policy_model})" if policy_model else ""
-        log.info(f'  Generating behavior taxonomy for "{label}"{model_suffix}')
+        log.info(f'Generating behavior taxonomy for "{label}"{model_suffix}')
     elif stage_name == "systematization":
         log.info(f"Refining policy structure...")
     elif stage_name == "design":

--- a/p2m/runner.py
+++ b/p2m/runner.py
@@ -90,6 +90,7 @@ def _write_manifest(manifest: RunManifest, run_root: Path) -> None:
 
 def _print_stage_start(stage_name: str, ctx: dict[str, Any], raw_cfg: dict[str, Any]) -> None:
     """Print a human-readable stage header."""
+    tag = f"[{stage_name}]"
     risk = ctx.get("risk") or ctx.get("concept") or ""
     if stage_name == "policy":
         label = risk.replace("\n", " ").strip()
@@ -99,9 +100,9 @@ def _print_stage_start(stage_name: str, ctx: dict[str, Any], raw_cfg: dict[str, 
         if isinstance(raw_cfg.get("model"), dict):
             policy_model = raw_cfg["model"].get("name", "")
         model_suffix = f" ({policy_model})" if policy_model else ""
-        log.info(f'Generating behavior taxonomy for "{label}"{model_suffix}')
+        log.info(f'{tag} Generating behavior taxonomy for "{label}"{model_suffix}')
     elif stage_name == "systematization":
-        log.info(f"Refining policy structure...")
+        log.info(f"{tag} Refining policy structure...")
     elif stage_name == "design":
         level_count = raw_cfg.get("level_count")
         factor_count = 0
@@ -117,11 +118,11 @@ def _print_stage_start(stage_name: str, ctx: dict[str, Any], raw_cfg: dict[str, 
             design_model = raw_cfg["model"].get("name", "")
         model_suffix = f" ({design_model})" if design_model else ""
         if level_count and factor_count:
-            log.info(f"Designing seed-coverage grid: {total_factors} factors x {level_count} levels each{model_suffix}...")
+            log.info(f"{tag} Designing seed-coverage grid: {total_factors} factors x {level_count} levels each{model_suffix}...")
         elif factor_count:
-            log.info(f"Designing seed-coverage grid: {total_factors} factors{model_suffix}...")
+            log.info(f"{tag} Designing seed-coverage grid: {total_factors} factors{model_suffix}...")
         else:
-            log.info(f"Designing seed-coverage grid (behavior factor only){model_suffix}...")
+            log.info(f"{tag} Designing seed-coverage grid (behavior factor only){model_suffix}...")
     elif stage_name == "seeds":
         prompt_budget = 0
         scenario_budget = 0
@@ -160,7 +161,7 @@ def _print_stage_start(stage_name: str, ctx: dict[str, Any], raw_cfg: dict[str, 
                 seed_models.add(kind_cfg["model"].get("name", ""))
         seed_models.discard("")
         model_suffix = f" ({', '.join(sorted(seed_models))})" if seed_models else ""
-        log.info(f"Generating test cases{detail}{model_suffix}...")
+        log.info(f"{tag} Generating test cases{detail}{model_suffix}...")
     elif stage_name == "rollout":
         target = ctx.get("target")
         target_name = ""
@@ -172,11 +173,11 @@ def _print_stage_start(stage_name: str, ctx: dict[str, Any], raw_cfg: dict[str, 
         if isinstance(raw_cfg.get("auditor"), dict) and isinstance(raw_cfg["auditor"].get("model"), dict):
             auditor_name = raw_cfg["auditor"]["model"].get("name", "")
         if auditor_name and target_name:
-            log.info(f"Running test cases (auditor: {auditor_name} \u2192 target: {target_name})...")
+            log.info(f"{tag} Running test cases (auditor: {auditor_name} \u2192 target: {target_name})...")
         elif target_name:
-            log.info(f"Running test cases against target ({target_name})...")
+            log.info(f"{tag} Running test cases against target ({target_name})...")
         else:
-            log.info(f"Running test cases against target...")
+            log.info(f"{tag} Running test cases against target...")
     elif stage_name == "judge":
         eval_cfg = ctx.get("evaluation")
         judge_model_obj = eval_cfg.judge.model if eval_cfg else None
@@ -189,15 +190,16 @@ def _print_stage_start(stage_name: str, ctx: dict[str, Any], raw_cfg: dict[str, 
         else:
             judge_model = ""
         if judge_model:
-            log.info(f"Scoring transcripts with judge ({judge_model})...")
+            log.info(f"{tag} Scoring transcripts with judge ({judge_model})...")
         else:
-            log.info(f"Scoring transcripts...")
+            log.info(f"{tag} Scoring transcripts...")
     else:
-        log.info(f"{stage_name}...")
+        log.info(f"{tag} Starting...")
 
 
 def _print_stage_done(stage_name: str, elapsed: float, summary: dict[str, Any] | None) -> None:
     """Print a human-readable stage completion summary."""
+    tag = f"[{stage_name}]"
     s = summary or {}
     if stage_name == "policy":
         # Prefer the new-science key; fall back to legacy for pre-merge artifacts.
@@ -207,18 +209,18 @@ def _print_stage_done(stage_name: str, elapsed: float, summary: dict[str, Any] |
         if len(names) > 3:
             preview += f", ... (+{count - 3} more)"
         if preview:
-            log.info(f"\u2713 Generated {count} behaviors: {preview} ({elapsed:.1f}s)")
+            log.info(f"{tag} \u2713 Generated {count} behaviors: {preview} ({elapsed:.1f}s)")
         else:
-            log.info(f"\u2713 Generated policy ({elapsed:.1f}s)")
+            log.info(f"{tag} \u2713 Generated policy ({elapsed:.1f}s)")
     elif stage_name == "design":
         factor_sizes = s.get("factor_sizes") or {}
         if factor_sizes:
             sizes_text = ", ".join(
                 f"{name}={size}" for name, size in factor_sizes.items()
             )
-            log.info(f"\u2713 Designed coverage grid ({sizes_text}) ({elapsed:.1f}s)")
+            log.info(f"{tag} \u2713 Designed coverage grid ({sizes_text}) ({elapsed:.1f}s)")
         else:
-            log.info(f"\u2713 Designed coverage grid ({elapsed:.1f}s)")
+            log.info(f"{tag} \u2713 Designed coverage grid ({elapsed:.1f}s)")
     elif stage_name == "seeds":
         total = s.get("total", 0)
         prompts = s.get("prompts", 0)
@@ -229,7 +231,7 @@ def _print_stage_done(stage_name: str, elapsed: float, summary: dict[str, Any] |
         if scenarios:
             parts.append(f"{scenarios} scenario{'s' if scenarios != 1 else ''}")
         detail = " (" + ", ".join(parts) + ")" if parts else ""
-        log.info(f"\u2713 Generated {total} test cases{detail} ({elapsed:.1f}s)")
+        log.info(f"{tag} \u2713 Generated {total} test cases{detail} ({elapsed:.1f}s)")
     elif stage_name == "rollout":
         count = s.get("count", 0)
         cached = s.get("cached_count", 0)
@@ -240,7 +242,7 @@ def _print_stage_done(stage_name: str, elapsed: float, summary: dict[str, Any] |
             extra = f" ({cached} cached)"
         else:
             extra = ""
-        log.info(f"\u2713 Completed {count} rollouts{extra} ({elapsed:.1f}s)")
+        log.info(f"{tag} \u2713 Completed {count} rollouts{extra} ({elapsed:.1f}s)")
     elif stage_name == "judge":
         count = s.get("count", 0)
         failures = s.get("failures", 0)
@@ -257,9 +259,9 @@ def _print_stage_done(stage_name: str, elapsed: float, summary: dict[str, Any] |
             extra += f", {failures} failures"
         if errors:
             extra += f", {errors} errors"
-        log.info(f"\u2713 Scored {count} transcripts{cache_extra}{extra} ({elapsed:.1f}s)")
+        log.info(f"{tag} \u2713 Scored {count} transcripts{cache_extra}{extra} ({elapsed:.1f}s)")
     else:
-        log.info(f"{stage_name} done ({elapsed:.1f}s)")
+        log.info(f"{tag} \u2713 Done ({elapsed:.1f}s)")
 
 
 def run_pipeline(
@@ -352,7 +354,7 @@ def run_pipeline(
         if module.SCOPE == "suite" and module.SUITE_OUTPUT and stage_name not in requested_force_stages:
             output_path = Path(ctx["suite_root"]) / module.SUITE_OUTPUT
             if output_path.exists():
-                log.info(f"Skipping {stage_name} (output already exists, use --force-stage {stage_name} to regenerate)")
+                log.info(f"[{stage_name}] Skipped (output exists, use --force-stage {stage_name} to regenerate)")
                 continue
 
         stages_to_run.append((stage_name, module, raw_cfg))
@@ -393,20 +395,20 @@ def run_pipeline(
             # Print just that message; suppress the multi-screen litellm/httpx
             # traceback unless the user opts into verbose output.
             ok = False
-            log.error(f"[error] {exc}")
+            log.error(f"[{stage_name}] {exc}")
             if os.environ.get("P2M_VERBOSE_ERRORS") == "1":
                 log.debug("Full traceback:", exc_info=True)
             else:
                 log.info("(set P2M_VERBOSE_ERRORS=1 to see the full traceback)")
         except Exception:  # noqa: BLE001
             ok = False
-            log.error("Unexpected error", exc_info=True)
+            log.error(f"[{stage_name}] Unexpected error", exc_info=True)
 
         elapsed = time.monotonic() - stage_start
         if ok:
             _print_stage_done(stage_name, elapsed, stage_result.get("_summary"))
         else:
-            log.error(f"{stage_name} failed ({elapsed:.1f}s)")
+            log.error(f"[{stage_name}] \u2717 Failed ({elapsed:.1f}s)")
 
         if manifest is not None and module.SCOPE == "run":
             manifest.stages[stage_name] = "completed" if ok else "failed"
@@ -422,7 +424,7 @@ def run_pipeline(
 
     total_elapsed = time.monotonic() - pipeline_start
     if failed_stage is None:
-        log.info(f"pipeline completed ({total_elapsed:.1f}s)")
+        log.info(f"Pipeline completed ({total_elapsed:.1f}s)")
         if run_root is not None:
             log.info("Results:")
             scores_path = run_root / "scores.jsonl"
@@ -438,7 +440,7 @@ def run_pipeline(
                 log.info("Inspect results:")
                 log.info(f"  uv run p2m results status {suite_id} {run_id}")
     else:
-        log.error(f"pipeline failed at {failed_stage} ({total_elapsed:.1f}s)")
+        log.error(f"Pipeline failed at {failed_stage} ({total_elapsed:.1f}s)")
 
     if manifest is None:
         return 0 if failed_stage is None else 1

--- a/p2m/runner.py
+++ b/p2m/runner.py
@@ -90,6 +90,7 @@ def _write_manifest(manifest: RunManifest, run_root: Path) -> None:
 
 def _print_stage_start(stage_name: str, ctx: dict[str, Any], raw_cfg: dict[str, Any]) -> None:
     """Print a human-readable stage header."""
+    tag = f"[{stage_name}]"
     risk = ctx.get("risk") or ctx.get("concept") or ""
     if stage_name == "policy":
         label = risk.replace("\n", " ").strip()
@@ -99,9 +100,9 @@ def _print_stage_start(stage_name: str, ctx: dict[str, Any], raw_cfg: dict[str, 
         if isinstance(raw_cfg.get("model"), dict):
             policy_model = raw_cfg["model"].get("name", "")
         model_suffix = f" ({policy_model})" if policy_model else ""
-        log.info(f'Generating behavior taxonomy for "{label}"{model_suffix}')
+        log.info(f'{tag} Generating behavior taxonomy for "{label}"{model_suffix}')
     elif stage_name == "systematization":
-        log.info(f"Refining policy structure...")
+        log.info(f"{tag} Refining policy structure...")
     elif stage_name == "design":
         level_count = raw_cfg.get("level_count")
         factor_count = 0
@@ -117,11 +118,11 @@ def _print_stage_start(stage_name: str, ctx: dict[str, Any], raw_cfg: dict[str, 
             design_model = raw_cfg["model"].get("name", "")
         model_suffix = f" ({design_model})" if design_model else ""
         if level_count and factor_count:
-            log.info(f"Designing seed-coverage grid: {total_factors} factors x {level_count} levels each{model_suffix}...")
+            log.info(f"{tag} Designing seed-coverage grid: {total_factors} factors x {level_count} levels each{model_suffix}...")
         elif factor_count:
-            log.info(f"Designing seed-coverage grid: {total_factors} factors{model_suffix}...")
+            log.info(f"{tag} Designing seed-coverage grid: {total_factors} factors{model_suffix}...")
         else:
-            log.info(f"Designing seed-coverage grid (behavior factor only){model_suffix}...")
+            log.info(f"{tag} Designing seed-coverage grid (behavior factor only){model_suffix}...")
     elif stage_name == "seeds":
         prompt_budget = 0
         scenario_budget = 0
@@ -129,8 +130,6 @@ def _print_stage_start(stage_name: str, ctx: dict[str, Any], raw_cfg: dict[str, 
             prompt_budget = raw_cfg["prompt"].get("budget", 0) or raw_cfg["prompt"].get("sample_size", 0)
         if isinstance(raw_cfg.get("scenario"), dict):
             scenario_budget = raw_cfg["scenario"].get("budget", 0) or raw_cfg["scenario"].get("sample_size", 0)
-        # Read behavior count from the policy output. Fall back to the
-        # legacy `sub_risks` key for any pre-merge artifacts on disk.
         behavior_count = 0
         policy_path = Path(ctx["suite_root"]) / "policy.json"
         if policy_path.exists():
@@ -160,7 +159,7 @@ def _print_stage_start(stage_name: str, ctx: dict[str, Any], raw_cfg: dict[str, 
                 seed_models.add(kind_cfg["model"].get("name", ""))
         seed_models.discard("")
         model_suffix = f" ({', '.join(sorted(seed_models))})" if seed_models else ""
-        log.info(f"Generating test cases{detail}{model_suffix}...")
+        log.info(f"{tag} Generating test cases{detail}{model_suffix}...")
     elif stage_name == "rollout":
         target = ctx.get("target")
         target_name = ""
@@ -172,16 +171,14 @@ def _print_stage_start(stage_name: str, ctx: dict[str, Any], raw_cfg: dict[str, 
         if isinstance(raw_cfg.get("auditor"), dict) and isinstance(raw_cfg["auditor"].get("model"), dict):
             auditor_name = raw_cfg["auditor"]["model"].get("name", "")
         if auditor_name and target_name:
-            log.info(f"Running test cases (auditor: {auditor_name} \u2192 target: {target_name})...")
+            log.info(f"{tag} Running test cases (auditor: {auditor_name} \u2192 target: {target_name})...")
         elif target_name:
-            log.info(f"Running test cases against target ({target_name})...")
+            log.info(f"{tag} Running test cases against target ({target_name})...")
         else:
-            log.info(f"Running test cases against target...")
+            log.info(f"{tag} Running test cases against target...")
     elif stage_name == "judge":
         eval_cfg = ctx.get("evaluation")
         judge_model_obj = eval_cfg.judge.model if eval_cfg else None
-        # judge.model is a ModelConfig dataclass post-init; reach for .name
-        # rather than letting the dataclass repr leak into the header.
         if judge_model_obj is not None and hasattr(judge_model_obj, "name"):
             judge_model = judge_model_obj.name or ""
         elif isinstance(judge_model_obj, str):
@@ -189,36 +186,36 @@ def _print_stage_start(stage_name: str, ctx: dict[str, Any], raw_cfg: dict[str, 
         else:
             judge_model = ""
         if judge_model:
-            log.info(f"Scoring transcripts with judge ({judge_model})...")
+            log.info(f"{tag} Scoring transcripts with judge ({judge_model})...")
         else:
-            log.info(f"Scoring transcripts...")
+            log.info(f"{tag} Scoring transcripts...")
     else:
-        log.info(f"{stage_name}...")
+        log.info(f"{tag} Starting...")
 
 
 def _print_stage_done(stage_name: str, elapsed: float, summary: dict[str, Any] | None) -> None:
     """Print a human-readable stage completion summary."""
+    tag = f"[{stage_name}]"
     s = summary or {}
     if stage_name == "policy":
-        # Prefer the new-science key; fall back to legacy for pre-merge artifacts.
         count = s.get("behavior_count") or s.get("sub_risk_count", 0)
         names = s.get("behavior_names") or s.get("sub_risk_names") or []
         preview = ", ".join(names[:3])
         if len(names) > 3:
             preview += f", ... (+{count - 3} more)"
         if preview:
-            log.info(f"\u2713 Generated {count} behaviors: {preview} ({elapsed:.1f}s)")
+            log.info(f"{tag} \u2713 Generated {count} behaviors: {preview} ({elapsed:.1f}s)")
         else:
-            log.info(f"\u2713 Generated policy ({elapsed:.1f}s)")
+            log.info(f"{tag} \u2713 Generated policy ({elapsed:.1f}s)")
     elif stage_name == "design":
         factor_sizes = s.get("factor_sizes") or {}
         if factor_sizes:
             sizes_text = ", ".join(
                 f"{name}={size}" for name, size in factor_sizes.items()
             )
-            log.info(f"\u2713 Designed coverage grid ({sizes_text}) ({elapsed:.1f}s)")
+            log.info(f"{tag} \u2713 Designed coverage grid ({sizes_text}) ({elapsed:.1f}s)")
         else:
-            log.info(f"\u2713 Designed coverage grid ({elapsed:.1f}s)")
+            log.info(f"{tag} \u2713 Designed coverage grid ({elapsed:.1f}s)")
     elif stage_name == "seeds":
         total = s.get("total", 0)
         prompts = s.get("prompts", 0)
@@ -229,7 +226,7 @@ def _print_stage_done(stage_name: str, elapsed: float, summary: dict[str, Any] |
         if scenarios:
             parts.append(f"{scenarios} scenario{'s' if scenarios != 1 else ''}")
         detail = " (" + ", ".join(parts) + ")" if parts else ""
-        log.info(f"\u2713 Generated {total} test cases{detail} ({elapsed:.1f}s)")
+        log.info(f"{tag} \u2713 Generated {total} test cases{detail} ({elapsed:.1f}s)")
     elif stage_name == "rollout":
         count = s.get("count", 0)
         cached = s.get("cached_count", 0)
@@ -240,7 +237,7 @@ def _print_stage_done(stage_name: str, elapsed: float, summary: dict[str, Any] |
             extra = f" ({cached} cached)"
         else:
             extra = ""
-        log.info(f"\u2713 Completed {count} rollouts{extra} ({elapsed:.1f}s)")
+        log.info(f"{tag} \u2713 Completed {count} rollouts{extra} ({elapsed:.1f}s)")
     elif stage_name == "judge":
         count = s.get("count", 0)
         failures = s.get("failures", 0)
@@ -257,9 +254,9 @@ def _print_stage_done(stage_name: str, elapsed: float, summary: dict[str, Any] |
             extra += f", {failures} failures"
         if errors:
             extra += f", {errors} errors"
-        log.info(f"\u2713 Scored {count} transcripts{cache_extra}{extra} ({elapsed:.1f}s)")
+        log.info(f"{tag} \u2713 Scored {count} transcripts{cache_extra}{extra} ({elapsed:.1f}s)")
     else:
-        log.info(f"{stage_name} done ({elapsed:.1f}s)")
+        log.info(f"{tag} \u2713 Done ({elapsed:.1f}s)")
 
 
 def run_pipeline(
@@ -352,7 +349,7 @@ def run_pipeline(
         if module.SCOPE == "suite" and module.SUITE_OUTPUT and stage_name not in requested_force_stages:
             output_path = Path(ctx["suite_root"]) / module.SUITE_OUTPUT
             if output_path.exists():
-                log.info(f"Skipping {stage_name} (output already exists, use --force-stage {stage_name} to regenerate)")
+                log.info(f"[{stage_name}] Skipped (output exists, use --force-stage {stage_name} to regenerate)")
                 continue
 
         stages_to_run.append((stage_name, module, raw_cfg))
@@ -393,20 +390,20 @@ def run_pipeline(
             # Print just that message; suppress the multi-screen litellm/httpx
             # traceback unless the user opts into verbose output.
             ok = False
-            log.error(f"[error] {exc}")
+            log.error(f"[{stage_name}] {exc}")
             if os.environ.get("P2M_VERBOSE_ERRORS") == "1":
                 log.debug("Full traceback:", exc_info=True)
             else:
                 log.info("(set P2M_VERBOSE_ERRORS=1 to see the full traceback)")
         except Exception:  # noqa: BLE001
             ok = False
-            log.error("Unexpected error", exc_info=True)
+            log.error(f"[{stage_name}] Unexpected error", exc_info=True)
 
         elapsed = time.monotonic() - stage_start
         if ok:
             _print_stage_done(stage_name, elapsed, stage_result.get("_summary"))
         else:
-            log.error(f"{stage_name} failed ({elapsed:.1f}s)")
+            log.error(f"[{stage_name}] \u2717 Failed ({elapsed:.1f}s)")
 
         if manifest is not None and module.SCOPE == "run":
             manifest.stages[stage_name] = "completed" if ok else "failed"
@@ -422,7 +419,7 @@ def run_pipeline(
 
     total_elapsed = time.monotonic() - pipeline_start
     if failed_stage is None:
-        log.info(f"pipeline completed ({total_elapsed:.1f}s)")
+        log.info(f"Pipeline completed ({total_elapsed:.1f}s)")
         if run_root is not None:
             log.info("Results:")
             scores_path = run_root / "scores.jsonl"
@@ -438,7 +435,7 @@ def run_pipeline(
                 log.info("Inspect results:")
                 log.info(f"  uv run p2m results status {suite_id} {run_id}")
     else:
-        log.error(f"pipeline failed at {failed_stage} ({total_elapsed:.1f}s)")
+        log.error(f"Pipeline failed at {failed_stage} ({total_elapsed:.1f}s)")
 
     if manifest is None:
         return 0 if failed_stage is None else 1

--- a/p2m/stages/design.py
+++ b/p2m/stages/design.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
+
+log = logging.getLogger(__name__)
 
 from p2m.config import parse_model_config, resolve_stage_paths
 from p2m.core.io import (
@@ -402,6 +405,7 @@ async def run(ctx: dict[str, Any], raw_cfg: dict[str, Any]) -> dict[str, Any]:
         reasoning_effort=model_cfg.reasoning_effort if model_cfg is not None else None,
         temperature=model_cfg.temperature if model_cfg is not None else None,
     )
+    log.debug(f"design: factor_sizes={result.get('factor_sizes', {})}")
     return {
         "design_path": result["design_path"],
         "_summary": {

--- a/p2m/stages/judge.py
+++ b/p2m/stages/judge.py
@@ -199,8 +199,7 @@ async def run_judge(
             stored_hash = config_hash_path.read_text(encoding="utf-8").strip() if config_hash_path.exists() else None
             if stored_hash is not None and stored_hash != config_hash:
                 log.warning(
-                    "Judge config or transcripts changed since last run - discarding %s and starting fresh",
-                    scores_path,
+                    f"Judge config or transcripts changed since last run - discarding {scores_path} and starting fresh"
                 )
                 scores_path.unlink()
             else:
@@ -210,8 +209,7 @@ async def run_judge(
                         completed_keys.add((str(prior.get("kind") or ""), str(sid)))
     if completed_keys:
         log.info(
-            "Resuming judge: %d transcripts already scored, skipping",
-            len(completed_keys),
+            f"Resuming judge: {len(completed_keys)} transcripts already scored, skipping"
         )
     config_hash_path.write_text(config_hash, encoding="utf-8")
 

--- a/p2m/stages/judge.py
+++ b/p2m/stages/judge.py
@@ -9,6 +9,8 @@ import logging
 from pathlib import Path
 from typing import Any
 
+log = logging.getLogger(__name__)
+
 from p2m.config import resolve_stage_paths
 from p2m.core.io import SCORES_FILE, TRANSCRIPTS_FILE, row_factors
 from p2m.core.io import append_jsonl_row, load_jsonl, load_prompt_text, resolve_path
@@ -196,7 +198,7 @@ async def run_judge(
         else:
             stored_hash = config_hash_path.read_text(encoding="utf-8").strip() if config_hash_path.exists() else None
             if stored_hash is not None and stored_hash != config_hash:
-                logging.warning(
+                log.warning(
                     "Judge config or transcripts changed since last run - discarding %s and starting fresh",
                     scores_path,
                 )
@@ -207,7 +209,7 @@ async def run_judge(
                     if sid:
                         completed_keys.add((str(prior.get("kind") or ""), str(sid)))
     if completed_keys:
-        logging.info(
+        log.info(
             "Resuming judge: %d transcripts already scored, skipping",
             len(completed_keys),
         )

--- a/p2m/stages/policy.py
+++ b/p2m/stages/policy.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any, Dict
+
+log = logging.getLogger(__name__)
 
 from p2m.config import parse_model_config, resolve_stage_paths
 from p2m.core.config_model import (
@@ -175,6 +178,7 @@ async def run(ctx: dict[str, Any], raw_cfg: dict[str, Any]) -> dict[str, Any]:
         reasoning_effort=model_cfg.reasoning_effort,
     )
     sys_path = str(Path(cfg["save_dir"]) / "systematization.json")
+    log.debug(f"policy: model={model_cfg.name}, behavior_count={behavior_count}, web_search={web_search}")
     await run_systematization(
         concept=concept_name,
         concept_text=concept_text,

--- a/p2m/stages/policy.py
+++ b/p2m/stages/policy.py
@@ -167,6 +167,7 @@ async def run(ctx: dict[str, Any], raw_cfg: dict[str, Any]) -> dict[str, Any]:
     concept_text = ctx.get("concept") or ""
     context = ctx.get("context")
 
+    from p2m.core.async_utils import log_heartbeat
     from p2m.core.config_model import ModelConfig as SysModelConfig
     from p2m.stages.systematization import run_systematization
     from p2m.stages.systematization_convert import run_systematization_to_policy
@@ -179,16 +180,17 @@ async def run(ctx: dict[str, Any], raw_cfg: dict[str, Any]) -> dict[str, Any]:
     )
     sys_path = str(Path(cfg["save_dir"]) / "systematization.json")
     log.debug(f"policy: model={model_cfg.name}, behavior_count={behavior_count}, web_search={web_search}")
-    log.info("  [1/2] Researching risk taxonomy...")
-    await run_systematization(
-        concept=concept_name,
-        concept_text=concept_text,
-        save_path=sys_path,
-        model_cfg=sys_model_cfg,
-        web_search=web_search,
-        context=context,
-    )
-    log.info("  [1/2] Risk taxonomy complete")
+    log.info("[1/2] Researching risk taxonomy...")
+    async with log_heartbeat("[1/2] Researching risk taxonomy"):
+        await run_systematization(
+            concept=concept_name,
+            concept_text=concept_text,
+            save_path=sys_path,
+            model_cfg=sys_model_cfg,
+            web_search=web_search,
+            context=context,
+        )
+    log.info("[1/2] Risk taxonomy complete")
 
     policy_path_str = str(Path(cfg["save_dir"]) / "policy.json")
     convert_model_cfg = SysModelConfig(
@@ -197,13 +199,14 @@ async def run(ctx: dict[str, Any], raw_cfg: dict[str, Any]) -> dict[str, Any]:
         max_tokens=model_cfg.max_tokens or DEFAULT_POLICY_MAX_TOKENS,
         reasoning_effort=model_cfg.reasoning_effort,
     )
-    log.info("  [2/2] Converting to structured policy...")
-    await run_systematization_to_policy(
-        systematization_path=sys_path,
-        save_path=policy_path_str,
-        model_cfg=convert_model_cfg,
-        behavior_count_hint=behavior_count,
-    )
+    log.info("[2/2] Converting to structured policy...")
+    async with log_heartbeat("[2/2] Converting to structured policy"):
+        await run_systematization_to_policy(
+            systematization_path=sys_path,
+            save_path=policy_path_str,
+            model_cfg=convert_model_cfg,
+            behavior_count_hint=behavior_count,
+        )
 
     return {
         "policy_dir": cfg["save_dir"],

--- a/p2m/stages/policy.py
+++ b/p2m/stages/policy.py
@@ -179,6 +179,7 @@ async def run(ctx: dict[str, Any], raw_cfg: dict[str, Any]) -> dict[str, Any]:
     )
     sys_path = str(Path(cfg["save_dir"]) / "systematization.json")
     log.debug(f"policy: model={model_cfg.name}, behavior_count={behavior_count}, web_search={web_search}")
+    log.info("  [1/2] Researching risk taxonomy...")
     await run_systematization(
         concept=concept_name,
         concept_text=concept_text,
@@ -187,6 +188,7 @@ async def run(ctx: dict[str, Any], raw_cfg: dict[str, Any]) -> dict[str, Any]:
         web_search=web_search,
         context=context,
     )
+    log.info("  [1/2] Risk taxonomy complete")
 
     policy_path_str = str(Path(cfg["save_dir"]) / "policy.json")
     convert_model_cfg = SysModelConfig(
@@ -195,6 +197,7 @@ async def run(ctx: dict[str, Any], raw_cfg: dict[str, Any]) -> dict[str, Any]:
         max_tokens=model_cfg.max_tokens or DEFAULT_POLICY_MAX_TOKENS,
         reasoning_effort=model_cfg.reasoning_effort,
     )
+    log.info("  [2/2] Converting to structured policy...")
     await run_systematization_to_policy(
         systematization_path=sys_path,
         save_path=policy_path_str,

--- a/p2m/stages/policy.py
+++ b/p2m/stages/policy.py
@@ -180,8 +180,8 @@ async def run(ctx: dict[str, Any], raw_cfg: dict[str, Any]) -> dict[str, Any]:
     )
     sys_path = str(Path(cfg["save_dir"]) / "systematization.json")
     log.debug(f"policy: model={model_cfg.name}, behavior_count={behavior_count}, web_search={web_search}")
-    log.info("[1/2] Researching risk taxonomy...")
-    async with log_heartbeat("[1/2] Researching risk taxonomy"):
+    log.info("[policy] [1/2] Researching risk taxonomy...")
+    async with log_heartbeat("[policy] [1/2] Researching risk taxonomy"):
         await run_systematization(
             concept=concept_name,
             concept_text=concept_text,
@@ -190,7 +190,7 @@ async def run(ctx: dict[str, Any], raw_cfg: dict[str, Any]) -> dict[str, Any]:
             web_search=web_search,
             context=context,
         )
-    log.info("[1/2] Risk taxonomy complete")
+    log.info("[policy] [1/2] Risk taxonomy complete")
 
     policy_path_str = str(Path(cfg["save_dir"]) / "policy.json")
     convert_model_cfg = SysModelConfig(
@@ -199,8 +199,8 @@ async def run(ctx: dict[str, Any], raw_cfg: dict[str, Any]) -> dict[str, Any]:
         max_tokens=model_cfg.max_tokens or DEFAULT_POLICY_MAX_TOKENS,
         reasoning_effort=model_cfg.reasoning_effort,
     )
-    log.info("[2/2] Converting to structured policy...")
-    async with log_heartbeat("[2/2] Converting to structured policy"):
+    log.info("[policy] [2/2] Converting to structured policy...")
+    async with log_heartbeat("[policy] [2/2] Converting to structured policy"):
         await run_systematization_to_policy(
             systematization_path=sys_path,
             save_path=policy_path_str,

--- a/p2m/stages/rollout.py
+++ b/p2m/stages/rollout.py
@@ -645,9 +645,7 @@ async def _run_auditor_target_loop(
                     raise ValueError("auditor returned hidden setup instead of a visible user turn")
                 if auditor_response.finish_reason == "length":
                     log.warning(
-                        "Auditor response truncated (finish_reason=length) at turn %d/%d",
-                        turn_index + 1,
-                        max_turns,
+                        f"Auditor response truncated (finish_reason=length) at turn {turn_index + 1}/{max_turns}"
                     )
                 # Remove any retry guidance messages before continuing.
                 auditor_messages = [m for m in auditor_messages if m.content != _AUDITOR_RETRY_GUIDANCE]
@@ -733,9 +731,7 @@ async def _run_auditor_target_loop(
             )
             if runtime_result.finish_reason == "length":
                 log.warning(
-                    "Target response truncated (finish_reason=length) at turn %d/%d",
-                    turn_index + 1,
-                    max_turns,
+                    f"Target response truncated (finish_reason=length) at turn {turn_index + 1}/{max_turns}"
                 )
         except Exception as exc:
             tb = traceback.format_exc()
@@ -909,8 +905,7 @@ async def run_rollout(
             stored_hash = config_hash_path.read_text(encoding="utf-8").strip() if config_hash_path.exists() else None
             if stored_hash is not None and stored_hash != config_hash:
                 log.warning(
-                    "Rollout config changed since last run - discarding %s and starting fresh",
-                    transcripts_path,
+                    f"Rollout config changed since last run - discarding {transcripts_path} and starting fresh"
                 )
                 transcripts_path.unlink()
             else:
@@ -920,8 +915,7 @@ async def run_rollout(
                         completed_seed_ids.add(str(sid))
     if completed_seed_ids:
         log.info(
-            "Resuming rollout: %d seeds already completed, skipping",
-            len(completed_seed_ids),
+            f"Resuming rollout: {len(completed_seed_ids)} seeds already completed, skipping"
         )
     config_hash_path.write_text(config_hash, encoding="utf-8")
     pending_seeds = [
@@ -1005,11 +999,11 @@ async def run_rollout(
         )
         kind_tag = f"[{kind}] " if kind else ""
         status = "\u2714" if error is None else f"\u2716 {type(error).__name__}"
-        progress_msg = "rollout [%d/%d] %s %s%s"
+        msg = f"rollout [{done}/{total}] {status} {kind_tag}{label}"
         if error is None:
-            log.info(progress_msg, done, total, status, kind_tag, label)
+            log.info(msg)
         else:
-            log.warning(progress_msg, done, total, status, kind_tag, label)
+            log.warning(msg)
 
     if errors:
         raise errors[0]

--- a/p2m/stages/rollout.py
+++ b/p2m/stages/rollout.py
@@ -1006,8 +1006,8 @@ async def run_rollout(
             or seed_row.get("seed_id", "")
         )
         kind_tag = f"[{kind}] " if kind else ""
-        status = "\u2714" if error is None else f"\u2716 {type(error).__name__}"
-        msg = f"rollout [{done}/{total}] {status} {kind_tag}{label}"
+        status = "\u2713" if error is None else f"\u2717 {type(error).__name__}"
+        msg = f"[rollout] [{done}/{total}] {status} {kind_tag}{label}"
         if error is None:
             log.info(msg)
         else:

--- a/p2m/stages/rollout.py
+++ b/p2m/stages/rollout.py
@@ -7,7 +7,6 @@ from dataclasses import asdict
 import hashlib
 import json as json_module
 import logging
-import sys
 import traceback
 import uuid
 from pathlib import Path
@@ -1006,20 +1005,11 @@ async def run_rollout(
         )
         kind_tag = f"[{kind}] " if kind else ""
         status = "\u2714" if error is None else f"\u2716 {type(error).__name__}"
-        # Write to sys.__stderr__ rather than sys.stderr. Reproducible
-        # behavior: when the target is an OTel-instrumented LangChain /
-        # LangGraph callable (Phoenix auto_instrument), `sys.stderr` is
-        # silently replaced with a buffering wrapper after the second
-        # rollout. Subsequent writes only emit a trailing "\n"; the
-        # message body is swallowed. Both `sys.__stderr__` (the original
-        # saved by the interpreter at startup) and raw `os.write(2, ...)`
-        # remain unaffected. Bypassing the wrapper here keeps the
-        # per-seed progress visible without disturbing whatever the
-        # instrumentation is doing with sys.stderr.
-        sys.__stderr__.write(
-            f"  rollout [{done}/{total}] {status} {kind_tag}{label}\n"
-        )
-        sys.__stderr__.flush()
+        progress_msg = "rollout [%d/%d] %s %s%s"
+        if error is None:
+            log.info(progress_msg, done, total, status, kind_tag, label)
+        else:
+            log.warning(progress_msg, done, total, status, kind_tag, label)
 
     if errors:
         raise errors[0]

--- a/p2m/stages/rollout.py
+++ b/p2m/stages/rollout.py
@@ -13,6 +13,8 @@ import uuid
 from pathlib import Path
 from typing import Any
 
+log = logging.getLogger(__name__)
+
 import click
 
 from p2m.config import resolve_stage_paths
@@ -643,7 +645,7 @@ async def _run_auditor_target_loop(
                 ):
                     raise ValueError("auditor returned hidden setup instead of a visible user turn")
                 if auditor_response.finish_reason == "length":
-                    logging.warning(
+                    log.warning(
                         "Auditor response truncated (finish_reason=length) at turn %d/%d",
                         turn_index + 1,
                         max_turns,
@@ -731,7 +733,7 @@ async def _run_auditor_target_loop(
                 )
             )
             if runtime_result.finish_reason == "length":
-                logging.warning(
+                log.warning(
                     "Target response truncated (finish_reason=length) at turn %d/%d",
                     turn_index + 1,
                     max_turns,
@@ -907,7 +909,7 @@ async def run_rollout(
             # Check that existing transcripts were produced with the same config.
             stored_hash = config_hash_path.read_text(encoding="utf-8").strip() if config_hash_path.exists() else None
             if stored_hash is not None and stored_hash != config_hash:
-                logging.warning(
+                log.warning(
                     "Rollout config changed since last run - discarding %s and starting fresh",
                     transcripts_path,
                 )
@@ -918,7 +920,7 @@ async def run_rollout(
                     if sid:
                         completed_seed_ids.add(str(sid))
     if completed_seed_ids:
-        logging.info(
+        log.info(
             "Resuming rollout: %d seeds already completed, skipping",
             len(completed_seed_ids),
         )

--- a/p2m/stages/seeds.py
+++ b/p2m/stages/seeds.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import random
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+log = logging.getLogger(__name__)
 
 from p2m.config import parse_model_config, reject_unknown_keys, resolve_stage_paths
 from p2m.core.async_utils import gather_limited
@@ -878,6 +881,13 @@ async def run(ctx: dict[str, Any], raw_cfg: dict[str, Any]) -> dict[str, Any]:
             f"seed generation requires a design at {design_path}. "
             f"Run the design stage first."
         )
+
+    kinds = []
+    if prompt_cfg is not None:
+        kinds.append(f"prompt(n={prompt_cfg['sample_size']})")
+    if scenario_cfg is not None:
+        kinds.append(f"scenario(n={scenario_cfg['sample_size']})")
+    log.debug(f"seeds: kinds=[{', '.join(kinds)}], tool_source={tool_source}")
 
     result = await run_seeds(
         policy_path=policy_path,

--- a/p2m/stages/systematization.py
+++ b/p2m/stages/systematization.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import json
+import logging
 import re
 from pathlib import Path
+
+log = logging.getLogger(__name__)
 
 from pydantic import BaseModel, ConfigDict
 
@@ -111,6 +114,7 @@ async def run_systematization(
         raise ValueError("systematization requires non-empty concept text")
     if mode not in ALLOWED_MODES:
         raise ValueError(f"systematization.mode must be one of: {', '.join(sorted(ALLOWED_MODES))}")
+    log.debug(f"systematization: concept={concept}, model={model_cfg.name}, mode={mode}, web_search={web_search}")
 
     temperature = model_cfg.temperature
     # Reasoning models don't support temperature

--- a/p2m/stages/systematization_convert.py
+++ b/p2m/stages/systematization_convert.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import json
+import logging
 import uuid
 from pathlib import Path
 from typing import Any
+
+log = logging.getLogger(__name__)
 
 from p2m.core.config_model import (
     DEFAULT_SYSTEMATIZATION_CONVERT_MAX_TOKENS,
@@ -108,6 +111,7 @@ async def run_systematization_to_policy(
             temperature=DEFAULT_SYSTEMATIZATION_CONVERT_TEMPERATURE,
             max_tokens=DEFAULT_SYSTEMATIZATION_CONVERT_MAX_TOKENS,
         )
+    log.debug(f"systematization_convert: model={model_cfg.name}, behavior_count_hint={behavior_count_hint}")
     data_path = Path(systematization_path).expanduser()
     if not data_path.is_absolute():
         data_path = BASE_DIR / data_path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -88,6 +88,14 @@ class CliTest(unittest.TestCase):
         result = self.runner.invoke(cli, ["--log-file", "/tmp/test.log", "--help"])
         self.assertEqual(result.exit_code, 0, msg=result.output)
 
+    def test_output_json_flag_accepted(self) -> None:
+        result = self.runner.invoke(cli, ["--output", "json", "--help"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+
+    def test_output_text_flag_accepted(self) -> None:
+        result = self.runner.invoke(cli, ["--output", "text", "--help"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -76,5 +76,18 @@ class CliTest(unittest.TestCase):
         )
 
 
+    def test_verbose_flag_accepted(self) -> None:
+        result = self.runner.invoke(cli, ["-v", "--help"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+
+    def test_quiet_flag_accepted(self) -> None:
+        result = self.runner.invoke(cli, ["-q", "--help"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+
+    def test_log_file_flag_accepted(self) -> None:
+        result = self.runner.invoke(cli, ["--log-file", "/tmp/test.log", "--help"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import sys
 import unittest
@@ -67,3 +68,44 @@ class ConfigureLoggingTest(unittest.TestCase):
         configure_logging()
         root = logging.getLogger()
         self.assertEqual(len(root.handlers), 1)
+
+    def test_json_output_uses_stream_handler(self) -> None:
+        configure_logging(json_output=True)
+        root = logging.getLogger()
+        self.assertEqual(len(root.handlers), 1)
+        handler = root.handlers[0]
+        self.assertIsInstance(handler, logging.StreamHandler)
+        self.assertNotIsInstance(handler, logging.FileHandler)
+
+    def test_json_output_emits_valid_json(self) -> None:
+        configure_logging(json_output=True)
+        root = logging.getLogger()
+        handler = root.handlers[0]
+        record = logging.LogRecord(
+            name="test", level=logging.INFO, pathname="", lineno=0,
+            msg="hello world", args=(), exc_info=None,
+        )
+        output = handler.format(record)
+        parsed = json.loads(output)
+        self.assertEqual(parsed["level"], "INFO")
+        self.assertEqual(parsed["message"], "hello world")
+        self.assertEqual(parsed["logger"], "test")
+        self.assertIn("timestamp", parsed)
+
+    def test_json_output_includes_exception(self) -> None:
+        configure_logging(json_output=True)
+        root = logging.getLogger()
+        handler = root.handlers[0]
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            import sys
+            exc_info = sys.exc_info()
+        record = logging.LogRecord(
+            name="test", level=logging.ERROR, pathname="", lineno=0,
+            msg="failed", args=(), exc_info=exc_info,
+        )
+        output = handler.format(record)
+        parsed = json.loads(output)
+        self.assertIn("exception", parsed)
+        self.assertIn("boom", parsed["exception"])

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,69 @@
+"""Tests for p2m.logging_config."""
+
+from __future__ import annotations
+
+import logging
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from p2m.logging_config import configure_logging
+
+
+class ConfigureLoggingTest(unittest.TestCase):
+    """Verify that configure_logging sets the expected root logger state."""
+
+    def tearDown(self) -> None:
+        # Reset root logger to avoid cross-test pollution.
+        root = logging.getLogger()
+        root.handlers.clear()
+        root.setLevel(logging.WARNING)
+
+    def test_default_level_is_info(self) -> None:
+        configure_logging()
+        self.assertEqual(logging.getLogger().level, logging.INFO)
+
+    def test_verbose_sets_debug(self) -> None:
+        configure_logging(verbose=True)
+        self.assertEqual(logging.getLogger().level, logging.DEBUG)
+
+    def test_quiet_sets_warning(self) -> None:
+        configure_logging(quiet=True)
+        self.assertEqual(logging.getLogger().level, logging.WARNING)
+
+    def test_console_handler_uses_original_stderr(self) -> None:
+        configure_logging()
+        root = logging.getLogger()
+        self.assertEqual(len(root.handlers), 1)
+        handler = root.handlers[0]
+        # RichHandler wraps a Console; verify it targets __stderr__.
+        console = handler.console  # type: ignore[attr-defined]
+        self.assertIs(console.file, sys.__stderr__)
+
+    def test_file_handler_added_when_log_file_set(self) -> None:
+        with TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "test.log"
+            configure_logging(log_file=log_path)
+            root = logging.getLogger()
+            self.assertEqual(len(root.handlers), 2)
+            file_handler = root.handlers[1]
+            self.assertIsInstance(file_handler, logging.FileHandler)
+
+    def test_file_handler_creates_parent_dirs(self) -> None:
+        with TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "nested" / "dir" / "test.log"
+            configure_logging(log_file=log_path)
+            self.assertTrue(log_path.parent.exists())
+
+    def test_litellm_loggers_pinned_to_warning(self) -> None:
+        configure_logging(verbose=True)
+        for name in ("LiteLLM", "litellm", "httpx"):
+            with self.subTest(logger=name):
+                self.assertEqual(logging.getLogger(name).level, logging.WARNING)
+
+    def test_repeated_calls_do_not_duplicate_handlers(self) -> None:
+        configure_logging()
+        configure_logging()
+        root = logging.getLogger()
+        self.assertEqual(len(root.handlers), 1)

--- a/tests/test_runner_progress.py
+++ b/tests/test_runner_progress.py
@@ -1,4 +1,3 @@
-import io
 import json
 import unittest
 from pathlib import Path
@@ -108,12 +107,13 @@ class RunnerProgressTest(unittest.TestCase):
                 encoding="utf-8",
             )
 
-            with patch("sys.stderr", new_callable=io.StringIO) as fake_err:
+            with self.assertLogs("p2m.runner", level="ERROR") as cm:
                 rc = run_pipeline(config=str(cfg_path))
 
             self.assertEqual(rc, 1)
-            self.assertIn("[config error]", fake_err.getvalue())
-            self.assertIn("run_id, suite_id", fake_err.getvalue())
+            log_output = "\n".join(cm.output)
+            self.assertIn("[config error]", log_output)
+            self.assertIn("run_id, suite_id", log_output)
 
     @unittest.skip("resume parameter removed from run_pipeline in merge")
     def test_run_pipeline_allows_existing_run_directory_with_resume(self) -> None:
@@ -194,37 +194,33 @@ class RunnerProgressTest(unittest.TestCase):
             async def boom(**_: object) -> None:
                 raise RuntimeError("boom")
 
-            fake_err = io.StringIO()
             with (
                 patch("p2m.stages.judge.run_judge", new=boom),
-                patch("sys.stderr", fake_err),
-                patch("sys.__stderr__", fake_err),
+                self.assertLogs("p2m.runner", level="ERROR") as cm,
             ):
                 rc = run_pipeline(config=str(cfg_path))
 
             self.assertEqual(rc, 1)
-            err = fake_err.getvalue()
-            self.assertIn("boom", err)
-            self.assertIn("failed", err)
+            log_output = "\n".join(cm.output)
+            self.assertIn("boom", log_output)
+            self.assertIn("failed", log_output)
 
     def test_run_pipeline_prints_timing_output(self) -> None:
         with TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)
             cfg_path = self._make_judge_config(root)
 
-            fake_err = io.StringIO()
             with (
                 patch("p2m.stages.judge.run_judge", new=self._make_fake_run_judge(root)),
-                patch("sys.stderr", fake_err),
-                patch("sys.__stderr__", fake_err),
+                self.assertLogs("p2m.runner", level="INFO") as cm,
             ):
                 rc = run_pipeline(config=str(cfg_path))
 
             self.assertEqual(rc, 0)
-            err = fake_err.getvalue()
-            self.assertIn("judge", err)
-            self.assertIn("pipeline completed", err)
-            self.assertRegex(err, r"\(\d+\.\d+s\)")
+            log_output = "\n".join(cm.output)
+            self.assertIn("judge", log_output)
+            self.assertIn("pipeline completed", log_output)
+            self.assertRegex(log_output, r"\(\d+\.\d+s\)")
 
     def test_run_pipeline_writes_manifest_mid_run(self) -> None:
         with TemporaryDirectory() as tmp_dir:

--- a/tests/test_runner_progress.py
+++ b/tests/test_runner_progress.py
@@ -219,7 +219,7 @@ class RunnerProgressTest(unittest.TestCase):
             self.assertEqual(rc, 0)
             log_output = "\n".join(cm.output)
             self.assertIn("judge", log_output)
-            self.assertIn("pipeline completed", log_output)
+            self.assertIn("Pipeline completed", log_output)
             self.assertRegex(log_output, r"\(\d+\.\d+s\)")
 
     def test_run_pipeline_writes_manifest_mid_run(self) -> None:


### PR DESCRIPTION
## Summary

Replaces four competing output mechanisms (unconfigured `logging.*`, `_progress()` → `sys.__stderr__`, `click.echo(err=True)`, `print(file=sys.stderr)`) with a single centralized logging system.

**Before**
<img width="2871" height="1222" alt="image" src="https://github.com/user-attachments/assets/81010dbe-5242-4084-8117-eaa1cd786239" />

**After**
<img width="1976" height="854" alt="image" src="https://github.com/user-attachments/assets/80b8e02c-d7c1-4514-b80d-7d0202b45197" />

Verbose
<img width="2450" height="1846" alt="image" src="https://github.com/user-attachments/assets/aa2f3c97-f49f-4acd-9fd1-4fa1fc3c9e8b" />
<img width="1848" height="701" alt="image" src="https://github.com/user-attachments/assets/6a36fb22-26ea-4852-97d7-c070cf542d5a" />

JSON
<img width="2881" height="1001" alt="image" src="https://github.com/user-attachments/assets/9f0ab2d2-15a8-4b3b-a489-461cf2404e7c" />


## Changes

### Phase 1: Logging bootstrap
- New `p2m/logging_config.py` with `configure_logging()` — `RichHandler` on `sys.__stderr__` (preserves OTel/Phoenix bypass), optional `FileHandler`
- CLI flags: `--verbose` (DEBUG), `--quiet` (WARNING), `--log-file <path>`, `--output json`
- LiteLLM/httpx/openai loggers pinned to WARNING at all verbosity levels

### Phase 2: Unify stdlib loggers
- Replace bare `logging.warning()`/`logging.info()` with named `log = logging.getLogger(__name__)` in transcript, rollout, judge (8 sites)

### Phase 3: Migrate `_progress()` → `log.info()`
- Remove the custom `_progress()` function and replace 32 call sites
- Errors upgraded to `log.error()` with `exc_info=True`

### Phase 4: Migrate raw `print(file=stderr)`
- `runner.py` config errors → `log.error()`
- `config.py` validation warnings → `log.warning()`

### Phase 5: Add logging to silent modules
- `log.debug()` in policy, design, seeds, systematization, systematization_convert, model_client
- `log.info()` sub-step progress in policy stage (two sequential LLM calls)

### Phase 6: Structured JSON output
- `--output json` flag for CI pipeline consumption
- `_JsonFormatter` emits one JSON object per log record with timestamp, level, logger, message, and optional exception

### Additional improvements
- All messages use consistent `[stage_name]` prefix format with ✓/✗ symbols
- Route rollout per-seed progress lines through logging (previously raw `sys.__stderr__.write()`)
- Suppress OpenAI SDK retry spam (`"Retrying request to /chat/completions"`)
- Add `log_heartbeat()` for long-running LLM calls (15s periodic "still working" messages)
- Per-call debug summary with latency, token usage, and finish_reason
- Fix Responses API usage/finish_reason extraction (`input_tokens`/`output_tokens` → `prompt_tokens`/`completion_tokens`)
- `--verbose`/`--quiet`/`--log-file`/`--output` accepted on both `p2m` group and `run` subcommand

## Test results
544 passed, 13 skipped (1 pre-existing Docker permission failure)