### PR TITLE
fix: improve error handling in policy generation and rollout

### DIFF
--- a/p2m/stages/rollout.py
+++ b/p2m/stages/rollout.py
@@ -37,6 +37,7 @@ from p2m.core.io import (
     row_factors,
 )
 from p2m.core.model_client import GenerateOptions, Message, ModelResponse, build_llm_call_trace, generate, to_jsonable
+from p2m.core.model_client import LLMAuthError, LLMInputError, LLMRateLimitError, LLMProviderError
 from p2m.core.session import (
     CallableSession,
     ExternalSession,
@@ -658,6 +659,11 @@ async def _run_auditor_target_loop(
                 auditor_messages = [m for m in auditor_messages if m.content != _AUDITOR_RETRY_GUIDANCE]
                 auditor_messages.append(auditor_response.message)
                 break
+            except (LLMAuthError, LLMInputError, LLMRateLimitError, LLMProviderError):
+                # Transport/auth/rate-limit errors should propagate to the
+                # runner's top-level handler — not be treated as bad auditor
+                # output.  The runner presents these with clean messages.
+                raise
             except Exception as exc:
                 last_error = str(exc)
                 if attempt < 2:
@@ -742,6 +748,12 @@ async def _run_auditor_target_loop(
                     turn_index + 1,
                     max_turns,
                 )
+        except (LLMAuthError, LLMInputError, LLMRateLimitError, LLMProviderError):
+            # LLM-level errors (rate limit, auth, bad request, provider 5xx)
+            # should propagate to the runner's top-level handler instead of
+            # being buried in the transcript as a target_error.  The runner
+            # presents these with clean, actionable messages.
+            raise
         except Exception as exc:
             tb = traceback.format_exc()
             transcript.add_event(TranscriptEvent(

--- a/p2m/stages/systematization_convert.py
+++ b/p2m/stages/systematization_convert.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import uuid
 from pathlib import Path
 from typing import Any
@@ -133,20 +134,44 @@ async def run_systematization_to_policy(
     # Reasoning models don't support temperature
     if model_cfg.reasoning_effort is not None:
         temperature = None
-    response = await generate_structured(
-        model_cfg.name,
-        prompt,
-        schema_name="policy",
-        json_schema=POLICY_SCHEMA,
-        options=GenerateOptions(
-            temperature=temperature,
-            max_tokens=model_cfg.max_tokens,
-            reasoning_effort=model_cfg.reasoning_effort,
-        ),
-    )
-    policy_payload = response.parsed
+
+    # Retry structured generation up to 2 times if the model returns
+    # a response that doesn't parse into a valid policy dict.  This is
+    # a transient LLM output quality issue — the model occasionally
+    # produces malformed JSON even with response_format set.
+    _MAX_PARSE_ATTEMPTS = 2
+    policy_payload: dict[str, Any] | None = None
+    last_text = ""
+    for _attempt in range(_MAX_PARSE_ATTEMPTS):
+        response = await generate_structured(
+            model_cfg.name,
+            prompt,
+            schema_name="policy",
+            json_schema=POLICY_SCHEMA,
+            options=GenerateOptions(
+                temperature=temperature,
+                max_tokens=model_cfg.max_tokens,
+                reasoning_effort=model_cfg.reasoning_effort,
+            ),
+        )
+        if isinstance(response.parsed, dict) and response.parsed:
+            policy_payload = response.parsed
+            break
+        last_text = response.text or ""
+        if _attempt < _MAX_PARSE_ATTEMPTS - 1:
+            logging.warning(
+                "Policy generation returned unparseable output (attempt %d/%d), retrying",
+                _attempt + 1,
+                _MAX_PARSE_ATTEMPTS,
+            )
+
     if not isinstance(policy_payload, dict) or not policy_payload:
-        raise ValueError("systematization_convert returned no structured policy")
+        raise ValueError(
+            f"systematization_convert returned no structured policy after "
+            f"{_MAX_PARSE_ATTEMPTS} attempts (last response: {last_text[:200]}). "
+            f"This is usually a transient model issue — rerun the command to retry. "
+            f"If it persists, check your endpoint's token rate limit and quota."
+        )
 
     concept_block = policy_payload.get("concept")
     if not isinstance(concept_block, dict):


### PR DESCRIPTION
## Summary

Fix two error handling issues that caused noisy failures and poor user experience during pipeline runs.

## Changes

### Commit 1: Retry structured policy generation on transient parse failures

**Problem:** The policy stage calls `generate_structured()` which can return a valid HTTP response with malformed JSON that doesn't parse into a policy dict. This immediately raised `ValueError` and failed the pipeline, even though a simple retry usually succeeds.

**Fix:**
- Retry structured generation up to 2 attempts on parse failure
- Log a warning on each retry attempt
- Include actionable hint in error message when retries exhausted: "rerun the command to retry" and "check your endpoint's token rate limit and quota"
- Include last response text (truncated) for debugging

Note: The rate limiter (`_with_retries` inside `generate_structured()`) handles HTTP-level errors (429/5xx). This retry is a separate layer for content-quality failures where the HTTP call succeeded but the output is unusable.

### Commit 2: Propagate LLM errors from rollout instead of burying in transcript

**Problem:** Two broad `except Exception` blocks in `rollout.py` caught classified LLM errors (`LLMRateLimitError`, `LLMAuthError`, etc.) and either:
- Treated rate-limit errors as "bad auditor output" and retried with a guidance prompt (auditor loop, L659)
- Buried LLM errors as `[TARGET ERROR]` in the transcript, then surfaced them as `RuntimeError: scenario ended with target_error` with a noisy traceback (target turn loop, L741)

**Fix:** Add explicit catch for `(LLMAuthError, LLMInputError, LLMRateLimitError, LLMProviderError)` before the broad `except Exception` that re-raises immediately. The runner's top-level handler at L393 already presents these with clean, actionable messages. Non-LLM errors (runtime crashes, JSON parse failures) still follow the existing transcript recording path.

## Testing

```
uv run pytest -q  # 528 passed (1 pre-existing docker permission failure)
```