### PR TITLE
Concurrency configurability and fail-fast on fatal errors

### DIFF
--- a/CONFIG_REFERENCE.md
+++ b/CONFIG_REFERENCE.md
@@ -146,6 +146,7 @@ Accepted keys:
   - `sample_size` — integer from `1` to `100000`. Default: `100`.
   - `model` — model config.
 - `tool_source` — string. Default: `runtime`. Allowed values: `runtime`, `per_seed`.
+- `concurrency` — positive integer. Default: `8`. Maximum concurrent LLM calls for seed generation.
 - `model` — shared fallback for `prompt.model` and `scenario.model`.
 
 At least one of `prompt` or `scenario` is required. The fallback order for prompt generation is `seeds.prompt.model`, then `seeds.model`, then `default_model`. Scenario generation uses the same order with `seeds.scenario.model` first.
@@ -252,6 +253,7 @@ Accepted keys:
   - `required_base` — optional boolean accepted by the parser and passed through unchanged. Current judge construction code does not read it.
 - `model` — model config. Required unless `default_model` is set.
 - `n` — positive integer. Default: `1`.
+- `concurrency` — positive integer. Default: `10`. Maximum concurrent LLM calls for judging.
 
 For customer-preview runs, define the dimensions you want the judge to score. If you omit `model` and `default_model`, config validation fails.
 

--- a/p2m/config.py
+++ b/p2m/config.py
@@ -12,6 +12,7 @@ import yaml
 
 from p2m.core.config_model import (
     DEFAULT_AUDITOR_MAX_TURNS,
+    DEFAULT_JUDGE_CONCURRENCY,
     DEFAULT_JUDGE_MAX_TOKENS,
     DEFAULT_JUDGE_TEMPERATURE,
     DEFAULT_ROLLOUT_CONCURRENCY,
@@ -678,7 +679,7 @@ def parse_pipeline_config(raw: dict[str, Any]) -> PipelineConfig | None:
         reject_unknown_keys(
             scorer_stage,
             field_name="pipeline.judge",
-            allowed={"model", "n", "dimensions", "transcripts_path", "policy_path", "save_dir",
+            allowed={"model", "n", "concurrency", "dimensions", "transcripts_path", "policy_path", "save_dir",
                        "enabled", "file_path"},
         )
         if judge_enabled:
@@ -696,6 +697,10 @@ def parse_pipeline_config(raw: dict[str, Any]) -> PipelineConfig | None:
                     default_max_tokens=DEFAULT_JUDGE_MAX_TOKENS,
                 ),
                 n=_coalesce(_optional_int(scorer_stage.get("n"), field_name="pipeline.judge.n"), 1),
+                concurrency=_coalesce(_optional_int(
+                    scorer_stage.get("concurrency"),
+                    field_name="pipeline.judge.concurrency",
+                ), DEFAULT_JUDGE_CONCURRENCY),
                 dimensions=dimensions,
             )
 

--- a/p2m/core/config_model.py
+++ b/p2m/core/config_model.py
@@ -23,6 +23,8 @@ DEFAULT_ROLLOUT_CONCURRENCY = 10
 DEFAULT_AUDITOR_MAX_TURNS = 10
 DEFAULT_JUDGE_TEMPERATURE = None
 DEFAULT_JUDGE_MAX_TOKENS = 12000
+DEFAULT_JUDGE_CONCURRENCY = 10
+DEFAULT_SEEDS_CONCURRENCY = 8
 DEFAULT_MODEL_TIMEOUT_S = 300.0  # 5 minutes per API call
 
 
@@ -183,6 +185,7 @@ class AuditorConfig:
 class JudgeConfig:
     model: ModelConfig | str
     n: int = 1
+    concurrency: int = DEFAULT_JUDGE_CONCURRENCY
     dimensions: list[dict[str, Any]] = field(default_factory=list)
 
     def __post_init__(self) -> None:
@@ -190,6 +193,8 @@ class JudgeConfig:
             self.model = ModelConfig(name=self.model)
         if self.n <= 0:
             raise ValueError("judge.n must be > 0")
+        if self.concurrency <= 0:
+            raise ValueError("judge.concurrency must be > 0")
         if not isinstance(self.dimensions, list):
             raise ValueError("judge.dimensions must be a list")
         for dimension in self.dimensions:

--- a/p2m/stages/judge.py
+++ b/p2m/stages/judge.py
@@ -17,6 +17,7 @@ from p2m.core.judge import (
     infer_judge_status,
     run_transcript_judge as run_llm_judge,
 )
+from p2m.core.model_client import LLMAuthError, LLMInputError
 from p2m.core.transcript import Transcript, TranscriptEvent, TranscriptMetadata
 from p2m.viewer_read_model import build_run_viewer_artifacts
 
@@ -237,6 +238,13 @@ async def run_judge(
         error = result.get("error")
         if error is not None:
             errors.append(error)
+            # Fatal errors (bad credentials, invalid request) cannot
+            # succeed on retry — cancel remaining tasks to avoid wasting
+            # API budget.
+            if isinstance(error, (LLMAuthError, LLMInputError)):
+                for task in tasks:
+                    task.cancel()
+                break
 
     # Always rebuild viewer artifacts so the on-disk read model reflects the
     # current scores.jsonl, even when a row failed and we are about to raise.

--- a/p2m/stages/judge.py
+++ b/p2m/stages/judge.py
@@ -218,7 +218,8 @@ async def run_judge(
         if (str(row.get("kind") or ""), str(row.get("seed_id", ""))) not in completed_keys
     ]
 
-    semaphore = asyncio.Semaphore(max(1, min(evaluation.rollout.concurrency, len(pending) or 1)))
+    judge_concurrency = evaluation.judge.concurrency if evaluation.judge else evaluation.rollout.concurrency
+    semaphore = asyncio.Semaphore(max(1, min(judge_concurrency, len(pending) or 1)))
 
     async def guard(item: tuple[int, dict[str, Any]]) -> dict[str, Any]:
         async with semaphore:

--- a/p2m/stages/rollout.py
+++ b/p2m/stages/rollout.py
@@ -37,6 +37,7 @@ from p2m.core.io import (
     row_factors,
 )
 from p2m.core.model_client import GenerateOptions, Message, ModelResponse, build_llm_call_trace, generate, to_jsonable
+from p2m.core.model_client import LLMAuthError, LLMInputError
 from p2m.core.session import (
     CallableSession,
     ExternalSession,
@@ -1026,10 +1027,20 @@ async def run_rollout(
             f"  rollout [{done}/{total}] {status} {kind_tag}{label}\n"
         )
         sys.__stderr__.flush()
+        # Fatal errors (bad credentials, invalid request) cannot succeed
+        # on retry — cancel remaining tasks to avoid wasting API budget.
+        if error is not None and isinstance(error, (LLMAuthError, LLMInputError)):
+            for task in tasks:
+                task.cancel()
+            break
 
+    # Always build viewer artifacts so partial results are visible, even
+    # when we are about to raise a fatal error — but only if any
+    # transcripts were actually written.
+    if transcripts_path.exists():
+        build_run_viewer_artifacts(out_dir)
     if errors:
         raise errors[0]
-    build_run_viewer_artifacts(out_dir)
 
     return {
         "transcripts_path": str(transcripts_path),

--- a/p2m/stages/seeds.py
+++ b/p2m/stages/seeds.py
@@ -14,6 +14,7 @@ from p2m.core.async_utils import gather_limited
 from p2m.core.config_model import (
     DEFAULT_GENERATION_MAX_TOKENS,
     DEFAULT_GENERATION_TEMPERATURE,
+    DEFAULT_SEEDS_CONCURRENCY,
     TargetConfig,
 )
 from p2m.core.io import (
@@ -825,6 +826,7 @@ async def run(ctx: dict[str, Any], raw_cfg: dict[str, Any]) -> dict[str, Any]:
             "tool_source",
             "model",
             "timeout_s",
+            "concurrency",
             "prompt",
             "scenario",
             "validators",
@@ -836,6 +838,14 @@ async def run(ctx: dict[str, Any], raw_cfg: dict[str, Any]) -> dict[str, Any]:
     tool_source = raw_cfg.get("tool_source", TOOL_SOURCE_RUNTIME)
     if not isinstance(tool_source, str):
         raise ValueError("seeds.tool_source must be a string")
+
+    concurrency_raw = raw_cfg.get("concurrency")
+    if concurrency_raw is not None:
+        concurrency = int(concurrency_raw)
+        if concurrency <= 0:
+            raise ValueError("seeds.concurrency must be > 0")
+    else:
+        concurrency = DEFAULT_SEEDS_CONCURRENCY
 
     prompt_cfg = None
     scenario_cfg = None
@@ -889,6 +899,7 @@ async def run(ctx: dict[str, Any], raw_cfg: dict[str, Any]) -> dict[str, Any]:
         target=ctx.get("target"),
         tool_source=tool_source,
         design=raw_design,
+        concurrency=concurrency,
     )
     return {
         "seeds_path": result["seeds_path"],

--- a/tests/test_concurrency_config.py
+++ b/tests/test_concurrency_config.py
@@ -1,0 +1,118 @@
+"""Tests for concurrency configurability across pipeline stages."""
+
+from __future__ import annotations
+
+import unittest
+
+import yaml
+
+from p2m.core.config_model import (
+    DEFAULT_JUDGE_CONCURRENCY,
+    DEFAULT_ROLLOUT_CONCURRENCY,
+    DEFAULT_SEEDS_CONCURRENCY,
+    JudgeConfig,
+    RolloutConfig,
+)
+from p2m.config import parse_pipeline_config
+
+
+class JudgeConfigConcurrencyTest(unittest.TestCase):
+    """JudgeConfig.concurrency field validation."""
+
+    def test_default_concurrency(self):
+        cfg = JudgeConfig(model="azure/gpt-5.4")
+        self.assertEqual(cfg.concurrency, DEFAULT_JUDGE_CONCURRENCY)
+
+    def test_custom_concurrency(self):
+        cfg = JudgeConfig(model="azure/gpt-5.4", concurrency=5)
+        self.assertEqual(cfg.concurrency, 5)
+
+    def test_concurrency_must_be_positive(self):
+        with self.assertRaises(ValueError, msg="judge.concurrency must be > 0"):
+            JudgeConfig(model="azure/gpt-5.4", concurrency=0)
+
+    def test_negative_concurrency_rejected(self):
+        with self.assertRaises(ValueError):
+            JudgeConfig(model="azure/gpt-5.4", concurrency=-1)
+
+
+class RolloutConfigConcurrencyTest(unittest.TestCase):
+    """RolloutConfig.concurrency default is unchanged."""
+
+    def test_default_concurrency(self):
+        cfg = RolloutConfig()
+        self.assertEqual(cfg.concurrency, DEFAULT_ROLLOUT_CONCURRENCY)
+
+
+class ParsePipelineJudgeConcurrencyTest(unittest.TestCase):
+    """pipeline.judge.concurrency parsed from YAML."""
+
+    def _parse(self, yaml_text: str) -> object:
+        raw = yaml.safe_load(yaml_text)
+        return parse_pipeline_config(raw)
+
+    def test_judge_concurrency_from_yaml(self):
+        pipeline = self._parse("""
+pipeline:
+  rollout:
+    target:
+      model:
+        name: azure/gpt-5.4-mini
+    concurrency: 10
+  judge:
+    model:
+      name: azure/gpt-5.4
+    concurrency: 3
+    dimensions:
+      safety:
+        description: Is the response safe?
+        rubric: "true = safe, false = unsafe"
+""")
+        self.assertEqual(pipeline.evaluation.judge.concurrency, 3)
+        self.assertEqual(pipeline.evaluation.rollout.concurrency, 10)
+
+    def test_judge_concurrency_defaults_when_omitted(self):
+        pipeline = self._parse("""
+pipeline:
+  rollout:
+    target:
+      model:
+        name: azure/gpt-5.4-mini
+  judge:
+    model:
+      name: azure/gpt-5.4
+    dimensions:
+      safety:
+        description: Is the response safe?
+        rubric: "true = safe, false = unsafe"
+""")
+        self.assertEqual(pipeline.evaluation.judge.concurrency, DEFAULT_JUDGE_CONCURRENCY)
+
+    def test_judge_concurrency_zero_rejected(self):
+        with self.assertRaises(ValueError):
+            self._parse("""
+pipeline:
+  rollout:
+    target:
+      model:
+        name: azure/gpt-5.4-mini
+  judge:
+    model:
+      name: azure/gpt-5.4
+    concurrency: 0
+    dimensions:
+      safety:
+        description: Is the response safe?
+        rubric: "true = safe, false = unsafe"
+""")
+
+
+class SeedsConcurrencyDefaultTest(unittest.TestCase):
+    """DEFAULT_SEEDS_CONCURRENCY is 8 (backward-compatible)."""
+
+    def test_default_value(self):
+        self.assertEqual(DEFAULT_SEEDS_CONCURRENCY, 8)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rollout_stage.py
+++ b/tests/test_rollout_stage.py
@@ -1160,6 +1160,60 @@ class RolloutStageTest(unittest.IsolatedAsyncioTestCase):
         )
         self.assertNotIn("parent_seed_id", canonical_rows[2])
 
+    async def test_run_rollout_cancels_remaining_tasks_on_fatal_auth_error(self) -> None:
+        """When one seed raises LLMAuthError, remaining tasks are cancelled."""
+        from p2m.core.model_client import LLMAuthError
+
+        seed_rows = [
+            {"kind": "prompt", "seed": {"description": f"prompt {i}"}}
+            for i in range(5)
+        ]
+        call_count = 0
+
+        async def fake_run_prompt_seed(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            # First task to run raises a fatal auth error
+            if call_count == 1:
+                raise LLMAuthError("Invalid API key")
+            # Other tasks should be cancelled before reaching here, but if
+            # they do run, add a small delay so the cancellation has time
+            await asyncio.sleep(0.5)
+
+            class FakeTranscript:
+                def to_dict(self_inner) -> dict[str, str]:
+                    return {"kind": "prompt", "seed_id": str(kwargs["seed"]["seed_id"])}
+
+            return FakeTranscript()
+
+        with TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            seed_path = tmp_path / "seeds.jsonl"
+            out_dir = tmp_path / "run"
+            seed_path.write_text(
+                "\n".join(json.dumps(row) for row in seed_rows) + "\n",
+                encoding="utf-8",
+            )
+
+            with patch("p2m.stages.rollout._run_prompt_seed", new=fake_run_prompt_seed):
+                with self.assertRaises(LLMAuthError):
+                    await run_rollout(
+                        seed_path=str(seed_path),
+                        target=TargetConfig(model="azure/gpt-5.4"),
+                        evaluation=EvaluationConfig(
+                            judge=JudgeConfig(model="azure/gpt-5.4"),
+                            rollout=RolloutConfig(concurrency=1),
+                        ),
+                        save_dir=str(out_dir),
+                        run_id="run-rollout",
+                    )
+
+        # With concurrency=1 and fail-fast, the fatal error should cancel
+        # remaining tasks. At most 2 may enter the worker (the failing one
+        # plus one that acquires the semaphore before cancel takes effect),
+        # but far fewer than all 5 seeds.
+        self.assertLessEqual(call_count, 2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Adds independent concurrency configuration for judge and seeds stages, and implements fail-fast cancellation when fatal LLM errors are detected.

## Changes

### 1. Independent concurrency per stage

Previously, judge reused `rollout.concurrency` and seeds hardcoded concurrency to 8. Each stage now has its own YAML key:

- `pipeline.judge.concurrency` (default: 10)
- `pipeline.seeds.concurrency` (default: 8)

Defaults preserve existing behavior. Example:

```yaml
pipeline:
  seeds:
    concurrency: 4
  rollout:
    concurrency: 10
  judge:
    concurrency: 5
```

### 2. Fail-fast on fatal LLM errors

When an `LLMAuthError` or `LLMInputError` hits one task in rollout or judge, all remaining tasks are now cancelled immediately. These errors (bad API key, invalid request) cannot succeed on retry, so continuing wastes API budget.

Transient errors (`LLMRateLimitError`, `LLMProviderError`) are unaffected and still collected without cancelling peers.

Also fixed `build_run_viewer_artifacts` to guard against missing transcripts file when all seeds fail.

## Testing

- 9 new config validation tests (defaults, custom values, invalid values, YAML parsing)
- 1 new fail-fast integration test (verifies task cancellation on `LLMAuthError`)
- All 73 relevant tests pass, no regressions