### PR TITLE
fix(deps): pin Phoenix auto-trace instrumentors for examples group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,16 @@ examples = [
   "openai-agents>=0.14.5",
   "pydantic-ai>=0.8.1",
   "smolagents>=1.22.0",
+  # Framework-specific OpenInference instrumentors used by the
+  # examples/phoenix_auto_trace/* demos. `phoenix.otel.register(auto_instrument=True)`
+  # auto-loads every installed `openinference-instrumentation-*` package and a
+  # single version mismatch crashes the whole call, so the upper bounds below
+  # match the framework versions pinned above. Bump these together when bumping
+  # crewai >= 1.10 or dspy >= 2.7.
+  "openinference-instrumentation-openai>=0.1.45",
+  "openinference-instrumentation-litellm>=0.1.30",
+  "openinference-instrumentation-dspy>=0.1.19,<0.1.20",
+  "openinference-instrumentation-crewai>=0.1.22,<1.0.0",
 ]
 all = [
   "p2m-policy[otel,langgraph,analysis,examples,regression]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,12 +61,15 @@ examples = [
   # examples/phoenix_auto_trace/* demos. `phoenix.otel.register(auto_instrument=True)`
   # auto-loads every installed `openinference-instrumentation-*` package and a
   # single version mismatch crashes the whole call, so the upper bounds below
-  # match the framework versions pinned above. Bump these together when bumping
-  # crewai >= 1.10 or dspy >= 2.7.
+  # match the framework versions pinned above. The crewai instrumentor pin is
+  # held at 0.1.17 because every release >=0.1.18 requires `crewai>=1.9.0`,
+  # which would conflict with our `crewai[azure-ai-inference]>=1.6.1` pin and
+  # silently disable crewai instrumentation. Bump these together when bumping
+  # crewai (-> instrumentor 1.x) or dspy (>= 2.7).
   "openinference-instrumentation-openai>=0.1.45",
   "openinference-instrumentation-litellm>=0.1.30",
   "openinference-instrumentation-dspy>=0.1.19,<0.1.20",
-  "openinference-instrumentation-crewai>=0.1.22,<1.0.0",
+  "openinference-instrumentation-crewai>=0.1.17,<0.1.18",
 ]
 all = [
   "p2m-policy[otel,langgraph,analysis,examples,regression]",

--- a/uv.lock
+++ b/uv.lock
@@ -3856,6 +3856,42 @@ wheels = [
 ]
 
 [[package]]
+name = "openinference-instrumentation-crewai"
+version = "0.1.22"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "openinference-instrumentation" },
+    { name = "openinference-semantic-conventions" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/eb/63f10686f0c00b917d15366d9b790171374c4ef3d8ba89eb09b8cc85a3f0/openinference_instrumentation_crewai-0.1.22.tar.gz", hash = "sha256:98fa33500a93fe5c90197b5fef89fab8690711def4296222be592f9c796f1202", size = 13939, upload-time = "2026-03-06T06:00:41.761Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/21/eb602b8c0aa24fefa4958d803954cbe109ea7b420fcfddcfb2e0a352b9fe/openinference_instrumentation_crewai-0.1.22-py3-none-any.whl", hash = "sha256:f895035106d23e659d440351961be3b8848add47fe27ad85c0e796b7675e0b28", size = 15712, upload-time = "2026-03-06T06:00:39.389Z" },
+]
+
+[[package]]
+name = "openinference-instrumentation-dspy"
+version = "0.1.19"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "openinference-instrumentation" },
+    { name = "openinference-semantic-conventions" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/6a/c336e4298b99732f11e184cbc1f8067d9dcc40dd93056e9c756584cb515b/openinference_instrumentation_dspy-0.1.19.tar.gz", hash = "sha256:2d2bcc6a3c664a0c97232933cbfcaf1e580f870324bc0cb77fead4956c935006", size = 19253, upload-time = "2025-03-14T23:54:20.734Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/e5/65d83efaeebe4edd724b4328efa18c40a0c8f63a77e3f73c28780905788f/openinference_instrumentation_dspy-0.1.19-py3-none-any.whl", hash = "sha256:f05b5a2449793d603a83ac690071aa6864c318233b85d1b3f7560c25b3289ab5", size = 13334, upload-time = "2025-03-14T23:54:06.669Z" },
+]
+
+[[package]]
 name = "openinference-instrumentation-langchain"
 version = "0.1.63"
 source = { registry = "https://pypi.org/simple" }
@@ -3870,6 +3906,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/bf/ed/a752b9827f3d49c49580417103c05ee41defe9242a13e50bde06e71146b4/openinference_instrumentation_langchain-0.1.63.tar.gz", hash = "sha256:fcfd010f9c2577cc78c2dbace7000c0855ee24ec0d2891c99f4df51072596def", size = 75540, upload-time = "2026-04-22T00:39:28.473Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/c2/3068ef467e0918d61c74fdfecd30a0cd44384a80d39046c957d5ff8e1611/openinference_instrumentation_langchain-0.1.63-py3-none-any.whl", hash = "sha256:c67f4c3e3a3848dfbb7f1c79fbe83f9501ebb7c6e297f624d719061cfc487162", size = 24746, upload-time = "2026-04-22T00:39:27.431Z" },
+]
+
+[[package]]
+name = "openinference-instrumentation-litellm"
+version = "0.1.30"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "openinference-instrumentation" },
+    { name = "openinference-semantic-conventions" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-sdk" },
+    { name = "setuptools" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/76/09c2c17c9b2d1315b0f106fdae2a11627cbbc82db54cbe28d06d6f0c687d/openinference_instrumentation_litellm-0.1.30.tar.gz", hash = "sha256:ef374d2bdd291ab812cfb03c065e811d8b0587dc0a9e0b050a990cfc158abeb2", size = 88828, upload-time = "2026-03-24T18:23:28.509Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/f0/6579a931a888c37f5a3ef88a9277565c4aea0ed4c67aaea65d2cfe775a6f/openinference_instrumentation_litellm-0.1.30-py3-none-any.whl", hash = "sha256:5f6ed221551e8000b390583cfe00e4463a71fb94d8ab4afac120ac21cdcf0f71", size = 16674, upload-time = "2026-03-24T18:23:26.349Z" },
 ]
 
 [[package]]
@@ -4243,7 +4297,11 @@ all = [
     { name = "numpy" },
     { name = "openai" },
     { name = "openai-agents" },
+    { name = "openinference-instrumentation-crewai" },
+    { name = "openinference-instrumentation-dspy" },
     { name = "openinference-instrumentation-langchain" },
+    { name = "openinference-instrumentation-litellm" },
+    { name = "openinference-instrumentation-openai" },
     { name = "openpyxl" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-sdk" },
@@ -4283,6 +4341,10 @@ examples = [
     { name = "llama-index-core" },
     { name = "llama-index-llms-openai" },
     { name = "openai-agents" },
+    { name = "openinference-instrumentation-crewai" },
+    { name = "openinference-instrumentation-dspy" },
+    { name = "openinference-instrumentation-litellm" },
+    { name = "openinference-instrumentation-openai" },
     { name = "pydantic-ai" },
     { name = "smolagents" },
 ]
@@ -4334,7 +4396,11 @@ requires-dist = [
     { name = "numpy", marker = "extra == 'regression'", specifier = ">=2.0.0" },
     { name = "openai", marker = "extra == 'analysis'", specifier = ">=1.30.0" },
     { name = "openai-agents", marker = "extra == 'examples'", specifier = ">=0.14.5" },
+    { name = "openinference-instrumentation-crewai", marker = "extra == 'examples'", specifier = ">=0.1.22,<1.0.0" },
+    { name = "openinference-instrumentation-dspy", marker = "extra == 'examples'", specifier = ">=0.1.19,<0.1.20" },
     { name = "openinference-instrumentation-langchain", marker = "extra == 'otel'", specifier = ">=0.1.62" },
+    { name = "openinference-instrumentation-litellm", marker = "extra == 'examples'", specifier = ">=0.1.30" },
+    { name = "openinference-instrumentation-openai", marker = "extra == 'examples'", specifier = ">=0.1.45" },
     { name = "openpyxl", marker = "extra == 'analysis'", specifier = ">=3.1.5" },
     { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.39.0" },
     { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.39.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -3857,7 +3857,7 @@ wheels = [
 
 [[package]]
 name = "openinference-instrumentation-crewai"
-version = "0.1.22"
+version = "0.1.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "openinference-instrumentation" },
@@ -3868,9 +3868,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/eb/63f10686f0c00b917d15366d9b790171374c4ef3d8ba89eb09b8cc85a3f0/openinference_instrumentation_crewai-0.1.22.tar.gz", hash = "sha256:98fa33500a93fe5c90197b5fef89fab8690711def4296222be592f9c796f1202", size = 13939, upload-time = "2026-03-06T06:00:41.761Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/7d/a33692382a2a82e963dad548811522a0fce64d497be895db1ce2ad121325/openinference_instrumentation_crewai-0.1.17.tar.gz", hash = "sha256:a978c93ff2a8122f9d35ddc00c58bdb9092f771718b35a96682175947a8e001b", size = 12246, upload-time = "2025-12-04T19:58:41.745Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/21/eb602b8c0aa24fefa4958d803954cbe109ea7b420fcfddcfb2e0a352b9fe/openinference_instrumentation_crewai-0.1.22-py3-none-any.whl", hash = "sha256:f895035106d23e659d440351961be3b8848add47fe27ad85c0e796b7675e0b28", size = 15712, upload-time = "2026-03-06T06:00:39.389Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/e9/8b7e170491a930bd7c680d48bccfb0c611d822f971130694324325b9bc8b/openinference_instrumentation_crewai-0.1.17-py3-none-any.whl", hash = "sha256:072b740dd3e0aa512054426808d80ba8bf8626e75149f0fb1ff35848501dd752", size = 13758, upload-time = "2025-12-04T19:58:38.593Z" },
 ]
 
 [[package]]
@@ -4396,7 +4396,7 @@ requires-dist = [
     { name = "numpy", marker = "extra == 'regression'", specifier = ">=2.0.0" },
     { name = "openai", marker = "extra == 'analysis'", specifier = ">=1.30.0" },
     { name = "openai-agents", marker = "extra == 'examples'", specifier = ">=0.14.5" },
-    { name = "openinference-instrumentation-crewai", marker = "extra == 'examples'", specifier = ">=0.1.22,<1.0.0" },
+    { name = "openinference-instrumentation-crewai", marker = "extra == 'examples'", specifier = ">=0.1.17,<0.1.18" },
     { name = "openinference-instrumentation-dspy", marker = "extra == 'examples'", specifier = ">=0.1.19,<0.1.20" },
     { name = "openinference-instrumentation-langchain", marker = "extra == 'otel'", specifier = ">=0.1.62" },
     { name = "openinference-instrumentation-litellm", marker = "extra == 'examples'", specifier = ">=0.1.30" },


### PR DESCRIPTION
## What

Adds the four framework-specific OpenInference instrumentors used by `examples/phoenix_auto_trace/eval_*.yaml` to the `examples` optional-dependencies group, with version bounds matched to the framework versions already pinned in the same group.

## Why

`phoenix.otel.register(auto_instrument=True)` auto-loads **every** installed `openinference-instrumentation-*` package. A single version-incompatible instrumentor crashes the entire call, breaking unrelated framework demos. Two real failures discovered while smoke-testing `main` post-#21:

| Framework (we ship) | Instrumentor that crashes | Fix |
|---|---|---|
| `dspy 2.6.13` | `openinference-instrumentation-dspy 0.1.34` (expects `LM.acall` not present) | pin `<0.1.20` |
| `crewai 1.6.1` | `openinference-instrumentation-crewai 1.1.4` (requires `crewai>=1.10.1`) | pin `<1.0.0` |

Plus the `openai` and `litellm` instrumentors were not declared at all — customers had to discover them.

## Pins

``toml
"openinference-instrumentation-openai>=0.1.45"
"openinference-instrumentation-litellm>=0.1.30"
"openinference-instrumentation-dspy>=0.1.19,<0.1.20"   # dspy 2.6.x
"openinference-instrumentation-crewai>=0.1.22,<1.0.0"  # crewai 1.6.x
``

A comment in `pyproject.toml` reminds future maintainers to bump these together when bumping crewai >= 1.10 or dspy >= 2.7.

## Verification

**Tier 1 unit tests:** `uv run pytest -q` -> 528 passed, 14 skipped, 0 failed.

**Azure smoke test on `main` @ 9fa3b30** -> 8/8 configs pass, 90 transcripts scored end-to-end through the SvelteKit viewer:

| # | Config | Suite / Run | Seeds | Time | Scores |
|---|---|---|---|---:|---:|
| 1 | travel_planner_langgraph | travel-planner-langgraph-v1 / demo-1 | 5 | 2m 09s | 5/5 |
| 2 | travel_planner_neurosan | travel-planner-neurosan-v1 / custom-otel | 5 | 3m 15s | 5/5 |
| 3 | pipes/health_assistant | health-assistant-v1 / gpt54-eval | 15 | 5m 15s | 15/15 |
| 4 | phoenix_auto_trace/eval_openai | framework-eval-mini / openai | 13 | 4m 05s | 13/13 |
| 5 | phoenix_auto_trace/eval_langchain | framework-eval-mini / langchain | 13 | 4m 20s | 13/13 |
| 6 | phoenix_auto_trace/eval_litellm | framework-eval-mini / litellm | 13 | 192m :warning: | 13/13 |
| 7 | phoenix_auto_trace/eval_dspy | framework-eval-mini / dspy | 13 | 5m 22s | 13/13 |
| 8 | phoenix_auto_trace/eval_crewai | framework-eval-mini / crewai | 13 | 65m :warning: | 13/13 |

Viewer (`npm run dev` in `viewer/`) renders all 4 suites; `framework-eval-mini` correctly groups all 5 framework runs; every run-detail page returns HTTP 200 with ~1.4MB of hydrated transcripts and scores.

### Notes (not addressed in this PR)

- `litellm` and `crewai` outliers above were Azure throttling + `RemoteDisconnected` retries, not code bugs (the rate-limit retry code from #17 worked, just slowly).
- `openinference-instrumentation-crewai 0.1.22` still emits a non-fatal `DependencyConflict: requested 'crewai >= 1.9.0' but found 'crewai 1.6.1'` warning at register time. Harmless but worth bumping crewai in a follow-up.