### PR TITLE
Fix: preserve Phoenix gRPC exporter when adding in-memory span processor

### DIFF
--- a/p2m/core/otel.py
+++ b/p2m/core/otel.py
@@ -509,15 +509,26 @@ class LiveOTelExporter:
         LiveOTelExporter._sdk_exporter = _Collector()
         processor = SimpleSpanProcessor(LiveOTelExporter._sdk_exporter)
 
+        def _add_processor_preserving(provider, proc):
+            # Phoenix's TracerProvider removes its default gRPC exporter
+            # when add_span_processor is called. Passing
+            # replace_default_processor=False preserves it. Standard OTel
+            # SDK providers don't accept this kwarg, so fall back to the
+            # normal call which already appends correctly.
+            try:
+                provider.add_span_processor(proc, replace_default_processor=False)
+            except TypeError:
+                provider.add_span_processor(proc)
+
         # Piggyback on existing provider if one is set (e.g., by Phoenix register())
         existing = otel_trace.get_tracer_provider()
         if isinstance(existing, TracerProvider):
-            existing.add_span_processor(processor)
+            _add_processor_preserving(existing, processor)
         else:
             # Unwrap ProxyTracerProvider if needed
             real = getattr(existing, "_real_provider", None)
             if isinstance(real, TracerProvider):
-                real.add_span_processor(processor)
+                _add_processor_preserving(real, processor)
             else:
                 # No SDK provider exists — create one as fallback
                 provider = TracerProvider()


### PR DESCRIPTION
## Problem

When `LiveOTelExporter.setup()` piggybacks on Phoenix's `TracerProvider`, it calls `add_span_processor()` to attach p2m's in-memory collector. Phoenix's custom `TracerProvider` overrides this method with **replace** semantics — it removes its default gRPC exporter before adding the new processor. This means traces reach p2m's judge (in-memory) but never reach the Phoenix UI.

## Root cause

Phoenix's `TracerProvider.add_span_processor()` has a `replace_default_processor` parameter (default `True`) that removes existing processors. The standard OTel SDK `add_span_processor` appends. Phoenix warns about this:
> `Using a default SpanProcessor. add_span_processor will overwrite this default.`

## Fix

Pass `replace_default_processor=False` when the provider supports it (Phoenix). Fall back to standard `add_span_processor` for providers that don't accept the kwarg (standard OTel SDK), which already appends correctly.

## Testing

- 527 tests pass, no regressions
- Manual verification: emitted test spans reach both Phoenix UI and p2m's in-memory collector simultaneously