### PR TITLE
chore(copilot): ignore local Copilot CLI instruction files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ p2m-experiments/
 # Build artifacts
 *.egg-info/
 p2m_policy.*
+
+# Internal Copilot CLI instructions (per-repo, never committed)
+.github/instructions/preview-boundary.instructions.md


### PR DESCRIPTION
Adds .github/instructions/preview-boundary.instructions.md to .gitignore so per-repo internal Copilot CLI instruction files never reach the public preview history.

The instruction file itself is created locally (and not committed) to provide repo-boundary guidance to Copilot CLI sessions whose cwd is this repo. Copilot CLI auto-loads files matching .github/instructions/**/*.instructions.md.