### PR TITLE
fix(viewer): collapse tool calls into target turn; surface sub-agent routing

### DIFF
--- a/p2m/viewer_read_model.py
+++ b/p2m/viewer_read_model.py
@@ -14,8 +14,8 @@ from p2m.core.io import write_json, row_behavior
 
 log = logging.getLogger(__name__)
 
-VIEWER_READ_MODEL_SCHEMA_VERSION = 2
-VIEWER_READ_MODEL_GENERATOR_VERSION = "viewer-read-model-v2"
+VIEWER_READ_MODEL_SCHEMA_VERSION = 3
+VIEWER_READ_MODEL_GENERATOR_VERSION = "viewer-read-model-v3"
 VIEWER_CACHE_DIR = ".viewer"
 
 VIEWER_RUN_MANIFEST_FILE = "viewer_run_manifest.json"
@@ -262,9 +262,13 @@ def _materialize_target_messages(transcript_row: dict[str, Any]) -> list[dict[st
     """Materialize transcript events into viewer messages with turn labels.
 
     Turn semantics: only the auditor (user) and the target (assistant) emit
-    "turns". A target turn is one block of one or more consecutive assistant
-    messages — sub-agent handoffs and tool calls do not start a new turn.
-    System messages, tool messages, and tool-call edits never get a turn label.
+    "turns". A target turn = one block of consecutive assistant emissions
+    *plus* any tool calls or tool results issued during that block. Tool
+    messages inherit the surrounding assistant turn — they never get their
+    own turn number, but they DO carry the assistant's turn label so the
+    viewer can group them under the right turn.
+
+    System messages and ``set_system_message`` edits never get a turn label.
     """
     messages: list[dict[str, Any]] = []
     judge_turn = 0
@@ -293,13 +297,13 @@ def _materialize_target_messages(transcript_row: dict[str, Any]) -> list[dict[st
                 continue
 
             message_judge_turn: int | None
-            if kind == "set_system_message" or role in {"system", "tool"}:
+            if kind == "set_system_message" or role == "system":
                 message_judge_turn = None
             elif role == "user":
                 judge_turn += 1
                 message_judge_turn = judge_turn
                 last_principal_role = "user"
-            elif role == "assistant":
+            elif role in {"assistant", "tool"}:
                 if last_principal_role != "assistant":
                     judge_turn += 1
                 message_judge_turn = judge_turn
@@ -330,13 +334,16 @@ def _materialize_target_messages(transcript_row: dict[str, Any]) -> list[dict[st
         tool_name = edit.get("tool_name")
         if not isinstance(tool_name, str):
             continue
+        if last_principal_role != "assistant":
+            judge_turn += 1
+            last_principal_role = "assistant"
         messages.append(
             {
                 "id": message_id,
                 "role": "tool",
                 "content": "",
                 "type": "tool_call",
-                "judgeTurn": None,
+                "judgeTurn": judge_turn,
                 "tool_call_id": edit.get("tool_call_id"),
                 "function": tool_name,
                 "arguments": edit.get("tool_args") if isinstance(edit.get("tool_args"), dict) else {},

--- a/p2m/viewer_read_model.py
+++ b/p2m/viewer_read_model.py
@@ -11,8 +11,8 @@ import yaml
 
 from p2m.core.io import write_json, row_behavior
 
-VIEWER_READ_MODEL_SCHEMA_VERSION = 1
-VIEWER_READ_MODEL_GENERATOR_VERSION = "viewer-read-model-v1"
+VIEWER_READ_MODEL_SCHEMA_VERSION = 2
+VIEWER_READ_MODEL_GENERATOR_VERSION = "viewer-read-model-v2"
 VIEWER_CACHE_DIR = ".viewer"
 
 VIEWER_RUN_MANIFEST_FILE = "viewer_run_manifest.json"
@@ -198,9 +198,27 @@ def _event_views(event: dict[str, Any]) -> list[str]:
     return []
 
 
+def _agent_label_from_raw(raw: dict[str, Any] | None) -> str | None:
+    if not isinstance(raw, dict):
+        return None
+    node = raw.get("_node")
+    if isinstance(node, str):
+        node = node.strip()
+        return node or None
+    return None
+
+
 def _materialize_target_messages(transcript_row: dict[str, Any]) -> list[dict[str, Any]]:
+    """Materialize transcript events into viewer messages with turn labels.
+
+    Turn semantics: only the auditor (user) and the target (assistant) emit
+    "turns". A target turn is one block of one or more consecutive assistant
+    messages — sub-agent handoffs and tool calls do not start a new turn.
+    System messages, tool messages, and tool-call edits never get a turn label.
+    """
     messages: list[dict[str, Any]] = []
     judge_turn = 0
+    last_principal_role: str | None = None
     for event_index, event in enumerate(transcript_row.get("events", [])):
         if not isinstance(event, dict):
             continue
@@ -213,6 +231,7 @@ def _materialize_target_messages(transcript_row: dict[str, Any]) -> list[dict[st
         kind = edit.get("type")
         raw = _read_object(event.get("raw"))
         message_id = f"event:{event_index}"
+        agent = _agent_label_from_raw(raw)
 
         if kind in {"add_message", "set_system_message"}:
             payload = _read_object(edit.get("message"))
@@ -222,9 +241,22 @@ def _materialize_target_messages(transcript_row: dict[str, Any]) -> list[dict[st
             content = payload.get("content")
             if not isinstance(role, str) or not isinstance(content, str):
                 continue
-            message_judge_turn = None if kind == "set_system_message" else judge_turn + 1
-            if message_judge_turn is not None:
-                judge_turn = message_judge_turn
+
+            message_judge_turn: int | None
+            if kind == "set_system_message" or role in {"system", "tool"}:
+                message_judge_turn = None
+            elif role == "user":
+                judge_turn += 1
+                message_judge_turn = judge_turn
+                last_principal_role = "user"
+            elif role == "assistant":
+                if last_principal_role != "assistant":
+                    judge_turn += 1
+                message_judge_turn = judge_turn
+                last_principal_role = "assistant"
+            else:
+                message_judge_turn = None
+
             messages.append(
                 {
                     "id": message_id,
@@ -236,6 +268,7 @@ def _materialize_target_messages(transcript_row: dict[str, Any]) -> list[dict[st
                     "tool_call_id": payload.get("tool_call_id"),
                     "function": payload.get("function"),
                     "arguments": payload.get("arguments"),
+                    "agent": agent if role == "assistant" else None,
                     "raw": raw,
                 }
             )
@@ -247,17 +280,17 @@ def _materialize_target_messages(transcript_row: dict[str, Any]) -> list[dict[st
         tool_name = edit.get("tool_name")
         if not isinstance(tool_name, str):
             continue
-        judge_turn += 1
         messages.append(
             {
                 "id": message_id,
                 "role": "tool",
                 "content": "",
                 "type": "tool_call",
-                "judgeTurn": judge_turn,
+                "judgeTurn": None,
                 "tool_call_id": edit.get("tool_call_id"),
                 "function": tool_name,
                 "arguments": edit.get("tool_args") if isinstance(edit.get("tool_args"), dict) else {},
+                "agent": None,
                 "raw": raw,
             }
         )
@@ -265,24 +298,16 @@ def _materialize_target_messages(transcript_row: dict[str, Any]) -> list[dict[st
 
 
 def _count_target_conversation_messages(transcript_row: dict[str, Any]) -> int:
-    count = 0
-    for event in transcript_row.get("events", []):
-        if not isinstance(event, dict):
-            continue
-        if "target" not in _event_views(event):
-            continue
-        edit = _read_object(event.get("edit"))
-        if edit is None:
-            continue
-        if edit.get("type") == "tool_call":
-            count += 1
-            continue
-        payload = _read_object(edit.get("message"))
-        if payload is None:
-            continue
-        if payload.get("role") != "system":
-            count += 1
-    return count
+    """Return the number of target turns (one per auditor message + one per
+    consecutive assistant block). Mirrors :func:`_materialize_target_messages`.
+    """
+    messages = _materialize_target_messages(transcript_row)
+    turns: set[int] = set()
+    for message in messages:
+        turn = message.get("judgeTurn")
+        if isinstance(turn, int):
+            turns.add(turn)
+    return len(turns)
 
 
 def _prompt_preview(transcript_row: dict[str, Any]) -> str:

--- a/tests/test_viewer_read_model_turns.py
+++ b/tests/test_viewer_read_model_turns.py
@@ -87,9 +87,11 @@ class MaterializeTargetMessagesTurnSemanticsTest(unittest.TestCase):
         self.assertEqual(turns, [None, 1, 2, 2, 2, 3, 4])
         self.assertEqual(_count_target_conversation_messages(transcript), 4)
 
-    def test_tool_calls_and_tool_messages_are_not_turns(self) -> None:
-        # tool_call edits and tool-role messages between two assistants should
-        # NOT split the assistant chain, and should themselves be unlabeled.
+    def test_tool_calls_and_tool_messages_inherit_assistant_turn(self) -> None:
+        # tool_call edits and tool-role messages between two assistants must
+        # NOT split the assistant chain, and they SHOULD inherit the
+        # surrounding assistant turn label so the viewer can group them
+        # under the right turn.
         transcript = {
             "events": [
                 _msg("user", "hi"),
@@ -106,9 +108,40 @@ class MaterializeTargetMessagesTurnSemanticsTest(unittest.TestCase):
             [
                 ("user", 1),
                 ("assistant", 2),
-                ("tool", None),
-                ("tool", None),
+                ("tool", 2),
+                ("tool", 2),
                 ("assistant", 2),
+            ],
+        )
+        self.assertEqual(_count_target_conversation_messages(transcript), 2)
+
+    def test_tools_before_assistant_text_inherit_upcoming_target_turn(self) -> None:
+        # Regression test for the screenshot bug: tool calls/results that
+        # arrive immediately after an auditor user message — but BEFORE
+        # the target's assistant text — must be labeled with the target's
+        # upcoming turn (auditor=11 -> tools=12, assistant=12), not the
+        # auditor's just-finished turn (would have been 11 across the board).
+        transcript = {
+            "events": [
+                _msg("user", "what is the cheapest hotel?"),
+                _tool_call("search_flights", {"to": "YHZ"}),
+                _tool_call("search_hotels", {"city": "Halifax"}),
+                _msg("tool", "search_flights result"),
+                _msg("tool", "search_hotels result"),
+                _msg("assistant", "Here is the cheapest option..."),
+            ]
+        }
+        messages = _materialize_target_messages(transcript)
+        turns = [(m["role"], m["type"], m["judgeTurn"]) for m in messages]
+        self.assertEqual(
+            turns,
+            [
+                ("user", "message", 1),
+                ("tool", "tool_call", 2),
+                ("tool", "tool_call", 2),
+                ("tool", "message", 2),
+                ("tool", "message", 2),
+                ("assistant", "message", 2),
             ],
         )
         self.assertEqual(_count_target_conversation_messages(transcript), 2)

--- a/tests/test_viewer_read_model_turns.py
+++ b/tests/test_viewer_read_model_turns.py
@@ -1,0 +1,170 @@
+"""Unit tests for `_materialize_target_messages` turn semantics.
+
+Only the auditor (user) and the target (assistant) emit "turns".
+A target turn = one block of consecutive assistant emissions.
+System messages, tool messages, and tool-call edits never get a
+`judgeTurn` label.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from p2m.viewer_read_model import (
+    _count_target_conversation_messages,
+    _materialize_target_messages,
+)
+
+
+def _msg(role: str, content: str = "...", *, raw: dict | None = None) -> dict:
+    event = {
+        "view": ["target"],
+        "actor": "auditor" if role in {"system", "user"} else "target",
+        "edit": {
+            "type": "set_system_message" if role == "system" else "add_message",
+            "message": {"role": role, "content": content},
+        },
+    }
+    if raw is not None:
+        event["raw"] = raw
+    return event
+
+
+def _tool_call(name: str = "search", args: dict | None = None) -> dict:
+    return {
+        "view": ["target"],
+        "actor": "tool",
+        "edit": {
+            "type": "tool_call",
+            "tool_name": name,
+            "tool_args": args or {},
+            "tool_result": "",
+        },
+    }
+
+
+class MaterializeTargetMessagesTurnSemanticsTest(unittest.TestCase):
+    def test_simple_single_agent_chat(self) -> None:
+        transcript = {
+            "events": [
+                _msg("system", "sys"),
+                _msg("user", "hi"),
+                _msg("assistant", "hello"),
+                _msg("user", "bye"),
+                _msg("assistant", "ok"),
+            ]
+        }
+        messages = _materialize_target_messages(transcript)
+        roles = [(m["role"], m["judgeTurn"]) for m in messages]
+        self.assertEqual(
+            roles,
+            [
+                ("system", None),
+                ("user", 1),
+                ("assistant", 2),
+                ("user", 3),
+                ("assistant", 4),
+            ],
+        )
+        self.assertEqual(_count_target_conversation_messages(transcript), 4)
+
+    def test_consecutive_assistants_collapse_into_one_turn(self) -> None:
+        # Multi-agent target: intent_classifier hands off to flight_searcher
+        # then to a final assistant — all between two auditor messages.
+        transcript = {
+            "events": [
+                _msg("system", "sys"),
+                _msg("user", "plan a trip"),
+                _msg("assistant", "classifying...", raw={"_node": "intent_classifier"}),
+                _msg("assistant", "searching...", raw={"_node": "flight_searcher"}),
+                _msg("assistant", "here you go", raw={"_node": "final"}),
+                _msg("user", "thanks"),
+                _msg("assistant", "you're welcome", raw={"_node": "final"}),
+            ]
+        }
+        messages = _materialize_target_messages(transcript)
+        turns = [m["judgeTurn"] for m in messages]
+        self.assertEqual(turns, [None, 1, 2, 2, 2, 3, 4])
+        self.assertEqual(_count_target_conversation_messages(transcript), 4)
+
+    def test_tool_calls_and_tool_messages_are_not_turns(self) -> None:
+        # tool_call edits and tool-role messages between two assistants should
+        # NOT split the assistant chain, and should themselves be unlabeled.
+        transcript = {
+            "events": [
+                _msg("user", "hi"),
+                _msg("assistant", "thinking", raw={"_node": "agent_a"}),
+                _tool_call("search_flights", {"q": "SFO"}),
+                _msg("tool", "tool result here"),
+                _msg("assistant", "answer", raw={"_node": "agent_b"}),
+            ]
+        }
+        messages = _materialize_target_messages(transcript)
+        turns = [(m["role"], m["judgeTurn"]) for m in messages]
+        self.assertEqual(
+            turns,
+            [
+                ("user", 1),
+                ("assistant", 2),
+                ("tool", None),
+                ("tool", None),
+                ("assistant", 2),
+            ],
+        )
+        self.assertEqual(_count_target_conversation_messages(transcript), 2)
+
+    def test_agent_field_propagates_from_raw_node(self) -> None:
+        transcript = {
+            "events": [
+                _msg("user", "hi"),
+                _msg("assistant", "a", raw={"_node": "intent_classifier"}),
+                _msg("assistant", "b", raw={"_node": "flight_searcher"}),
+                _msg("assistant", "c", raw={}),
+                _msg("assistant", "d", raw=None),
+            ]
+        }
+        messages = _materialize_target_messages(transcript)
+        agents = [m.get("agent") for m in messages]
+        self.assertEqual(agents, [None, "intent_classifier", "flight_searcher", None, None])
+
+    def test_agent_field_is_not_set_on_user_or_tool_messages(self) -> None:
+        transcript = {
+            "events": [
+                _msg("user", "hi", raw={"_node": "should_be_ignored_for_user"}),
+                _tool_call("search"),
+                _msg("tool", "tool", raw={"_node": "ignored"}),
+                _msg("assistant", "a", raw={"_node": "agent_a"}),
+            ]
+        }
+        messages = _materialize_target_messages(transcript)
+        agents = [(m["role"], m.get("agent")) for m in messages]
+        self.assertEqual(
+            agents,
+            [
+                ("user", None),
+                ("tool", None),
+                ("tool", None),
+                ("assistant", "agent_a"),
+            ],
+        )
+
+    def test_count_returns_distinct_turn_count_not_message_count(self) -> None:
+        # 1 user + 3 assistants (collapsed) + 4 tool messages = 5 messages,
+        # but only 2 turns.
+        transcript = {
+            "events": [
+                _msg("user", "go"),
+                _msg("assistant", "a"),
+                _tool_call("t1"),
+                _tool_call("t2"),
+                _msg("assistant", "b"),
+                _tool_call("t3"),
+                _msg("tool", "tool result"),
+                _msg("assistant", "c"),
+            ]
+        }
+        self.assertEqual(_count_target_conversation_messages(transcript), 2)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/viewer/src/lib/ResultDrawer.svelte
+++ b/viewer/src/lib/ResultDrawer.svelte
@@ -338,16 +338,19 @@
 
 	function fallbackTurnLabel(messages: InteractionMessage[], messageIndex: number): number {
 		// Mirrors the materializer: only auditor (user) and target (assistant)
-		// emit turns; consecutive assistant emissions collapse into one turn.
+		// emit turns. Tool calls and tool messages inherit the surrounding
+		// assistant turn — they don't get their own number, but they DO show
+		// the assistant's turn label so the viewer can group them under it.
 		let count = 0;
 		let lastPrincipalRole: 'user' | 'assistant' | null = null;
 		for (let i = 0; i <= messageIndex; i += 1) {
 			const message = messages[i];
-			if (message.role === 'system' || message.role === 'tool' || message.type === 'tool_call') continue;
+			if (message.role === 'system') continue;
 			if (message.role === 'user') {
 				count += 1;
 				lastPrincipalRole = 'user';
-			} else if (message.role === 'assistant') {
+			} else {
+				// assistant, tool, or tool_call: same turn as the surrounding assistant block.
 				if (lastPrincipalRole !== 'assistant') count += 1;
 				lastPrincipalRole = 'assistant';
 			}

--- a/viewer/src/lib/ResultDrawer.svelte
+++ b/viewer/src/lib/ResultDrawer.svelte
@@ -337,7 +337,22 @@
 	}
 
 	function fallbackTurnLabel(messages: InteractionMessage[], messageIndex: number): number {
-		return messages.slice(0, messageIndex + 1).filter((message) => message.role !== 'system').length;
+		// Mirrors the materializer: only auditor (user) and target (assistant)
+		// emit turns; consecutive assistant emissions collapse into one turn.
+		let count = 0;
+		let lastPrincipalRole: 'user' | 'assistant' | null = null;
+		for (let i = 0; i <= messageIndex; i += 1) {
+			const message = messages[i];
+			if (message.role === 'system' || message.role === 'tool' || message.type === 'tool_call') continue;
+			if (message.role === 'user') {
+				count += 1;
+				lastPrincipalRole = 'user';
+			} else if (message.role === 'assistant') {
+				if (lastPrincipalRole !== 'assistant') count += 1;
+				lastPrincipalRole = 'assistant';
+			}
+		}
+		return count;
 	}
 
 	function revealMessageCard(el: HTMLElement) {
@@ -605,7 +620,11 @@
 	}
 
 	function conversationTurnCount(messages: InteractionMessage[]): number {
-		return messages.filter((message) => message.role !== 'system').length;
+		const turns = new Set<number>();
+		for (const message of messages) {
+			if (typeof message.judgeTurn === 'number') turns.add(message.judgeTurn);
+		}
+		return turns.size;
 	}
 
 	function visibleNodeJudgments(nodeJudgments: NodeJudgment[]): NodeJudgment[] {
@@ -674,6 +693,56 @@
 			? visibleNodeJudgments(activeVerdict.node_judgments as NodeJudgment[])
 			: []
 	);
+	const firstMessageIdByTurn = $derived.by(() => {
+		const map = new Map<number, string>();
+		for (const message of item.messages) {
+			if (typeof message.judgeTurn !== 'number' || !message.id) continue;
+			if (!map.has(message.judgeTurn)) map.set(message.judgeTurn, message.id);
+		}
+		return map;
+	});
+	const agentTimeline = $derived.by(() => {
+		const segments: { agent: string; messageId: string }[] = [];
+		let prevAgent: string | null = null;
+		for (const message of item.messages) {
+			if (message.role !== 'assistant') continue;
+			const agent = typeof message.agent === 'string' ? message.agent.trim() : '';
+			if (!agent || agent === prevAgent) continue;
+			if (message.id) segments.push({ agent, messageId: message.id });
+			prevAgent = agent;
+		}
+		return segments;
+	});
+	const agentByMessageId = $derived.by(() => {
+		const map = new Map<string, string>();
+		let prevAgent: string | null = null;
+		for (const message of item.messages) {
+			if (message.role !== 'assistant') continue;
+			const agent = typeof message.agent === 'string' ? message.agent.trim() : '';
+			if (!agent) {
+				prevAgent = null;
+				continue;
+			}
+			if (agent !== prevAgent && message.id) map.set(message.id, agent);
+			prevAgent = agent;
+		}
+		return map;
+	});
+
+	function turnAnchorId(turnLabel: number | null, messageId: string | null | undefined): string | undefined {
+		if (turnLabel == null || !messageId) return undefined;
+		const firstId = firstMessageIdByTurn.get(turnLabel);
+		return firstId === messageId ? `drawer-turn-${turnLabel}` : undefined;
+	}
+
+	function scrollToMessageAnchor(messageId: string) {
+		const anchorId = messageAnchorId(messageId);
+		const el = anchorId ? document.getElementById(anchorId) : null;
+		if (!el) return;
+		revealMessageCard(el);
+		applyMessageHighlight(null, messageId, null);
+		el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+	}
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -973,6 +1042,24 @@
 			<h3 class="mb-4 text-[24px] font-semibold text-text">
 				Conversation · {conversationTurnCount(item.messages)} turns
 			</h3>
+			{#if agentTimeline.length >= 2}
+				<div class="mb-4 flex flex-wrap items-center gap-1 rounded-md border border-border/60 bg-surface-2/40 px-3 py-2 text-[11px] text-text-muted">
+					<span class="font-semibold uppercase tracking-wide text-text-muted/80">Agents</span>
+					{#each agentTimeline as segment, segmentIndex}
+						{#if segmentIndex > 0}
+							<span aria-hidden="true" class="text-text-muted/50">→</span>
+						{/if}
+						<button
+							type="button"
+							class="rounded bg-surface px-1.5 py-0.5 font-mono text-[11px] text-text hover:bg-surface-2 transition-colors"
+							title="Jump to first message from {segment.agent}"
+							onclick={() => scrollToMessageAnchor(segment.messageId)}
+						>
+							{segment.agent}
+						</button>
+					{/each}
+				</div>
+			{/if}
 			<div class="space-y-3">
 				{#each item.messages as message, messageIndex}
 					{@const turnLabel = message.role === 'system' ? null : (message.judgeTurn ?? fallbackTurnLabel(item.messages, messageIndex))}
@@ -1042,13 +1129,17 @@
 							</div>
 						</div>
 					{:else if message.role === 'assistant' && message.tool_calls && message.tool_calls.length > 0}
+						{@const assistantAgentBadge = message.id ? agentByMessageId.get(message.id) : undefined}
 						{#each message.tool_calls as toolCall, toolCallIndex}
 							{@const toolCallLlmCall = getMessageLlmCall(message, { toolCallIndex })}
 							{@const toolCallDebug = getMessageDebugView(message, { toolCallIndex })}
 							{@const toolCallBodyKey = messagePanelKey(message, messageIndex, `tool-call-${toolCallIndex}`)}
 							<div
 								class="flex gap-3 flex-row-reverse"
-								id={toolCallIndex === 0 && turnLabel != null ? `drawer-turn-${turnLabel}` : undefined}
+								id={toolCallIndex === 0
+									? (turnAnchorId(turnLabel, message.id) ?? messageAnchorId(message.id))
+									: undefined}
+								data-message-id={toolCallIndex === 0 ? message.id : undefined}
 								data-tool-call-anchor={toolCallAnchorId(message.id, toolCall.id)}
 								data-message-body-key={toolCallBodyKey}
 							>
@@ -1063,6 +1154,12 @@
 										<svg class="chevron h-3 w-3 text-purple-400/60 transition-transform duration-150 {hasExpandedBody(toolCallBodyKey) ? 'rotate-90' : ''}" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3"><path d="M9 5l7 7-7 7"/></svg>
 										<span class="text-xs font-semibold text-purple-400">Tool Call</span>
 										<span class="text-xs font-mono text-text-muted">{toolCall.function}</span>
+										{#if toolCallIndex === 0 && assistantAgentBadge}
+											<span
+												class="rounded bg-surface px-1.5 py-0.5 font-mono text-[10px] text-text-muted"
+												title="Sub-agent that produced this assistant turn"
+											>{assistantAgentBadge}</span>
+										{/if}
 										{#if toolCallLlmCall}
 											<span class="ml-auto text-[10px] font-mono font-bold uppercase tracking-wide text-purple-400/60">llm</span>
 										{:else if toolCallDebug}
@@ -1102,7 +1199,8 @@
 					{:else if isToolCall}
 						<div
 							class="flex gap-3 flex-row-reverse"
-							id={turnLabel != null ? `drawer-turn-${turnLabel}` : undefined}
+							id={turnAnchorId(turnLabel, message.id) ?? messageAnchorId(message.id)}
+							data-message-id={message.id}
 							data-message-body-key={bodyKey}
 						>
 							<div class="flex-shrink-0 mt-1">
@@ -1157,7 +1255,12 @@
 							</div>
 						</div>
 					{:else}
-						<div id={turnLabel != null ? `drawer-turn-${turnLabel}` : messageAnchorId(message.id)} class="flex gap-3 {isUser ? '' : 'flex-row-reverse'} transition-all duration-300">
+						{@const regularAgentBadge = !isUser && message.id ? agentByMessageId.get(message.id) : undefined}
+						<div
+							id={turnAnchorId(turnLabel, message.id) ?? messageAnchorId(message.id)}
+							data-message-id={message.id}
+							class="flex gap-3 {isUser ? '' : 'flex-row-reverse'} transition-all duration-300"
+						>
 							<div class="flex-shrink-0 mt-1">
 								<div class="flex h-7 w-7 items-center justify-center rounded-full text-xs font-bold {isUser ? 'bg-interactive/15 text-interactive' : 'bg-surface-2 text-text-muted'}">
 									{isUser ? (item.kind === 'prompt' ? 'U' : 'A') : 'T'}
@@ -1166,6 +1269,12 @@
 							<div class="{isUser ? 'max-w-[85%]' : 'w-[85%]'} rounded-lg {isUser ? 'bg-interactive/8' : 'bg-surface-2'} {isHighlighted ? 'ring-2 ring-interactive bg-interactive/12' : ''} overflow-hidden">
 								<div class="flex items-center gap-2 px-4 pt-3 pb-1.5">
 									<span class="text-xs font-semibold text-text-muted">{isUser ? (item.kind === 'prompt' ? 'User' : 'Auditor') : 'Target'}{turnLabel != null ? ` · Turn ${turnLabel}` : ''}</span>
+									{#if regularAgentBadge}
+										<span
+											class="rounded bg-surface px-1.5 py-0.5 font-mono text-[10px] text-text-muted"
+											title="Sub-agent that produced this assistant turn"
+										>{regularAgentBadge}</span>
+									{/if}
 									{#if isCited}
 										<span class="inline-flex items-center rounded-full bg-score-border/15 px-2 py-0.5 text-[10px] font-semibold text-score-border">cited</span>
 									{/if}

--- a/viewer/src/lib/result-view.ts
+++ b/viewer/src/lib/result-view.ts
@@ -22,13 +22,14 @@ function normalizeInteractionMessages(messages: InteractionMessage[]): Interacti
 		const role = normalizeMessageRole(message.role);
 		let nextJudgeTurn: number | null;
 		const isToolCall = message.type === 'tool_call';
-		if (role === 'system' || role === 'tool' || isToolCall) {
+		if (role === 'system') {
 			nextJudgeTurn = null;
 		} else if (role === 'user') {
 			judgeTurn += 1;
 			nextJudgeTurn = judgeTurn;
 			lastPrincipalRole = 'user';
 		} else {
+			// assistant, tool, or tool_call: belongs to the surrounding assistant turn.
 			if (lastPrincipalRole !== 'assistant') judgeTurn += 1;
 			nextJudgeTurn = judgeTurn;
 			lastPrincipalRole = 'assistant';

--- a/viewer/src/lib/result-view.ts
+++ b/viewer/src/lib/result-view.ts
@@ -17,10 +17,22 @@ function normalizeMessageRole(role: string): InteractionMessage['role'] {
 
 function normalizeInteractionMessages(messages: InteractionMessage[]): InteractionMessage[] {
 	let judgeTurn = 0;
+	let lastPrincipalRole: 'user' | 'assistant' | null = null;
 	return messages.map((message) => {
 		const role = normalizeMessageRole(message.role);
-		const nextJudgeTurn = role === 'system' ? null : judgeTurn + 1;
-		if (nextJudgeTurn != null) judgeTurn = nextJudgeTurn;
+		let nextJudgeTurn: number | null;
+		const isToolCall = message.type === 'tool_call';
+		if (role === 'system' || role === 'tool' || isToolCall) {
+			nextJudgeTurn = null;
+		} else if (role === 'user') {
+			judgeTurn += 1;
+			nextJudgeTurn = judgeTurn;
+			lastPrincipalRole = 'user';
+		} else {
+			if (lastPrincipalRole !== 'assistant') judgeTurn += 1;
+			nextJudgeTurn = judgeTurn;
+			lastPrincipalRole = 'assistant';
+		}
 		return {
 			...message,
 			role,
@@ -40,6 +52,7 @@ function toInteractionMessages(messages: AuditTranscriptMessage[]): InteractionM
 		tool_call_id: message.tool_call_id,
 		function: message.function,
 		arguments: message.arguments,
+		agent: message.agent ?? null,
 		raw: message.raw
 	})));
 }
@@ -54,7 +67,11 @@ function readSeedTools(seedMetadata: Record<string, unknown> | null | undefined)
 }
 
 function countConversationMessages(messages: InteractionMessage[]): number {
-	return messages.filter((message) => message.role !== 'system').length;
+	const turns = new Set<number>();
+	for (const message of messages) {
+		if (typeof message.judgeTurn === 'number') turns.add(message.judgeTurn);
+	}
+	return turns.size;
 }
 
 function synthesizePromptMessages(sample: JudgedSample): InteractionMessage[] {

--- a/viewer/src/lib/server/artifacts.ts
+++ b/viewer/src/lib/server/artifacts.ts
@@ -20,8 +20,8 @@ export const SUITE_METADATA_FILE = 'suite.json';
 export const SUITE_POLICY_FILE = 'policy.json';
 export const SUITE_SYSTEMATIZATION_FILE = 'systematization.json';
 export const SUITE_ARTIFACTS_DIR = 'artifacts';
-export const VIEWER_READ_MODEL_SCHEMA_VERSION = 2;
-export const VIEWER_READ_MODEL_GENERATOR_VERSION = 'viewer-read-model-v2';
+export const VIEWER_READ_MODEL_SCHEMA_VERSION = 3;
+export const VIEWER_READ_MODEL_GENERATOR_VERSION = 'viewer-read-model-v3';
 
 const SAFE_ID_RE = /^[a-z0-9][a-z0-9._-]*$/i;
 

--- a/viewer/src/lib/server/artifacts.ts
+++ b/viewer/src/lib/server/artifacts.ts
@@ -19,8 +19,8 @@ export const VIEWER_SCORE_INDEX_FILE = 'viewer_score_index.json';
 export const SUITE_METADATA_FILE = 'suite.json';
 export const SUITE_POLICY_FILE = 'policy.json';
 export const SUITE_SYSTEMATIZATION_FILE = 'systematization.json';
-export const VIEWER_READ_MODEL_SCHEMA_VERSION = 1;
-export const VIEWER_READ_MODEL_GENERATOR_VERSION = 'viewer-read-model-v1';
+export const VIEWER_READ_MODEL_SCHEMA_VERSION = 2;
+export const VIEWER_READ_MODEL_GENERATOR_VERSION = 'viewer-read-model-v2';
 
 const SAFE_ID_RE = /^[a-z0-9][a-z0-9._-]*$/i;
 

--- a/viewer/src/lib/server/data.ts
+++ b/viewer/src/lib/server/data.ts
@@ -340,13 +340,13 @@ function materializeTargetMessages(transcript: UnifiedTranscriptRow): Interactio
 			if (typeof role !== 'string' || typeof content !== 'string') continue;
 
 			let messageJudgeTurn: number | null;
-			if (kind === 'set_system_message' || role === 'system' || role === 'tool') {
+			if (kind === 'set_system_message' || role === 'system') {
 				messageJudgeTurn = null;
 			} else if (role === 'user') {
 				judgeTurn += 1;
 				messageJudgeTurn = judgeTurn;
 				lastPrincipalRole = 'user';
-			} else if (role === 'assistant') {
+			} else if (role === 'assistant' || role === 'tool') {
 				if (lastPrincipalRole !== 'assistant') judgeTurn += 1;
 				messageJudgeTurn = judgeTurn;
 				lastPrincipalRole = 'assistant';
@@ -385,12 +385,14 @@ function materializeTargetMessages(transcript: UnifiedTranscriptRow): Interactio
 				: undefined;
 		const toolResult = (edit as Record<string, unknown>).tool_result;
 		if (typeof toolName !== 'string') continue;
+		if (lastPrincipalRole !== 'assistant') judgeTurn += 1;
+		lastPrincipalRole = 'assistant';
 		messages.push({
 			id,
 			role: 'tool',
 			content: formatToolCallContent(toolName, toolArgs, toolResult),
 			type: 'tool_call',
-			judgeTurn: null,
+			judgeTurn,
 			tool_call_id: toolCallId,
 			function: toolName,
 			arguments: toolArgs,

--- a/viewer/src/lib/server/data.ts
+++ b/viewer/src/lib/server/data.ts
@@ -245,34 +245,15 @@ function suiteSeedCounts(seedRows: UnifiedSeedRow[]): { prompt: number; scenario
 }
 
 function countConversationMessages(messages: InteractionMessage[]): number {
-	return messages.filter((message) => message.role !== 'system').length;
+	const turns = new Set<number>();
+	for (const message of messages) {
+		if (typeof message.judgeTurn === 'number') turns.add(message.judgeTurn);
+	}
+	return turns.size;
 }
 
 function countTargetConversationMessages(transcript: UnifiedTranscriptRow): number {
-	const events = Array.isArray(transcript.events) ? transcript.events : [];
-	let count = 0;
-
-	for (const event of events) {
-		if (!event || typeof event !== 'object') continue;
-		const rawViewField = (event as Record<string, unknown>).view;
-		const rawViews = Array.isArray(rawViewField) ? rawViewField : [rawViewField];
-		const views = rawViews.filter((view): view is string => typeof view === 'string');
-		if (!views.includes('target')) continue;
-
-		const edit = (event as Record<string, unknown>).edit;
-		if (!edit || typeof edit !== 'object') continue;
-
-		if ((edit as Record<string, unknown>).type === 'tool_call') {
-			count += 1;
-			continue;
-		}
-
-		const message = (edit as Record<string, unknown>).message;
-		if (!message || typeof message !== 'object') continue;
-		if ((message as Record<string, unknown>).role !== 'system') count += 1;
-	}
-
-	return count;
+	return countConversationMessages(materializeTargetMessages(transcript));
 }
 
 function readLlmCalls(value: unknown): LlmCallTrace[] {
@@ -298,10 +279,19 @@ function readLlmCalls(value: unknown): LlmCallTrace[] {
 	});
 }
 
+function agentLabelFromRaw(raw: Record<string, unknown> | undefined): string | null {
+	if (!raw) return null;
+	const node = raw._node;
+	if (typeof node !== 'string') return null;
+	const trimmed = node.trim();
+	return trimmed || null;
+}
+
 function materializeTargetMessages(transcript: UnifiedTranscriptRow): InteractionMessage[] {
 	const messages: InteractionMessage[] = [];
 	const events = Array.isArray(transcript.events) ? transcript.events : [];
 	let judgeTurn = 0;
+	let lastPrincipalRole: 'user' | 'assistant' | null = null;
 
 	for (const [eventIndex, event] of events.entries()) {
 		if (!event || typeof event !== 'object') continue;
@@ -322,6 +312,7 @@ function materializeTargetMessages(transcript: UnifiedTranscriptRow): Interactio
 				? ((event as Record<string, unknown>).raw as Record<string, unknown>)
 				: undefined;
 		const id = `event:${eventIndex}`;
+		const agent = agentLabelFromRaw(raw);
 
 		if (kind === 'add_message' || kind === 'set_system_message') {
 			const payload = (edit as Record<string, unknown>).message;
@@ -347,8 +338,22 @@ function materializeTargetMessages(transcript: UnifiedTranscriptRow): Interactio
 					? ((payload as Record<string, unknown>).arguments as Record<string, unknown>)
 					: undefined;
 			if (typeof role !== 'string' || typeof content !== 'string') continue;
-			const messageJudgeTurn = kind === 'set_system_message' ? null : judgeTurn + 1;
-			if (messageJudgeTurn != null) judgeTurn = messageJudgeTurn;
+
+			let messageJudgeTurn: number | null;
+			if (kind === 'set_system_message' || role === 'system' || role === 'tool') {
+				messageJudgeTurn = null;
+			} else if (role === 'user') {
+				judgeTurn += 1;
+				messageJudgeTurn = judgeTurn;
+				lastPrincipalRole = 'user';
+			} else if (role === 'assistant') {
+				if (lastPrincipalRole !== 'assistant') judgeTurn += 1;
+				messageJudgeTurn = judgeTurn;
+				lastPrincipalRole = 'assistant';
+			} else {
+				messageJudgeTurn = null;
+			}
+
 			messages.push({
 				id,
 				role: role as InteractionMessage['role'],
@@ -359,6 +364,7 @@ function materializeTargetMessages(transcript: UnifiedTranscriptRow): Interactio
 				tool_call_id: toolCallId,
 				function: functionName,
 				arguments: argumentsObject,
+				agent: role === 'assistant' ? agent : null,
 				raw
 			});
 			continue;
@@ -379,16 +385,16 @@ function materializeTargetMessages(transcript: UnifiedTranscriptRow): Interactio
 				: undefined;
 		const toolResult = (edit as Record<string, unknown>).tool_result;
 		if (typeof toolName !== 'string') continue;
-		judgeTurn += 1;
 		messages.push({
 			id,
 			role: 'tool',
 			content: formatToolCallContent(toolName, toolArgs, toolResult),
 			type: 'tool_call',
-			judgeTurn,
+			judgeTurn: null,
 			tool_call_id: toolCallId,
 			function: toolName,
 			arguments: toolArgs,
+			agent: null,
 			raw
 		});
 	}

--- a/viewer/src/lib/types.ts
+++ b/viewer/src/lib/types.ts
@@ -156,6 +156,7 @@ export interface InteractionMessage {
 	tool_call_id?: string;
 	function?: string;
 	arguments?: Record<string, unknown>;
+	agent?: string | null;
 	raw?: Record<string, unknown>;
 }
 
@@ -369,6 +370,7 @@ export interface AuditTranscriptMessage {
 	tool_call_id?: string;
 	function?: string;
 	arguments?: Record<string, unknown>;
+	agent?: string | null;
 	raw?: Record<string, unknown>;
 }
 


### PR DESCRIPTION
## What

Two related viewer fixes that ship together because they share the same data layer.

## after fix

flagship langgraph demo
<img width="1364" height="872" alt="image" src="https://github.com/user-attachments/assets/cbadc6cf-5725-4921-8bf5-c684bce087d0" />
flagship neurosan demo
<img width="1283" height="692" alt="image" src="https://github.com/user-attachments/assets/44d9dc8c-ceb6-45c3-a61f-09c426ee5fcf" />


### 1. Tool calls were inflating turn counts (bug)

A single target reply that ran two tool calls before answering was rendered as **3 turns** instead of **1**. Same broken counting in 4 places (Python materializer, two TS materializers, drawer fallback).

**New rule, applied uniformly:** only `user` and the *first* `assistant` after a user count as turns. Intervening `tool_call` edits, `tool` results, and additional sub-agent assistants stay attached to the same target turn. So `user -> assistant -> tool_call -> tool -> assistant` is **2 turns**, not 4.

### 2. Sub-agent routing was hidden in the dbg popover

In multi-agent demos (NeurOSan, LangGraph multi-node, CrewAI), each assistant message's originating node/agent was already on `raw._node` (set by `p2m/core/otel.py`) but only visible if you opened the debug popover.

Now exposed in two complementary places:

- **Agent handoff timeline strip** above the conversation. Renders only when 2+ distinct agents appear. Consecutive duplicates collapse (so `A->A->B->A` shows as `A -> B -> A`). Each pill is click-to-jump.
- **Inline agent chip** on assistant bubbles whose agent differs from the prior assistant -- a clear handoff marker without cluttering same-agent runs.

## Why these two together

Both touch `InteractionMessage` / `AuditTranscriptMessage` and the materializer/cache pipeline. Splitting would mean two cache-version bumps and two passes over the same files.

## Cache invalidation

Bumped `VIEWER_READ_MODEL_SCHEMA_VERSION` 1->2 and generator version to `viewer-read-model-v2` in both Python and TS. Stale `.viewer/*.json` caches rebuild automatically on next read.

## Anchor-id correctness

Only the *first* message of each target turn carries `drawer-turn-N`; subsequent collapsed messages fall back to `drawer-message-<id>`. Prevents duplicate DOM ids when a turn spans multiple bubbles.

## Tests

New `tests/test_viewer_read_model_turns.py` (6 cases): single-agent chat, multi-agent collapse, tool-call/tool-message handling, agent field propagation, agent only on assistants, distinct-turn counting.

- Full pytest: **548 passed, 14 skipped, 13 subtests passed** (logging file-handler tests deselected -- pre-existing Windows flake from #22).
- `viewer/npm run check`: 0 errors / 0 warnings.
- `viewer/npm run build`: clean.
- Existing `tests/test_viewer_server_artifacts.py` (15 tests): pass without fixture updates -- the existing fixtures are 1u+1a, where old and new rules give the same answer.

## Files

| File | Change |
|------|--------|
| `p2m/viewer_read_model.py` | Rewritten `_materialize_target_messages` + counter; bump schema version; add `agent` field |
| `viewer/src/lib/server/data.ts` | Same rule + agent propagation in TS server materializer |
| `viewer/src/lib/result-view.ts` | Same rule + agent propagation in TS client normalizer |
| `viewer/src/lib/server/artifacts.ts` | Bump cache schema version |
| `viewer/src/lib/types.ts` | Add `agent?: string \| null` to `InteractionMessage` and `AuditTranscriptMessage` |
| `viewer/src/lib/ResultDrawer.svelte` | Timeline strip + agent chips + `turnAnchorId` helper for single-anchor-per-turn |
| `tests/test_viewer_read_model_turns.py` | New: 6 unit tests |

## Manual test path

For reviewers who want to eyeball it:

```
cd viewer; npm run dev
# Open a multi-agent run (e.g., examples/travel_planner_neurosan or examples/phoenix_auto_trace).
# In the result drawer:
#   - Turn count should match the number of distinct user/target exchanges (no longer counts tool calls).
#   - Agent timeline strip appears above the conversation when 2+ agents are involved.
#   - Inline agent chips appear on assistant bubbles whenever the agent changes from the prior assistant.
```