### PR TITLE
fix(seeds): enforce minItems in structured-output schema to prevent short-count failures

### DIFF
--- a/p2m/stages/seeds.py
+++ b/p2m/stages/seeds.py
@@ -159,6 +159,7 @@ SEED_SCHEMA_WITH_TOOLS: dict[str, Any] = {
 def seeds_response_schema(
     tool_source: str = TOOL_SOURCE_RUNTIME,
     min_items: int | None = None,
+    max_items: int | None = None,
 ) -> dict[str, Any]:
     """Full response schema wrapping seeds in a ``{"seeds": [...]}`` envelope.
 
@@ -166,11 +167,17 @@ def seeds_response_schema(
     least that many seeds. Without this lower bound, gpt-5.4-mini frequently
     returns N-1 items for batches larger than ~10, since the schema previously
     allowed 0-2000 items regardless of the prompt's stated count.
+
+    When ``max_items`` is provided, it overrides the default 2000 ceiling so
+    callers can pin both bounds to the exact target count. Pinning both bounds
+    keeps the schema symmetric with the prompt's stated count and prevents the
+    model from over-generating in the (unlikely) inverse failure mode.
     """
     item_schema = SEED_SCHEMA_WITH_TOOLS if tool_source == TOOL_SOURCE_PER_SEED else SEED_SCHEMA
+    resolved_max = max_items if (max_items is not None and max_items > 0) else 2000
     seeds_schema: dict[str, Any] = {
         "type": "array",
-        "maxItems": 2000,
+        "maxItems": resolved_max,
         "items": item_schema,
     }
     if min_items is not None and min_items > 0:
@@ -663,7 +670,9 @@ async def _generate_records(
         )
         slug = slugify(str(job.behavior.get("name") or ""))
         behavior_name = str(job.behavior.get("name") or "")
-        job_schema = seeds_response_schema(tool_source, min_items=job.count)
+        job_schema = seeds_response_schema(
+            tool_source, min_items=job.count, max_items=job.count
+        )
 
         response = await generate_structured(
             model,

--- a/p2m/stages/seeds.py
+++ b/p2m/stages/seeds.py
@@ -156,14 +156,30 @@ SEED_SCHEMA_WITH_TOOLS: dict[str, Any] = {
 }
 
 
-def seeds_response_schema(tool_source: str = TOOL_SOURCE_RUNTIME) -> dict[str, Any]:
-    """Full response schema wrapping seeds in a ``{"seeds": [...]}`` envelope."""
+def seeds_response_schema(
+    tool_source: str = TOOL_SOURCE_RUNTIME,
+    min_items: int | None = None,
+) -> dict[str, Any]:
+    """Full response schema wrapping seeds in a ``{"seeds": [...]}`` envelope.
+
+    When ``min_items`` is provided, the schema requires the model to return at
+    least that many seeds. Without this lower bound, gpt-5.4-mini frequently
+    returns N-1 items for batches larger than ~10, since the schema previously
+    allowed 0-2000 items regardless of the prompt's stated count.
+    """
     item_schema = SEED_SCHEMA_WITH_TOOLS if tool_source == TOOL_SOURCE_PER_SEED else SEED_SCHEMA
+    seeds_schema: dict[str, Any] = {
+        "type": "array",
+        "maxItems": 2000,
+        "items": item_schema,
+    }
+    if min_items is not None and min_items > 0:
+        seeds_schema["minItems"] = min_items
     return {
         "type": "object",
         "additionalProperties": False,
         "properties": {
-            "seeds": {"type": "array", "maxItems": 2000, "items": item_schema},
+            "seeds": seeds_schema,
         },
         "required": ["seeds"],
     }
@@ -623,7 +639,6 @@ async def _generate_records(
         raise ValueError("seed generation concurrency must be > 0")
 
     design_data = design or {}
-    schema = seeds_response_schema(tool_source)
     seed_id_prefix = SEED_ID_PREFIX[kind]
     concept_name = policy.get("concept", {}).get("name", "concept")
 
@@ -648,12 +663,13 @@ async def _generate_records(
         )
         slug = slugify(str(job.behavior.get("name") or ""))
         behavior_name = str(job.behavior.get("name") or "")
+        job_schema = seeds_response_schema(tool_source, min_items=job.count)
 
         response = await generate_structured(
             model,
             prompt,
             schema_name=f"{kind}_seeds",
-            json_schema=schema,
+            json_schema=job_schema,
             options=GenerateOptions(
                 temperature=temperature, max_tokens=max_tokens,
                 reasoning_effort=reasoning_effort, timeout_s=timeout_s,

--- a/tests/test_seed_sampling_characterization.py
+++ b/tests/test_seed_sampling_characterization.py
@@ -132,6 +132,20 @@ class SeedsResponseSchemaTest(unittest.TestCase):
         schema = seeds_response_schema()
         self.assertEqual(schema["properties"]["seeds"]["items"], SEED_SCHEMA)
 
+    def test_schema_omits_min_items_by_default(self) -> None:
+        schema = seeds_response_schema()
+        self.assertNotIn("minItems", schema["properties"]["seeds"])
+
+    def test_schema_pins_min_items_when_count_supplied(self) -> None:
+        schema = seeds_response_schema(min_items=27)
+        self.assertEqual(schema["properties"]["seeds"]["minItems"], 27)
+        self.assertEqual(schema["properties"]["seeds"]["maxItems"], 2000)
+
+    def test_schema_ignores_non_positive_min_items(self) -> None:
+        for value in (0, -1):
+            schema = seeds_response_schema(min_items=value)
+            self.assertNotIn("minItems", schema["properties"]["seeds"])
+
 
 class LabelEntrySchemaTest(unittest.TestCase):
     def test_schema_enumerates_present_factors_only(self) -> None:

--- a/tests/test_seed_sampling_characterization.py
+++ b/tests/test_seed_sampling_characterization.py
@@ -135,6 +135,7 @@ class SeedsResponseSchemaTest(unittest.TestCase):
     def test_schema_omits_min_items_by_default(self) -> None:
         schema = seeds_response_schema()
         self.assertNotIn("minItems", schema["properties"]["seeds"])
+        self.assertEqual(schema["properties"]["seeds"]["maxItems"], 2000)
 
     def test_schema_pins_min_items_when_count_supplied(self) -> None:
         schema = seeds_response_schema(min_items=27)
@@ -145,6 +146,16 @@ class SeedsResponseSchemaTest(unittest.TestCase):
         for value in (0, -1):
             schema = seeds_response_schema(min_items=value)
             self.assertNotIn("minItems", schema["properties"]["seeds"])
+
+    def test_schema_pins_both_bounds_when_min_and_max_match(self) -> None:
+        schema = seeds_response_schema(min_items=500, max_items=500)
+        self.assertEqual(schema["properties"]["seeds"]["minItems"], 500)
+        self.assertEqual(schema["properties"]["seeds"]["maxItems"], 500)
+
+    def test_schema_ignores_non_positive_max_items(self) -> None:
+        for value in (0, -1):
+            schema = seeds_response_schema(max_items=value)
+            self.assertEqual(schema["properties"]["seeds"]["maxItems"], 2000)
 
 
 class LabelEntrySchemaTest(unittest.TestCase):


### PR DESCRIPTION
## Problem

The seeds stage aborts when the model returns fewer items than requested per-cell batch, even by one. With larger `sample_size` values, this is statistically inevitable and the pipeline cannot proceed past seeds.

**Repro** (clean main, fresh artifacts dir):

```yaml
# eval config based on examples.travel_planner_langgraph
seeds:
  prompt:
    model: { name: azure/gpt-5.4-mini, temperature: 0.7 }
    sample_size: 500  # 18-cell design grid → ~27-28 seeds per cell
```

Three consecutive runs failed at the same stage with the same shape:

```
ValueError: prompt generation returned 26 seeds for a batch of 27
ValueError: prompt generation returned 22 seeds for a batch of 23
ValueError: prompt generation returned 25 seeds for a batch of 26
```

Bumping `max_tokens` 5× (3000 → 16000) did not help, confirming this is not output truncation. The model was simply emitting one fewer item than the prompt asked for.

## Root cause

`seeds_response_schema()` was generating a schema with no `minItems` constraint on the seeds array:

```python
"seeds": {"type": "array", "maxItems": 2000, "items": item_schema}
```

The prompt asked for N seeds in natural language, but the schema told the model "0 to 2000 is fine." When the structured-output layer enforced the schema, returning N-1 was a valid response. `gpt-5.4-mini` did this consistently at batch sizes above ~10-15 per cell.

The strict equality check at `seeds.py:668` then aborted the entire stage on the first short response:

```python
if len(returned_seeds) < job.count:
    raise ValueError(...)
```

## Fix

Thread `min_items` through `seeds_response_schema()` and pin it to `job.count` per call. The schema now enforces the count the prompt asked for, eliminating the under-generation at the structured-output layer instead of catching it after the fact.

This mirrors the existing pattern in `_labels_response_schema()`, which already pins both `minItems` and `maxItems` to count - so the precedent in this codebase is to use schema-level enforcement for exact-count structured outputs.

## Validation

- **Repro: confirmed broken on main.** Three runs of `sample_size=500` on `examples.travel_planner_langgraph` failed at seeds with the short-count error.
- **Repro: confirmed fixed on this branch.** Same config now generates the full 502 test cases (500 prompts + 2 scenarios) and the pipeline proceeds to rollout. Run is still in progress at the time of this PR; will paste final perf numbers in a follow-up comment.
- **Unit tests:** 4 new tests in `SeedsResponseSchemaTest` covering default behavior, `min_items` enforcement, and zero/negative-value handling. Full seed-related suite (105 tests) passes.

## Why the strict check stays

I considered loosening the worker-layer check to accept-and-warn instead of raising on short count. Decided against it because:

1. The schema fix removes the failure mode at its source rather than papering over it downstream.
2. The strict check is still useful as a safety net - if the model violates the now-enforced `minItems` constraint somehow, we want to know rather than silently produce undersized batches.
3. Other stages (notably `_labels_response_schema`) already use the same pin-via-schema pattern, so this keeps the codebase consistent.

If there's appetite for a separate retry-on-short-count or accept-and-warn fallback at the worker layer, happy to do that in a follow-up.
