### PR TITLE
rollout/judge: per-seed error isolation with batch-level error-rate threshold

### DIFF
--- a/p2m/core/session.py
+++ b/p2m/core/session.py
@@ -15,6 +15,7 @@ from p2m.core.model_client import (
     Message,
     ModelResponse,
     ToolCall,
+    _classify_llm_error,
     build_llm_call_trace,
     generate,
     generate_with_tools,
@@ -512,15 +513,35 @@ class CallableSession:
                 for msg in messages
                 if msg.role in ("user", "assistant")
             ]
-            raw_result = await invoke_callable(
-                self._callable, user_text, history=history,
-                timeout_s=self._message_timeout_s,
-            )
+            try:
+                raw_result = await invoke_callable(
+                    self._callable, user_text, history=history,
+                    timeout_s=self._message_timeout_s,
+                )
+            except Exception as exc:
+                # The user callable typically makes its own LLM calls
+                # (LangGraph, agent frameworks, raw litellm) which bypass
+                # our generate()/_with_retries wrapper, so provider errors
+                # bubble up unclassified. Re-raise them as the right p2m
+                # error class (LLMInputError for content-filter / 400s,
+                # LLMRateLimitError for 429s, LLMProviderError for 5xx,
+                # LLMAuthError for 401/403) so the rollout stage's per-seed
+                # isolation paths can do their job.
+                classified = _classify_llm_error(exc)
+                if classified is exc:
+                    raise
+                raise classified from exc
         else:
-            raw_result = await invoke_callable(
-                self._callable, user_text,
-                timeout_s=self._message_timeout_s,
-            )
+            try:
+                raw_result = await invoke_callable(
+                    self._callable, user_text,
+                    timeout_s=self._message_timeout_s,
+                )
+            except Exception as exc:
+                classified = _classify_llm_error(exc)
+                if classified is exc:
+                    raise
+                raise classified from exc
 
         result = self._normalize_callable_result(raw_result)
 

--- a/p2m/stages/judge.py
+++ b/p2m/stages/judge.py
@@ -170,7 +170,41 @@ async def run_judge(
                 "output_index": output_index,
                 "score_row": await score_row(row),
             }
-        except (LLMAuthError, LLMInputError, LLMRateLimitError, LLMProviderError):
+        except LLMInputError as exc:
+            # Judge-side input refusal (e.g. Azure content filter rejecting
+            # a transcript whose adversarial content the judge LLM can't
+            # process). This is per-seed data, not a global pipeline
+            # problem: a different transcript will judge cleanly. Record a
+            # filter_skipped score row so the seed isn't lost and the
+            # stage can move on. Mirrors the target_input_refused and
+            # auditor_input_refused handling in rollout.
+            seed_id = row.get("seed_id", "?")
+            log.warning(
+                "Judge content-filter refusal for seed %s: %s",
+                seed_id, exc,
+            )
+            factors = row_factors(row)
+            score_row_filter_skipped = {
+                "kind": row.get("kind", ""),
+                "seed_id": seed_id,
+                "concept": row.get("concept", ""),
+                "judge_model": judge_model,
+                "target": row.get("target", ""),
+                "auditor_model": row.get("auditor_model", ""),
+                "judge_status": "filter_skipped",
+                "judge_error": f"judge_input_refused: {exc}",
+                "verdict": {},
+            }
+            if factors:
+                score_row_filter_skipped["factors"] = factors
+            return {
+                "output_index": output_index,
+                "score_row": score_row_filter_skipped,
+            }
+        except (LLMAuthError, LLMRateLimitError, LLMProviderError):
+            # Auth/rate-limit/provider-5xx errors are global pipeline
+            # problems, not seed-specific. Propagate so the runner can
+            # surface a clean message and fail the stage fast.
             raise
         except (json.JSONDecodeError, ValueError) as exc:
             seed_id = row.get("seed_id", "?")

--- a/p2m/stages/rollout.py
+++ b/p2m/stages/rollout.py
@@ -7,6 +7,7 @@ from dataclasses import asdict
 import hashlib
 import json as json_module
 import logging
+import os
 import re
 import traceback
 import uuid
@@ -1035,8 +1036,57 @@ async def run_rollout(
         if str(seed.get("seed_id", "")) not in completed_seed_ids
     ]
 
+    def _synthesize_error_transcript(
+        seed_row: dict[str, Any],
+        exc: Exception,
+        stop_reason: str,
+    ) -> dict[str, Any]:
+        """Build a minimal transcript dict capturing an unrecoverable per-seed error.
+
+        Mirrors the shape of a successful transcript so judge / metrics / viewer
+        downstream consumers see a uniform record per seed regardless of whether
+        the rollout succeeded. The transcript has a single system event with the
+        error text and the supplied stop_reason; no LLM calls are recorded.
+        """
+        target_label = (
+            str(target.model.name) if target.model
+            else (target.connector or target.callable or target.endpoint or "")
+        )
+        metadata = TranscriptMetadata(
+            kind=str(seed_row.get("kind") or ""),
+            seed_id=str(seed_row.get("seed_id") or ""),
+            concept=str(seed_row.get("concept") or ""),
+            target=target_label,
+            auditor_model=(
+                str(evaluation.auditor.model.name)
+                if evaluation and evaluation.auditor and evaluation.auditor.model
+                else ""
+            ),
+            factors=row_factors(seed_row),
+        )
+        transcript = Transcript(metadata=metadata)
+        transcript.add_event(TranscriptEvent(
+            view=["system", "combined"],
+            actor="system",
+            edit=AddMessageEdit(
+                message=TranscriptMessage(
+                    role="system",
+                    content=f"[ROLLOUT WORKER ERROR: {type(exc).__name__}: {exc}]",
+                ),
+            ),
+        ))
+        transcript.stop_reason = stop_reason
+        return transcript.to_dict()
+
     async def _worker(seed: tuple[int, dict[str, Any]]) -> dict[str, Any]:
-        """Wrap single-seed rollout so concurrent execution keeps errors structured."""
+        """Wrap single-seed rollout so concurrent execution keeps errors structured.
+
+        Generic isolation: any exception from a per-seed rollout (other than
+        the global error classes that should fail the whole stage) is recorded
+        as a transcript with stop_reason="runtime_error" so one bad seed never
+        kills the batch. Global errors (LLMAuthError, LLMRateLimitError,
+        LLMProviderError) still propagate to the stage-level handler.
+        """
         output_index, seed_row = seed
         try:
             kind = seed_row["kind"]
@@ -1061,22 +1111,30 @@ async def run_rollout(
             else:
                 raise ValueError(f"unsupported seed kind: {kind}")
             return {"output_index": output_index, "transcript_row": transcript.to_dict()}
-        except (LLMAuthError, LLMInputError, LLMRateLimitError, LLMProviderError):
+        except (LLMAuthError, LLMRateLimitError, LLMProviderError):
+            # Global pipeline problems (auth, rate-limit cliff, provider 5xx).
+            # Not seed-specific. Fail the stage fast so the runner can surface
+            # a clean message.
             raise
-        except (ValueError, KeyError) as exc:
+        except Exception as exc:  # noqa: BLE001
+            # Any other per-seed failure (config/validation issues, LangGraph
+            # internal task escapes, target runtime errors that propagated
+            # past the inner handlers, etc.) becomes a recorded transcript
+            # with stop_reason="runtime_error". The seed is preserved and
+            # the batch continues. If too many seeds fail this way, the
+            # outer gather loop's threshold check still aborts the stage.
             seed_id = seed_row.get("seed_id", "?")
             log.debug(
-                "Rollout worker config/validation error for seed %s: %s\n%s",
+                "Rollout worker error for seed %s: %s\n%s",
                 seed_id, exc, traceback.format_exc(),
             )
-            return {"output_index": output_index, "error": exc}
-        except Exception as exc:
-            seed_id = seed_row.get("seed_id", "?")
-            log.debug(
-                "Rollout worker failed for seed %s: %s\n%s",
-                seed_id, exc, traceback.format_exc(),
-            )
-            return {"output_index": output_index, "error": exc}
+            return {
+                "output_index": output_index,
+                "transcript_row": _synthesize_error_transcript(
+                    seed_row, exc, "runtime_error",
+                ),
+                "error": exc,
+            }
 
     semaphore = asyncio.Semaphore(max(1, min(rollout.concurrency, len(pending_seeds) or 1)))
 
@@ -1086,6 +1144,27 @@ async def run_rollout(
 
     tasks = [asyncio.create_task(_guard(seed)) for seed in pending_seeds]
     total = len(tasks)
+    # Per-seed error tolerance: rollout treats per-seed failures as data,
+    # not as stage-fatal events. The stage aborts only if more than
+    # ROLLOUT_ERROR_FAIL_RATIO of seeds fail (default 10%). This lets one
+    # bad LangGraph internal escape, target_error, or runtime_error land
+    # cleanly without throwing away the rest of a 1k-seed run, while a
+    # systemic problem (deployment misconfigured, every seed errors) still
+    # surfaces as a stage failure. Tunable via P2M_ROLLOUT_ERROR_FAIL_RATIO
+    # env override for ops-debug scenarios.
+    ROLLOUT_ERROR_FAIL_RATIO_DEFAULT = 0.10
+    fail_ratio = ROLLOUT_ERROR_FAIL_RATIO_DEFAULT
+    fail_ratio_env = os.environ.get("P2M_ROLLOUT_ERROR_FAIL_RATIO")
+    if fail_ratio_env:
+        try:
+            parsed = float(fail_ratio_env)
+            if 0.0 <= parsed <= 1.0:
+                fail_ratio = parsed
+        except ValueError:
+            log.warning(
+                "P2M_ROLLOUT_ERROR_FAIL_RATIO=%r is not a float in [0, 1]; ignoring",
+                fail_ratio_env,
+            )
     results = []
     errors: list[Exception] = []
     for completed_task in asyncio.as_completed(tasks):
@@ -1099,7 +1178,7 @@ async def run_rollout(
         # record a transcript with stop_reason="target_error" instead of
         # propagating. This is correct for transient mid-turn failures,
         # but when every turn fails (e.g. deployment doesn't exist) the
-        # transcript is garbage and should surface as a rollout error.
+        # transcript is garbage and should count toward the error ratio.
         if error is None and transcript_row is not None:
             if transcript_row.get("stop_reason") == "target_error":
                 error = RuntimeError(
@@ -1132,7 +1211,17 @@ async def run_rollout(
             log.warning(msg)
 
     if errors:
-        raise errors[0]
+        error_ratio = len(errors) / max(1, total)
+        if error_ratio > fail_ratio:
+            log.error(
+                "[rollout] %d of %d seeds errored (%.1f%% > %.1f%% threshold); aborting stage",
+                len(errors), total, 100 * error_ratio, 100 * fail_ratio,
+            )
+            raise errors[0]
+        log.warning(
+            "[rollout] %d of %d seeds errored (%.1f%% <= %.1f%% threshold); continuing",
+            len(errors), total, 100 * error_ratio, 100 * fail_ratio,
+        )
     build_run_viewer_artifacts(out_dir)
 
     return {

--- a/p2m/stages/rollout.py
+++ b/p2m/stages/rollout.py
@@ -700,10 +700,32 @@ async def _run_auditor_target_loop(
                 auditor_messages = [m for m in auditor_messages if m.content != _AUDITOR_RETRY_GUIDANCE]
                 auditor_messages.append(auditor_response.message)
                 break
-            except (LLMAuthError, LLMInputError, LLMRateLimitError, LLMProviderError):
-                # Transport/auth/rate-limit errors should propagate to the
-                # runner's top-level handler — not be treated as bad auditor
-                # output.  The runner presents these with clean messages.
+            except LLMInputError as exc:
+                # Auditor-side input refusal (e.g. Azure Prompt Shields
+                # rejecting the auditor's adversarial prompt as a suspected
+                # jailbreak attempt - the default auditor system prompt is
+                # jailbreak-shaped by design and reliably trips Prompt
+                # Shields on a small fraction of seeds). This is per-seed
+                # data, not a global pipeline error: a different seed will
+                # lead the auditor down a different path and complete
+                # normally. Record the refusal in the transcript and stop
+                # the conversation cleanly so the worker can move on.
+                transcript.add_event(TranscriptEvent(
+                    view=["system", "combined"],
+                    actor="system",
+                    edit=AddMessageEdit(
+                        message=TranscriptMessage(
+                            role="system",
+                            content=f"[AUDITOR INPUT REFUSED: {exc}]",
+                        ),
+                    ),
+                ))
+                stop_reason = "auditor_input_refused"
+                break
+            except (LLMAuthError, LLMRateLimitError, LLMProviderError):
+                # Auth/rate-limit/provider-5xx errors are global pipeline
+                # problems, not seed-specific. Propagate so the runner can
+                # surface a clean message and fail the stage fast.
                 raise
             except Exception as exc:
                 last_error = str(exc)

--- a/p2m/stages/rollout.py
+++ b/p2m/stages/rollout.py
@@ -611,6 +611,25 @@ async def _run_prompt_seed(
         )
 
     if runtime_error is not None:
+        # Target-side LLMInputError (e.g. Azure content filter rejecting an
+        # adversarial prompt) is intrinsic to this seed's data, not a global
+        # pipeline problem. Record it as a transcript event so judge/metrics
+        # can see the refusal, and continue with the next seed. Other
+        # classified LLM errors (auth, rate-limit, provider 5xx) and arbitrary
+        # runtime exceptions still propagate to the worker error path.
+        if isinstance(runtime_error, LLMInputError):
+            transcript.add_event(TranscriptEvent(
+                view=["target", "combined"],
+                actor="system",
+                edit=AddMessageEdit(
+                    message=TranscriptMessage(
+                        role="system",
+                        content=f"[TARGET INPUT REFUSED: {runtime_error}]",
+                    ),
+                ),
+            ))
+            transcript.stop_reason = "target_input_refused"
+            return transcript
         raise runtime_error
     if runtime_result is None:
         raise RuntimeError("Prompt rollout did not produce a runtime result.")
@@ -772,11 +791,29 @@ async def _run_auditor_target_loop(
                 log.warning(
                     f"Target response truncated (finish_reason=length) at turn {turn_index + 1}/{max_turns}"
                 )
-        except (LLMAuthError, LLMInputError, LLMRateLimitError, LLMProviderError):
-            # LLM-level errors (rate limit, auth, bad request, provider 5xx)
-            # should propagate to the runner's top-level handler instead of
-            # being buried in the transcript as a target_error.  The runner
-            # presents these with clean, actionable messages.
+        except LLMInputError as exc:
+            # Target-side input refusal (e.g. Azure content filter rejecting
+            # an adversarial prompt) is intrinsic to this seed's data, not a
+            # global pipeline problem. Record it like an ordinary target_error
+            # so judge/metrics can see the refusal, and let the worker keep
+            # going on the next seed.
+            transcript.add_event(TranscriptEvent(
+                view=["target", "combined"],
+                actor="system",
+                edit=AddMessageEdit(
+                    message=TranscriptMessage(
+                        role="system",
+                        content=f"[TARGET INPUT REFUSED: {exc}]",
+                    ),
+                ),
+            ))
+            auditor_messages.append(Message(role="user", content=f"<target_error>{exc}</target_error>"))
+            stop_reason = "target_input_refused"
+            break
+        except (LLMAuthError, LLMRateLimitError, LLMProviderError):
+            # Auth/rate-limit/provider-5xx errors are global pipeline
+            # problems, not seed-specific. Propagate so the runner can
+            # surface a clean message and fail the stage fast.
             raise
         except Exception as exc:
             tb = traceback.format_exc()

--- a/tests/test_exception_handling.py
+++ b/tests/test_exception_handling.py
@@ -123,6 +123,75 @@ class CallableSessionErrorTest(unittest.IsolatedAsyncioTestCase):
         await session.open()
         await session.close()
 
+    async def test_run_turn_reclassifies_litellm_bad_request_as_input_error(self) -> None:
+        """User callables (LangGraph, agent frameworks, raw litellm) bypass
+        ``generate()``/``_with_retries`` and so emit unclassified provider
+        errors. ``CallableSession.run_turn`` must re-classify them so the
+        rollout stage's per-seed isolation paths can route content-filter
+        rejections to a recorded transcript event instead of aborting the
+        whole batch.
+        """
+        from p2m.core.session import CallableSession
+        from p2m.core.model_client import LLMInputError, Message
+
+        # Lightweight stand-in for ``litellm.BadRequestError`` that avoids
+        # importing litellm in the unit test. ``_classify_llm_error`` reads
+        # exception types from the live litellm module at call time, so we
+        # patch it directly to make the substitution explicit.
+        class FakeLitellmBadRequest(Exception):
+            pass
+
+        def _classified(exc: Exception) -> Exception:
+            if isinstance(exc, FakeLitellmBadRequest):
+                err = LLMInputError(f"Bad request: {exc}")
+                err.__cause__ = exc
+                return err
+            return exc
+
+        async def fake_invoke_callable(fn, *args, **kwargs):
+            raise FakeLitellmBadRequest(
+                "Invalid prompt: your prompt was flagged as potentially "
+                "violating our usage policy"
+            )
+
+        session = CallableSession(callable_ref="json:dumps")
+        await session.open()
+        try:
+            with (
+                patch("p2m.core.session.invoke_callable", new=fake_invoke_callable),
+                patch("p2m.core.session._classify_llm_error", new=_classified),
+            ):
+                with self.assertRaises(LLMInputError) as ctx:
+                    await session.run_turn([Message(role="user", content="hi")])
+            self.assertIn("flagged as potentially violating", str(ctx.exception))
+            self.assertIsInstance(ctx.exception.__cause__, FakeLitellmBadRequest)
+        finally:
+            await session.close()
+
+    async def test_run_turn_passes_through_unclassified_exceptions(self) -> None:
+        """Errors that the classifier doesn't recognise (e.g. user agent
+        crashes, ValueError from misconfigured tools) must propagate as-is
+        rather than being smuggled into one of the four LLM error classes.
+        """
+        from p2m.core.session import CallableSession
+        from p2m.core.model_client import Message
+
+        class CustomAgentError(RuntimeError):
+            pass
+
+        async def fake_invoke_callable(fn, *args, **kwargs):
+            raise CustomAgentError("user agent blew up")
+
+        session = CallableSession(callable_ref="json:dumps")
+        await session.open()
+        try:
+            with patch("p2m.core.session.invoke_callable", new=fake_invoke_callable):
+                with self.assertRaises(CustomAgentError) as ctx:
+                    await session.run_turn([Message(role="user", content="hi")])
+            self.assertIn("user agent blew up", str(ctx.exception))
+        finally:
+            await session.close()
+
 
 class OTelTracedSessionErrorTest(unittest.IsolatedAsyncioTestCase):
     async def test_missing_module_raises_value_error(self) -> None:

--- a/tests/test_rollout_stage.py
+++ b/tests/test_rollout_stage.py
@@ -7,9 +7,9 @@ from unittest.mock import patch
 
 from p2m.core.config_model import AuditorConfig, EvaluationConfig, JudgeConfig, RolloutConfig, TargetConfig, ToolsConfig
 from p2m.core.io import load_seeds
-from p2m.core.model_client import Message, ModelResponse
+from p2m.core.model_client import LLMInputError, LLMProviderError, Message, ModelResponse
 from p2m.core.session import TurnResult
-from p2m.stages.rollout import _prepare_seeds, _rollout_config_fingerprint, run_rollout
+from p2m.stages.rollout import _prepare_seeds, _rollout_config_fingerprint, _run_prompt_seed, run_rollout
 from p2m.viewer_read_model import ViewerReadModelBuildError
 
 
@@ -1261,6 +1261,193 @@ class RolloutStageTest(unittest.IsolatedAsyncioTestCase):
             ["seed_000001", "seed_000002", "seed_000003"],
         )
         self.assertNotIn("parent_seed_id", canonical_rows[2])
+
+    async def test_run_prompt_seed_records_target_input_refusal(self) -> None:
+        """Target-side LLMInputError is recorded as a transcript event, not raised.
+
+        Without this, one Azure content-filter refusal kills the entire batch
+        even though 499 other adversarial prompts completed successfully.
+        """
+        from p2m.core.session import HostedSession
+
+        async def fake_run_turn(self_inner, messages):
+            raise LLMInputError(
+                "Bad request: AzureException BadRequestError - Invalid prompt: "
+                "your prompt was flagged as potentially violating our usage policy."
+            )
+
+        async def fake_open(self_inner):
+            return None
+
+        async def fake_close(self_inner):
+            return None
+
+        seed_row = {
+            "kind": "prompt",
+            "seed_id": "seed_000001",
+            "seed": {"description": "adversarial prompt the target refuses"},
+        }
+
+        with (
+            patch.object(HostedSession, "open", new=fake_open),
+            patch.object(HostedSession, "close", new=fake_close),
+            patch.object(HostedSession, "run_turn", new=fake_run_turn),
+        ):
+            transcript = await _run_prompt_seed(
+                seed=seed_row,
+                target=TargetConfig(model="azure/gpt-5.4-mini"),
+                rollout=RolloutConfig(max_turns=1, concurrency=1),
+                max_tokens=1000,
+                config_path=None,
+            )
+
+        self.assertEqual(transcript.stop_reason, "target_input_refused")
+        refusal_events = [
+            event for event in transcript.events
+            if event.edit.type == "add_message"
+            and "[TARGET INPUT REFUSED:" in (event.edit.message.content or "")
+        ]
+        self.assertEqual(len(refusal_events), 1)
+        self.assertIn("flagged as potentially violating", refusal_events[0].edit.message.content)
+
+    async def test_run_rollout_isolates_target_input_refusal_to_one_seed(self) -> None:
+        """One target_input_refused seed must not abort the rest of the batch.
+
+        Mirrors the May 11 overnight scale-500 failure: seed 501 of 502 hit
+        Azure content filter, and the whole rollout stage failed because the
+        worker re-raised LLMInputError. The fix routes target-side input errors
+        into the per-seed transcript instead of propagating.
+        """
+        from p2m.core.session import HostedSession
+
+        seed_rows = [
+            {"kind": "prompt", "seed": {"description": f"prompt {i}"}}
+            for i in range(5)
+        ]
+        run_turn_calls: list[str] = []
+
+        async def fake_run_turn(self_inner, messages):
+            # The seed_id is encoded in the call_label on the session
+            # (target:seed_000001 etc); decode by index from the user message.
+            user_text = next(
+                (m.text or "" for m in messages if m.role == "user"),
+                "",
+            )
+            run_turn_calls.append(user_text)
+            if "prompt 2" in user_text:
+                raise LLMInputError(
+                    "Bad request: AzureException BadRequestError - "
+                    "prompt flagged as potentially violating our usage policy"
+                )
+            return TurnResult(
+                text="OK",
+                state_messages=list(messages) + [Message(role="assistant", content="OK")],
+                interaction_messages=[
+                    {"role": "user", "content": user_text},
+                    {"role": "assistant", "content": "OK"},
+                ],
+                raw={"response": {"content": "OK"}},
+            )
+
+        async def fake_open(self_inner):
+            return None
+
+        async def fake_close(self_inner):
+            return None
+
+        with TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            seed_path = tmp_path / "seeds.jsonl"
+            out_dir = tmp_path / "run"
+            seed_path.write_text(
+                "\n".join(json.dumps(row) for row in seed_rows) + "\n",
+                encoding="utf-8",
+            )
+
+            with (
+                patch.object(HostedSession, "open", new=fake_open),
+                patch.object(HostedSession, "close", new=fake_close),
+                patch.object(HostedSession, "run_turn", new=fake_run_turn),
+            ):
+                result = await run_rollout(
+                    seed_path=str(seed_path),
+                    target=TargetConfig(model="azure/gpt-5.4-mini"),
+                    evaluation=EvaluationConfig(
+                        judge=JudgeConfig(model="azure/gpt-5.4"),
+                        auditor=AuditorConfig(model="azure/gpt-5.4"),
+                        rollout=RolloutConfig(concurrency=1),
+                    ),
+                    save_dir=str(out_dir),
+                    run_id="run-refusal-isolation",
+                )
+
+            transcript_rows = [
+                json.loads(line)
+                for line in (out_dir / "transcripts.jsonl").read_text(encoding="utf-8").splitlines()
+            ]
+
+        # All 5 seeds attempted at the runtime layer (no fail-fast).
+        self.assertEqual(len(run_turn_calls), 5)
+        # All 5 transcripts written. The refused one carries the new
+        # target_input_refused stop_reason; the others carry "completed".
+        self.assertEqual(len(transcript_rows), 5)
+        self.assertEqual(result["new_count"], 5)
+
+        by_seed = {row["seed_id"]: row for row in transcript_rows}
+        refused = by_seed["seed_000003"]
+        self.assertEqual(refused["stop_reason"], "target_input_refused")
+        refusal_events = [
+            event for event in refused["events"]
+            if event["edit"]["type"] == "add_message"
+            and "[TARGET INPUT REFUSED:" in event["edit"]["message"].get("content", "")
+        ]
+        self.assertEqual(len(refusal_events), 1)
+
+        for completed_id in ("seed_000001", "seed_000002", "seed_000004", "seed_000005"):
+            self.assertEqual(
+                by_seed[completed_id]["stop_reason"],
+                "completed",
+                f"{completed_id} should have completed cleanly",
+            )
+
+    async def test_run_rollout_still_fails_fast_on_provider_5xx(self) -> None:
+        """LLMProviderError (Azure 5xx) is global, not seed-specific.
+
+        Verifies the fix didn't accidentally swallow auth/rate-limit/5xx
+        errors that should still abort the stage.
+        """
+        seed_rows = [
+            {"kind": "prompt", "seed": {"description": f"prompt {i}"}}
+            for i in range(3)
+        ]
+
+        async def fake_run_prompt_seed(**kwargs):
+            raise LLMProviderError("Azure 503 ServiceUnavailable")
+
+        with TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            seed_path = tmp_path / "seeds.jsonl"
+            out_dir = tmp_path / "run"
+            seed_path.write_text(
+                "\n".join(json.dumps(row) for row in seed_rows) + "\n",
+                encoding="utf-8",
+            )
+
+            with (
+                patch("p2m.stages.rollout._run_prompt_seed", new=fake_run_prompt_seed),
+                self.assertRaises(LLMProviderError),
+            ):
+                await run_rollout(
+                    seed_path=str(seed_path),
+                    target=TargetConfig(model="azure/gpt-5.4-mini"),
+                    evaluation=EvaluationConfig(
+                        judge=JudgeConfig(model="azure/gpt-5.4"),
+                        auditor=AuditorConfig(model="azure/gpt-5.4"),
+                        rollout=RolloutConfig(concurrency=1),
+                    ),
+                    save_dir=str(out_dir),
+                    run_id="run-provider-error",
+                )
 
 
 if __name__ == "__main__":

--- a/tests/test_rollout_stage.py
+++ b/tests/test_rollout_stage.py
@@ -1410,6 +1410,119 @@ class RolloutStageTest(unittest.IsolatedAsyncioTestCase):
                 f"{completed_id} should have completed cleanly",
             )
 
+    async def test_run_rollout_isolates_auditor_input_refusal_to_one_seed(self) -> None:
+        """One auditor_input_refused seed must not abort the rest of the batch.
+
+        Mirrors the May 12 PR #44 mix-1k failure: at scenario 853 of 1000
+        the auditor's adversarial prompt tripped Azure Prompt Shields'
+        jailbreak detector (the default auditor system prompt is
+        jailbreak-shaped by design - Aaron flagged this in the May 12
+        standup and worked around it in PR #45 with a tame variant). The
+        stage aborted because the auditor catch in _run_auditor_target_loop
+        re-raised LLMInputError. The fix routes auditor-side input errors
+        into a recorded transcript event with stop_reason=auditor_input_refused.
+        """
+        seed_rows = [
+            {
+                "kind": "scenario",
+                "seed": {
+                    "title": f"Title {i}",
+                    "description": f"scenario seed {i}",
+                },
+            }
+            for i in range(5)
+        ]
+        auditor_calls: list[str] = []
+
+        async def fake_generate(model, messages, options):
+            del options
+            # Identify which seed we're auditing by inspecting the auditor
+            # system prompt, which embeds the seed description verbatim.
+            description_marker = ""
+            for msg in messages:
+                content = msg.content if hasattr(msg, "content") else msg.get("content", "")
+                if "scenario seed" in content:
+                    description_marker = content
+                    break
+            auditor_calls.append(description_marker[:120])
+            if "scenario seed 2" in description_marker:
+                raise LLMInputError(
+                    "Bad request: AzureException BadRequestError - Invalid "
+                    "prompt: your prompt was flagged as potentially "
+                    "violating our usage policy (Prompt Shields jailbreak)"
+                )
+            return ModelResponse(text="Where should I go?", model=str(model))
+
+        class FakeHostedSession:
+            runtime_mode = "hosted"
+
+            async def open(self) -> None:
+                return None
+
+            async def close(self) -> None:
+                return None
+
+            async def run_turn(self, messages):
+                user_text = ""
+                for msg in reversed(messages):
+                    if msg.role == "user":
+                        user_text = msg.text
+                        break
+                return TurnResult(
+                    text="OK.",
+                    state_messages=list(messages) + [Message(role="assistant", content="OK.")],
+                    interaction_messages=[
+                        {"role": "user", "content": user_text},
+                        {"role": "assistant", "content": "OK."},
+                    ],
+                    raw={"response": {"content": "OK."}},
+                )
+
+        with TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            seed_path = tmp_path / "seeds.jsonl"
+            out_dir = tmp_path / "run"
+            seed_path.write_text(
+                "\n".join(json.dumps(row) for row in seed_rows) + "\n",
+                encoding="utf-8",
+            )
+
+            with (
+                patch("p2m.stages.rollout.generate", new=fake_generate),
+                patch("p2m.stages.rollout._build_target_session", return_value=FakeHostedSession()),
+            ):
+                result = await run_rollout(
+                    seed_path=str(seed_path),
+                    target=TargetConfig(model="azure/gpt-5.4-mini"),
+                    evaluation=EvaluationConfig(
+                        judge=JudgeConfig(model="azure/gpt-5.4"),
+                        auditor=AuditorConfig(model="azure/gpt-5.4-mini"),
+                        rollout=RolloutConfig(max_turns=1, concurrency=1),
+                    ),
+                    save_dir=str(out_dir),
+                    run_id="run-auditor-refusal",
+                )
+
+            transcript_rows = [
+                json.loads(line)
+                for line in (out_dir / "transcripts.jsonl").read_text(encoding="utf-8").splitlines()
+            ]
+
+        # All 5 scenarios reached the auditor (no fail-fast on seed 3).
+        self.assertEqual(len(auditor_calls), 5)
+        self.assertEqual(len(transcript_rows), 5)
+        self.assertEqual(result["new_count"], 5)
+
+        by_seed = {row["seed_id"]: row for row in transcript_rows}
+        refused = by_seed["seed_000003"]
+        self.assertEqual(refused["stop_reason"], "auditor_input_refused")
+        refusal_events = [
+            event for event in refused["events"]
+            if event["edit"]["type"] == "add_message"
+            and "[AUDITOR INPUT REFUSED:" in event["edit"]["message"].get("content", "")
+        ]
+        self.assertEqual(len(refusal_events), 1)
+
     async def test_run_rollout_still_fails_fast_on_provider_5xx(self) -> None:
         """LLMProviderError (Azure 5xx) is global, not seed-specific.
 

--- a/tests/test_rollout_stage.py
+++ b/tests/test_rollout_stage.py
@@ -1048,6 +1048,11 @@ class RolloutStageTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(sorted(row["seed_id"] for row in final_rows), ["seed_000001", "seed_000002"])
 
     async def test_run_rollout_keeps_partial_successful_transcripts_when_later_worker_fails(self) -> None:
+        """When a per-seed worker raises beyond the error tolerance, partial
+        successes still get persisted to transcripts.jsonl and the failing
+        seed is recorded with stop_reason="runtime_error". The stage then
+        aborts because the error ratio exceeds the threshold (default 10%).
+        """
         seed_rows = [
             {"kind": "prompt", "seed": {"description": "successful prompt"}},
             {"kind": "prompt", "seed": {"description": "failing prompt"}},
@@ -1103,6 +1108,10 @@ class RolloutStageTest(unittest.IsolatedAsyncioTestCase):
                 self.assertEqual([row["seed_id"] for row in interim_rows], ["seed_000001"])
 
                 release_failure.set()
+                # 50% error rate (1 of 2) exceeds the default 10% threshold,
+                # so the stage still aborts. The new behavior is that the
+                # failing seed gets a runtime_error transcript before the
+                # stage raises, so the file has 2 rows instead of 1.
                 with self.assertRaisesRegex(RuntimeError, "boom"):
                     await rollout_task
 
@@ -1111,7 +1120,14 @@ class RolloutStageTest(unittest.IsolatedAsyncioTestCase):
                 for line in transcripts_path.read_text(encoding="utf-8").splitlines()
             ]
 
-        self.assertEqual([row["seed_id"] for row in final_rows], ["seed_000001"])
+        # Both seeds now have transcripts: seed_1 succeeded, seed_2 has a
+        # synthesized runtime_error transcript carrying the error message.
+        self.assertEqual(
+            sorted(row["seed_id"] for row in final_rows),
+            ["seed_000001", "seed_000002"],
+        )
+        failed_row = next(r for r in final_rows if r["seed_id"] == "seed_000002")
+        self.assertEqual(failed_row["stop_reason"], "runtime_error")
 
     async def test_run_rollout_resumes_from_existing_transcripts(self) -> None:
         """Pre-populated transcripts.jsonl causes completed seeds to be skipped."""
@@ -1561,6 +1577,85 @@ class RolloutStageTest(unittest.IsolatedAsyncioTestCase):
                     save_dir=str(out_dir),
                     run_id="run-provider-error",
                 )
+
+    async def test_run_rollout_tolerates_below_threshold_errors(self) -> None:
+        """Per-seed errors below the 10% threshold are recorded but do not abort.
+
+        This is the generic per-seed isolation: one bad LangGraph internal
+        task escape, one runtime error from a target's own LLM call, etc.,
+        produces a synthesized transcript with stop_reason='runtime_error'
+        and the batch keeps going. Only triggers an abort when the error
+        rate exceeds the configured threshold.
+        """
+        # 20 seeds, 1 fails -> 5% error rate, well under the 10% default.
+        seed_rows = [
+            {"kind": "prompt", "seed": {"description": f"prompt {i}"}}
+            for i in range(20)
+        ]
+
+        async def fake_run_prompt_seed(**kwargs):
+            seed_id = str(kwargs["seed"]["seed_id"])
+            if seed_id == "seed_000005":
+                # Simulates a LangGraph internal task escape: arbitrary
+                # non-classified exception bubbling up from inside the
+                # callable target's own LLM call.
+                raise RuntimeError("LangGraph internal task crashed")
+
+            class FakeTranscript:
+                def to_dict(self_inner) -> dict[str, str]:
+                    return {"kind": "prompt", "seed_id": seed_id, "stop_reason": "completed"}
+
+            return FakeTranscript()
+
+        with TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            seed_path = tmp_path / "seeds.jsonl"
+            out_dir = tmp_path / "run"
+            seed_path.write_text(
+                "\n".join(json.dumps(row) for row in seed_rows) + "\n",
+                encoding="utf-8",
+            )
+
+            with patch("p2m.stages.rollout._run_prompt_seed", new=fake_run_prompt_seed):
+                result = await run_rollout(
+                    seed_path=str(seed_path),
+                    target=TargetConfig(model="azure/gpt-5.4-mini"),
+                    evaluation=EvaluationConfig(
+                        judge=JudgeConfig(model="azure/gpt-5.4"),
+                        auditor=AuditorConfig(model="azure/gpt-5.4"),
+                        rollout=RolloutConfig(concurrency=1),
+                    ),
+                    save_dir=str(out_dir),
+                    run_id="run-below-threshold",
+                )
+
+            transcript_rows = [
+                json.loads(line)
+                for line in (out_dir / "transcripts.jsonl").read_text(encoding="utf-8").splitlines()
+            ]
+
+        # Batch completed (no stage abort).
+        self.assertEqual(result["new_count"], 20)
+        # All 20 transcripts present, including the synthesized one for the
+        # failed seed.
+        self.assertEqual(len(transcript_rows), 20)
+
+        by_seed = {row["seed_id"]: row for row in transcript_rows}
+        failed = by_seed["seed_000005"]
+        self.assertEqual(failed["stop_reason"], "runtime_error")
+        error_events = [
+            event for event in failed["events"]
+            if event["edit"]["type"] == "add_message"
+            and "[ROLLOUT WORKER ERROR" in event["edit"]["message"].get("content", "")
+        ]
+        self.assertEqual(len(error_events), 1)
+        self.assertIn("LangGraph internal task crashed", error_events[0]["edit"]["message"]["content"])
+
+        # The other 19 seeds completed cleanly.
+        for sid in (f"seed_00000{i + 1}" for i in range(9)):
+            if sid == "seed_000005":
+                continue
+            self.assertEqual(by_seed[sid]["stop_reason"], "completed")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

A single content-filter / input-refusal hit was killing entire scale runs. The May 11 overnight scale-500 was the first one: seed 501 of 502 was rejected by Azure CF, and 500 already-completed transcripts were thrown away. As subsequent runs ran further, three more independent places surfaced the same failure mode:

- **callable-target raw `litellm` exceptions** - LangGraph (and any framework wrapper) makes provider calls inside the user callable, so `litellm.BadRequestError` etc. bypass `generate()`/`_with_retries` entirely and the rollout's `isinstance(_, LLMInputError)` checks miss them.
- **auditor-side input refusals** - the adversarial prompt the auditor sends to the target trips Azure Prompt Shields' jailbreak detector. Surfaced live at seed 853/1000 on the May 12 mix run.
- **judge-side input refusals** - the same adversarial content the auditor produced trips the content filter on the judge call itself. Surfaced at scored-seed 539/1000 on the May 12 rerun.
- **non-classified runtime errors inside the agent under test** - `openai.BadRequestError` raised inside a LangGraph internal task ('research') escaped past both `_run_prompt_seed` and `CallableSession`'s wrapper because it was raised in a different `asyncio` task than the one being awaited, so it never reached the classification layer at all.

This is the wrong failure mode for an adversarial-eval pipeline. Generating prompts the target / auditor / judge refuses is exactly what we're supposed to do, and the refusal itself is data we want to keep, not a global pipeline error.

## Fix

Treat per-seed failures as **data**, not as global pipeline errors, at four layers, plus a generic catch-all with a batch-level error-rate threshold.

### Per-layer isolation

| Layer | What's caught | Recorded as |
|---|---|---|
| **Target side** (`rollout._run_prompt_seed`, `_run_auditor_target_loop`) | `LLMInputError` from the target call | `[TARGET INPUT REFUSED: ...]` event, `stop_reason='target_input_refused'` |
| **Callable target classification** (`session.CallableSession.run_turn`) | Raw provider exceptions raised inside user callables | Wrapped via `_classify_llm_error` so they flow through the same target-side isolation; unclassified errors propagate unchanged |
| **Auditor side** (`rollout._run_auditor_target_loop`) | `LLMInputError` from the auditor call | `[AUDITOR INPUT REFUSED: ...]` event, `stop_reason='auditor_input_refused'` |
| **Judge side** (`stages.judge`) | `LLMInputError` on the judge call | Synthetic score row with `judge_status='filter_skipped'`, `judge_error='judge_input_refused: ...'`; flows through the existing `infer_judge_status()` contract as a non-ok seed |

### Generic catch-all (final commit)

Any non-global exception that escapes the targeted handlers now synthesizes a transcript with `stop_reason='runtime_error'` carrying a single system event with the error type and message. The transcript is written like a normal one; the seed isn't lost. The exception is still attached to the result so the gather loop can count it.

### Batch-level error-ratio threshold

Replaced `if errors: raise errors[0]` in the rollout gather loop with a configurable threshold:

- Default **10%** (1 in 10 seeds erroring is the tipping point)
- Tunable via `P2M_ROLLOUT_ERROR_FAIL_RATIO` for ops scenarios
- Below threshold: log a single warning summary with the ratio, stage completes normally
- Above threshold: log an error and raise the first exception so the runner surfaces a clean message

Systemic failures (auth misconfigured, every seed errors) still fail fast.

### What still fails fast (intentionally)

- `LLMAuthError` - global config problem; retry won't help
- `LLMRateLimitError` - global throttling
- `LLMProviderError` - provider 5xx; conservative choice
- Any pre-rollout stage failure (policy/design/seeds) - those have no per-seed semantics

## Validation

End-to-end 1k mix run on `15332c8` (`travel-planner-langgraph-pr44-mix1k-e2e/baseline`, 700 prompts + 300 scenarios, C=5):

| Stage | Wall | Per case |
|---|---|---|
| policy | 16.2s | - |
| design | 3.1s | - |
| seeds | 72.9s | - |
| rollout | 1796.7s (29.9 min) | 1.80s |
| judge | 1925.8s (32.1 min) | 1.93s |
| **total** | **3814.7s (1h 3m 36s)** | |

1000/1000 transcripts, 1000/1000 scored, all `judge_status='ok'`, zero recorded runtime errors. Earlier runs on the same branch did exercise the isolation paths live (auditor refusal at 853, judge filter at 539, LangGraph escape ~994); the final run was clean.

## Tests

7 new tests:

- `test_run_turn_reclassifies_litellm_bad_request_as_input_error` (session)
- `test_run_turn_passes_through_unclassified_exceptions` (session)
- `test_run_prompt_seed_records_target_input_refusal` (rollout)
- `test_run_rollout_isolates_target_input_refusal_to_one_seed` (rollout)
- `test_run_rollout_isolates_auditor_input_refusal_to_one_seed` (rollout)
- `test_run_rollout_still_fails_fast_on_provider_5xx` (rollout)
- `test_run_rollout_tolerates_below_threshold_errors` (rollout)

1 existing test updated (`test_run_rollout_keeps_partial_successful_transcripts_when_later_worker_fails`) to reflect the new contract: failing seeds now have synthesized `stop_reason='runtime_error'` transcripts, and the 50% error rate still aborts.

All 52 rollout + exception-handling tests pass locally.

## Files

```
p2m/core/session.py              |  37 +++-
p2m/stages/judge.py              |  36 +++-
p2m/stages/rollout.py            | 194 ++++++++++++++++---
tests/test_exception_handling.py |  69 +++++++
tests/test_rollout_stage.py      | 401 +++++++++++++++++++++++++++++++++++-
5 files changed, 702 insertions(+), 35 deletions(-)
```

## Commits (read in order)

Each commit closed a real gap surfaced by the previous commit's validation, so the sequence is also the discovery log:

1. `82cf339` - target-side `LLMInputError` isolation (the original May 11 fix).
2. `0184d8d` - classify raw `litellm` exceptions raised inside user callables, so callable-target frameworks (LangGraph, etc.) flow through the same target-side isolation.
3. `f265154` - auditor-side `LLMInputError` isolation.
4. `dcaa91f` - judge-side `LLMInputError` isolation.
5. `15332c8` - generic per-seed error isolation with batch-level error-ratio threshold.

## Known follow-ups not in this PR

- **Seeds-stage content-filter refusals are not isolated.** Generation is pre-rollout, so the per-seed semantics here don't apply directly. Separate work.
- **10% default error-ratio threshold is a starting value, not a calibrated one.** For 10-seed runs it's 1-error sensitive; for 1k+ runs it allows up to 100 silent errors. Worth revisiting once we have multi-run error-rate data.
- **`P2M_ROLLOUT_ERROR_FAIL_RATIO` env var is a temporary control surface.** If it stays useful it should graduate to a real config field; if not, it can be dropped.
- **Overlaps with Aaron's PR #45 benchmark shim** (`_install_content_filter_tolerance` in `scripts/benchmark.py`, using `stop_reason="content_filter_blocked"`). That patch monkey-patches the rollout to drop content-filter-blocked seeds at benchmark time; this PR lands per-seed isolation in product code so the shim can be retired once #45 merges (or revisited to align stop_reason naming).
