### PR TITLE
fix(examples): add trace:phoenix block to framework-eval-mini configs so tool calls reach the viewer

### DIFF
--- a/examples/phoenix_auto_trace/eval_crewai.yaml
+++ b/examples/phoenix_auto_trace/eval_crewai.yaml
@@ -1,6 +1,8 @@
 # Framework eval: shared suite, one run per framework.
 # All 5 frameworks use the same policy+seeds, same judge (gpt-5.4-mini).
-# Targets are plain callables (no target.trace) — demos self-instrument via Phoenix.
+# The demo callable self-instruments via `phoenix.otel.register(auto_instrument=True)`;
+# the `trace: { backend: phoenix }` block below tells p2m to pull those spans out
+# of Phoenix at end-of-session so tool calls show up in the viewer.
 
 suite: framework-eval-mini
 run: crewai
@@ -36,6 +38,9 @@ pipeline:
     concurrency: 1
     target:
       callable: examples.phoenix_auto_trace.travel_crewai:chat
+      trace:
+        backend: phoenix
+        group_by: session.id
     auditor:
       model: { name: azure/gpt-5.4-mini, temperature: 0.0, max_tokens: 10000 }
     max_turns: 6

--- a/examples/phoenix_auto_trace/eval_dspy.yaml
+++ b/examples/phoenix_auto_trace/eval_dspy.yaml
@@ -1,6 +1,8 @@
 # Framework eval: shared suite, one run per framework.
 # All 5 frameworks use the same policy+seeds, same judge (gpt-5.4-mini).
-# Targets are plain callables (no target.trace) — demos self-instrument via Phoenix.
+# The demo callable self-instruments via `phoenix.otel.register(auto_instrument=True)`;
+# the `trace: { backend: phoenix }` block below tells p2m to pull those spans out
+# of Phoenix at end-of-session so tool calls show up in the viewer.
 
 suite: framework-eval-mini
 run: dspy
@@ -36,6 +38,9 @@ pipeline:
     concurrency: 1
     target:
       callable: examples.phoenix_auto_trace.travel_dspy:chat
+      trace:
+        backend: phoenix
+        group_by: session.id
     auditor:
       model: { name: azure/gpt-5.4-mini, temperature: 0.0, max_tokens: 10000 }
     max_turns: 6

--- a/examples/phoenix_auto_trace/eval_framework_template.yaml
+++ b/examples/phoenix_auto_trace/eval_framework_template.yaml
@@ -53,6 +53,9 @@ pipeline:
     concurrency: 1
     target:
       callable: REPLACE_WITH_FRAMEWORK:chat
+      trace:
+        backend: phoenix             # demo callables call phoenix.otel.register();
+        group_by: session.id         # this pulls those spans into transcripts.jsonl
     auditor:
       model: { name: azure/gpt-5.4-mini, temperature: 0.0, max_tokens: 10000 }
     max_turns: 6

--- a/examples/phoenix_auto_trace/eval_langchain.yaml
+++ b/examples/phoenix_auto_trace/eval_langchain.yaml
@@ -1,6 +1,8 @@
 # Framework eval: shared suite, one run per framework.
 # All 5 frameworks use the same policy+seeds, same judge (gpt-5.4-mini).
-# Targets are plain callables (no target.trace) — demos self-instrument via Phoenix.
+# The demo callable self-instruments via `phoenix.otel.register(auto_instrument=True)`;
+# the `trace: { backend: phoenix }` block below tells p2m to pull those spans out
+# of Phoenix at end-of-session so tool calls show up in the viewer.
 
 suite: framework-eval-mini
 run: langchain
@@ -36,6 +38,9 @@ pipeline:
     concurrency: 1
     target:
       callable: examples.phoenix_auto_trace.travel_langchain:chat
+      trace:
+        backend: phoenix
+        group_by: session.id
     auditor:
       model: { name: azure/gpt-5.4-mini, temperature: 0.0, max_tokens: 10000 }
     max_turns: 6

--- a/examples/phoenix_auto_trace/eval_litellm.yaml
+++ b/examples/phoenix_auto_trace/eval_litellm.yaml
@@ -1,6 +1,8 @@
 # Framework eval: shared suite, one run per framework.
 # All 5 frameworks use the same policy+seeds, same judge (gpt-5.4-mini).
-# Targets are plain callables (no target.trace) — demos self-instrument via Phoenix.
+# The demo callable self-instruments via `phoenix.otel.register(auto_instrument=True)`;
+# the `trace: { backend: phoenix }` block below tells p2m to pull those spans out
+# of Phoenix at end-of-session so tool calls show up in the viewer.
 
 suite: framework-eval-mini
 run: litellm
@@ -36,6 +38,9 @@ pipeline:
     concurrency: 1
     target:
       callable: examples.phoenix_auto_trace.travel_litellm:chat
+      trace:
+        backend: phoenix
+        group_by: session.id
     auditor:
       model: { name: azure/gpt-5.4-mini, temperature: 0.0, max_tokens: 10000 }
     max_turns: 6

--- a/examples/phoenix_auto_trace/eval_openai.yaml
+++ b/examples/phoenix_auto_trace/eval_openai.yaml
@@ -1,6 +1,8 @@
 # Framework eval: shared suite, one run per framework.
 # All 5 frameworks use the same policy+seeds, same judge (gpt-5.4-mini).
-# Targets are plain callables (no target.trace) — demos self-instrument via Phoenix.
+# The demo callable self-instruments via `phoenix.otel.register(auto_instrument=True)`;
+# the `trace: { backend: phoenix }` block below tells p2m to pull those spans out
+# of Phoenix at end-of-session so tool calls show up in the viewer.
 
 suite: framework-eval-mini
 run: openai
@@ -36,6 +38,9 @@ pipeline:
     concurrency: 1
     target:
       callable: examples.phoenix_auto_trace.travel_openai:chat
+      trace:
+        backend: phoenix
+        group_by: session.id
     auditor:
       model: { name: azure/gpt-5.4-mini, temperature: 0.0, max_tokens: 10000 }
     max_turns: 6


### PR DESCRIPTION
## Why this matters

For the **crewai** and **dspy** tabs (and 3 other framework tabs) in `framework-eval-mini`, the viewer renders **zero tool calls or tool results** even though the agents actually call tools. Reviewers see assistants seemingly answering from thin air — looks broken.

The root cause isn't a viewer bug — it's a **silent config gap** in `examples/phoenix_auto_trace/`.

## Root cause

Each framework demo (`travel_openai.py`, `travel_litellm.py`, `travel_langchain.py`, `travel_crewai.py`, `travel_dspy.py`) calls

```python
from phoenix.otel import register
register(auto_instrument=True)
```

so spans flow into the Phoenix OTel collector. But the matching eval config files (`eval_openai.yaml`, `eval_litellm.yaml`, ...) **lacked** the `target.trace` block, so p2m never queried Phoenix at end-of-session and never wrote those spans into `transcripts.jsonl`.

The misleading comment at the top of each config — *"Targets are plain callables (no target.trace) — demos self-instrument via Phoenix"* — was technically true (Phoenix DID get the spans) but practically wrong (p2m needs the `trace:` block to retrieve them).

## Fix

Add the standard 3-line trace block to all 5 framework configs + the template:

```diff
     target:
       callable: examples.phoenix_auto_trace.travel_<framework>:chat
+      trace:
+        backend: phoenix
+        group_by: session.id
```

…and rewrite the leading comment so future readers don't repeat the same omission when they copy these as templates.

## Verification (litellm seed)

Ran `examples/phoenix_auto_trace/eval_litellm.yaml` (tiny budget) on this branch and inspected `transcripts.jsonl`:

|  | Pre-fix | Post-fix |
|---|---|---|
| Assistant `event.raw` | `null` | `{trace_metadata, trace_events[…]}` |
| `trace_metadata.llm_call_count` | absent | `8` |
| `trace_metadata.tools_called` | absent | `[]`* |
| `trace_events[]` length | absent | `8` |

*tools_called is empty for THAT specific 1-seed run because the model chose to fabricate tool results in plain text instead of issuing actual tool_call requests (model behavior under `gpt-5.4-mini` at temp 0.7 with a single sample). Cross-checked the working `large-travel-planner-langgraph-v1` run (same `trace: phoenix` pattern): **154 tool_call edits across 15 transcripts**, confirming the config shape is correct and tool events DO surface to the viewer through this path.

## Files

- `examples/phoenix_auto_trace/eval_openai.yaml`
- `examples/phoenix_auto_trace/eval_litellm.yaml`
- `examples/phoenix_auto_trace/eval_langchain.yaml`
- `examples/phoenix_auto_trace/eval_crewai.yaml`
- `examples/phoenix_auto_trace/eval_dspy.yaml`
- `examples/phoenix_auto_trace/eval_framework_template.yaml` (so future framework configs inherit the right shape)

## Caveat — re-run required

Existing `artifacts/results/framework-eval-mini/{openai,litellm,langchain,crewai,dspy}/transcripts.jsonl` were captured **before** this fix and will keep showing zero tools until the suite is re-run. Suggest doing the regen in a follow-up commit (one full pass at the existing budget = ~5 framework × ~5min = ~25min wall-clock) and committing the refreshed transcripts so the viewer demos render correctly out-of-the-box.

## Tests

`uv run pytest -q` — 618 passed (no test code changed; the configs are runtime data, no schema impact).

## Related

- The viewer turn-numbering fix (#38) makes tool calls land on the right turn label once they arrive, but this PR is what makes them arrive at all for these 5 frameworks. The two fixes compose.
