### PR TITLE
docs: add CELA-reviewed risks and limitations section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,37 +72,6 @@ What the quickstart does:
 
 Start with the full walkthrough: [`docs/quickstart.md`](docs/quickstart.md).
 
-## Important: Risks and limitations
-
-> Adaptive Evaluation is designed to generate and run scenario-based evaluations for AI systems, including adversarial and edge-case tests. These scenarios are intended to help surface potential weaknesses, unsafe behaviors, and other undesirable outcomes. They do not guarantee that a system has failed, nor are they guarantees that a system is safe.
->
-> Because generated scenarios can meaningfully affect system behavior, using this product without adequate sandboxing or environment controls can cause real-world side effects. Depending on the target system, evaluations may trigger unwanted actions such as data modification or deletion, information disclosure, code or configuration changes, external messages, or other operational impacts.
->
-> You are responsible for ensuring that evaluations run only in environments that are appropriate for testing, including the use of:
->
-> - test or synthetic data where possible
-> - restricted credentials and scoped permissions
-> - isolated or non-production systems
-> - safeguards for logging, storage, and external actions
->
-> You should review generated adversarial or stress-test prompts before use and confirm that your environment can safely handle them. Some generated scenarios may involve jailbreak-style behavior, prompt injection, tool misuse, over-broad requests, or other forms of adversarial interaction.
->
-> Adaptive Evaluation is not a compliance or certification tool. You and your users remain responsible for ensuring that evaluated systems comply with applicable laws, regulations, contractual obligations, internal policies, and industry standards.
->
-> Use of this system may also result in meaningful compute and inference costs. You should monitor usage, model calls, tool execution, and resource consumption during evaluations.
-
-### Additional limitations
-
-- **Real system side effects may occur.** Evaluations can trigger writes, messages, workflow actions, code changes, ticket creation, or other effects if the target is connected to live systems.
-- **Results are scenario-dependent.** Outcomes depend on the generated scenario, available tools, retrieved context, system configuration, and runtime environment.
-- **Automated judgments are best-effort.** LLM-based scoring and review can be incorrect; treat single-run outputs as signals for investigation, not definitive truth.
-- **Run-to-run behavior may vary.** Results may differ across runs, especially for multi-turn or tool-using systems.
-- **Untrusted content can affect outcomes.** Retrieved documents, tool outputs, and external content may influence both the target system and automated judges in unexpected ways.
-- **Sensitive content may appear in artifacts.** If the evaluated system emits secrets, personal data, or restricted content, that material may appear in logs, traces, prompts, outputs, or evaluation artifacts.
-- **Costs may scale quickly.** Large evaluations, repeated retries, or tool-heavy runs can incur substantial inference and execution costs.
-- **This is not a substitute for human review.** High-stakes conclusions should be supported by expert review, grounded evidence, and, where appropriate, additional statistical validation.
-- **Reproducibility may be imperfect.** Results can vary across model versions, deployments, tool backends, and runtime settings.
-
 ## How it works
 
 ```text
@@ -201,4 +170,35 @@ Preview feedback is welcome: confusing names, missing target examples, trace gap
 - **macOS, `litellm` AttributeError after install** — some macOS security tooling can silently truncate the `litellm` wheel during extraction with `uv sync`, causing errors like `AttributeError: module 'litellm' has no attribute 'acompletion'`. The `pip install -e ".[otel,langgraph]"` path above uses copy-based installs and avoids this. If you must use `uv`, grant your terminal Full Disk Access and run `xattr -cr .venv` to clear quarantine attributes.
 - **Windows, `UnicodeEncodeError` when running auto-trace demos** — set `$env:PYTHONUTF8 = "1"` before `python -m examples.phoenix_auto_trace.travel_openai`.
 - **Docker-backed pipes fail with "docker daemon unavailable"** — `examples/pipes/health_assistant_sandbox.yaml` and `_external.yaml` need Docker Desktop running.
+
+## Important: Risks and limitations
+
+Adaptive Evaluation is designed to generate and run scenario-based evaluations for AI systems, including adversarial and edge-case tests. These scenarios are intended to help surface potential weaknesses, unsafe behaviors, and other undesirable outcomes. They do not guarantee that a system has failed, nor are they guarantees that a system is safe.
+
+Because generated scenarios can meaningfully affect system behavior, using this product without adequate sandboxing or environment controls can cause real-world side effects. Depending on the target system, evaluations may trigger unwanted actions such as data modification or deletion, information disclosure, code or configuration changes, external messages, or other operational impacts.
+
+You are responsible for ensuring that evaluations run only in environments that are appropriate for testing, including the use of:
+
+- test or synthetic data where possible
+- restricted credentials and scoped permissions
+- isolated or non-production systems
+- safeguards for logging, storage, and external actions
+
+You should review generated adversarial or stress-test prompts before use and confirm that your environment can safely handle them. Some generated scenarios may involve jailbreak-style behavior, prompt injection, tool misuse, over-broad requests, or other forms of adversarial interaction.
+
+Adaptive Evaluation is not a compliance or certification tool. You and your users remain responsible for ensuring that evaluated systems comply with applicable laws, regulations, contractual obligations, internal policies, and industry standards.
+
+Use of this system may also result in meaningful compute and inference costs. You should monitor usage, model calls, tool execution, and resource consumption during evaluations.
+
+### Additional limitations
+
+- **Real system side effects may occur.** Evaluations can trigger writes, messages, workflow actions, code changes, ticket creation, or other effects if the target is connected to live systems.
+- **Results are scenario-dependent.** Outcomes depend on the generated scenario, available tools, retrieved context, system configuration, and runtime environment.
+- **Automated judgments are best-effort.** LLM-based scoring and review can be incorrect; treat single-run outputs as signals for investigation, not definitive truth.
+- **Run-to-run behavior may vary.** Results may differ across runs, especially for multi-turn or tool-using systems.
+- **Untrusted content can affect outcomes.** Retrieved documents, tool outputs, and external content may influence both the target system and automated judges in unexpected ways.
+- **Sensitive content may appear in artifacts.** If the evaluated system emits secrets, personal data, or restricted content, that material may appear in logs, traces, prompts, outputs, or evaluation artifacts.
+- **Costs may scale quickly.** Large evaluations, repeated retries, or tool-heavy runs can incur substantial inference and execution costs.
+- **This is not a substitute for human review.** High-stakes conclusions should be supported by expert review, grounded evidence, and, where appropriate, additional statistical validation.
+- **Reproducibility may be imperfect.** Results can vary across model versions, deployments, tool backends, and runtime settings.
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,37 @@ What the quickstart does:
 
 Start with the full walkthrough: [`docs/quickstart.md`](docs/quickstart.md).
 
+## Important: Risks and limitations
+
+> Adaptive Evaluation is designed to generate and run scenario-based evaluations for AI systems, including adversarial and edge-case tests. These scenarios are intended to help surface potential weaknesses, unsafe behaviors, and other undesirable outcomes. They do not guarantee that a system has failed, nor are they guarantees that a system is safe.
+>
+> Because generated scenarios can meaningfully affect system behavior, using this product without adequate sandboxing or environment controls can cause real-world side effects. Depending on the target system, evaluations may trigger unwanted actions such as data modification or deletion, information disclosure, code or configuration changes, external messages, or other operational impacts.
+>
+> You are responsible for ensuring that evaluations run only in environments that are appropriate for testing, including the use of:
+>
+> - test or synthetic data where possible
+> - restricted credentials and scoped permissions
+> - isolated or non-production systems
+> - safeguards for logging, storage, and external actions
+>
+> You should review generated adversarial or stress-test prompts before use and confirm that your environment can safely handle them. Some generated scenarios may involve jailbreak-style behavior, prompt injection, tool misuse, over-broad requests, or other forms of adversarial interaction.
+>
+> Adaptive Evaluation is not a compliance or certification tool. You and your users remain responsible for ensuring that evaluated systems comply with applicable laws, regulations, contractual obligations, internal policies, and industry standards.
+>
+> Use of this system may also result in meaningful compute and inference costs. You should monitor usage, model calls, tool execution, and resource consumption during evaluations.
+
+### Additional limitations
+
+- **Real system side effects may occur.** Evaluations can trigger writes, messages, workflow actions, code changes, ticket creation, or other effects if the target is connected to live systems.
+- **Results are scenario-dependent.** Outcomes depend on the generated scenario, available tools, retrieved context, system configuration, and runtime environment.
+- **Automated judgments are best-effort.** LLM-based scoring and review can be incorrect; treat single-run outputs as signals for investigation, not definitive truth.
+- **Run-to-run behavior may vary.** Results may differ across runs, especially for multi-turn or tool-using systems.
+- **Untrusted content can affect outcomes.** Retrieved documents, tool outputs, and external content may influence both the target system and automated judges in unexpected ways.
+- **Sensitive content may appear in artifacts.** If the evaluated system emits secrets, personal data, or restricted content, that material may appear in logs, traces, prompts, outputs, or evaluation artifacts.
+- **Costs may scale quickly.** Large evaluations, repeated retries, or tool-heavy runs can incur substantial inference and execution costs.
+- **This is not a substitute for human review.** High-stakes conclusions should be supported by expert review, grounded evidence, and, where appropriate, additional statistical validation.
+- **Reproducibility may be imperfect.** Results can vary across model versions, deployments, tool backends, and runtime settings.
+
 ## How it works
 
 ```text


### PR DESCRIPTION
## What

Adds an **Important: Risks and limitations** section to `README.md`, placed right after Quickstart and before "How it works."

## Why

CELA review on 2026-05-15 ahead of broader public-preview repo access. This is the release-gate item that needs to land before `microsoft/adaptive-eval` opens to a wider audience.

## Section structure

1. **Top-line blockquote disclaimer** covering:
   - Scenario-based testing intent — surfacing weaknesses ≠ guaranteeing safety or failure
   - Sandboxing requirement — real-world side effects are possible
   - Customer responsibility list (test/synthetic data, restricted credentials, isolated systems, logging/storage safeguards)
   - Review of generated adversarial prompts (jailbreak, prompt injection, tool misuse, etc.)
   - **Not a compliance/certification tool** — customer remains responsible for legal/regulatory compliance
   - Inference-cost awareness
2. **Additional limitations** — 9 customer-readable bullets covering: side effects, scenario dependence, judge best-effort scoring, run-to-run variance, untrusted content influence, sensitive content in artifacts, cost scaling, "not a substitute for human review," reproducibility limits.

## Placement rationale

Right after Quickstart (line 73), before "How it works" (line 75). Customers should see the risks before they invest in writing a config, but after they've understood what the tool does enough for the risks to make sense.

## Scope

Docs-only. No code, no examples, no configuration touched.

## Reviewers

@cc tagging once the right CELA + RAI reviewers are confirmed (this PR is the customer-facing version of the disclaimer text drafted with CELA).
