### PR TITLE
provider: gate web search support

### DIFF
--- a/p2m/core/model_client.py
+++ b/p2m/core/model_client.py
@@ -175,6 +175,39 @@ def build_json_schema_text_format(
     }
 
 
+def _model_family(model: str) -> str:
+    """Return the provider/model-family prefix used for transport capability checks."""
+    normalized = (model or "").strip().lower()
+    if "/" in normalized:
+        return normalized.split("/", 1)[0]
+    if normalized.startswith(("gpt-", "o1", "o3", "o4")):
+        return "openai"
+    return normalized
+
+
+def _supports_web_search_preview(model: str) -> bool:
+    """Whether this model can use the Responses API web_search_preview tool.
+
+    The current implementation sends OpenAI Responses API payloads with
+    ``tools=[{"type": "web_search_preview"}]``. LiteLLM exposes that
+    path for OpenAI-compatible models, but provider smoke testing showed
+    Gemini fails before useful generation when this tool is combined with
+    structured output. Keep the gate intentionally narrow until each
+    provider has an explicit, tested web-search path.
+    """
+    return _model_family(model) in {"openai", "azure"}
+
+
+def _require_web_search_preview_support(model: str) -> None:
+    if _supports_web_search_preview(model):
+        return
+    raise ValueError(
+        "web_search uses the OpenAI Responses API web_search_preview tool, "
+        f"which is not enabled for model '{model}'. Disable web_search for this "
+        "stage or use an OpenAI/Azure OpenAI model."
+    )
+
+
 def messages_to_openai(messages: str | Sequence[MessageLike]) -> list[dict[str, Any]]:
     """Convert message inputs into OpenAI-format dicts."""
     if isinstance(messages, str):
@@ -811,8 +844,10 @@ async def generate(
 ) -> ModelResponse:
     """Run a standard async text generation call."""
     resolved_options = options or GenerateOptions()
-    litellm = _get_litellm_module()
     api_mode = "responses" if resolved_options.web_search else "chat_completion"
+    if resolved_options.web_search:
+        _require_web_search_preview_support(model)
+    litellm = _get_litellm_module()
     t0 = time.monotonic()
 
     if resolved_options.web_search:
@@ -860,8 +895,10 @@ async def generate_structured(
 ) -> ModelResponse:
     """Run a structured generation call constrained by a JSON schema."""
     resolved_options = options or GenerateOptions()
-    litellm = _get_litellm_module()
     api_mode = "responses" if resolved_options.web_search else "chat_completion"
+    if resolved_options.web_search:
+        _require_web_search_preview_support(model)
+    litellm = _get_litellm_module()
     t0 = time.monotonic()
 
     if resolved_options.web_search:

--- a/tests/test_model_client.py
+++ b/tests/test_model_client.py
@@ -97,6 +97,37 @@ class ModelClientTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response_format["json_schema"]["schema"], schema)
         self.assertEqual(response.parsed, {"verdict": "pass"})
 
+    async def test_generate_structured_with_web_search_rejects_gemini(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {"verdict": {"type": "string"}},
+            "required": ["verdict"],
+            "additionalProperties": False,
+        }
+
+        with patch.object(model_client, "_get_litellm_module") as get_litellm:
+            with self.assertRaisesRegex(ValueError, "web_search.*gemini/gemini-2.5-flash"):
+                await model_client.generate_structured(
+                    "gemini/gemini-2.5-flash",
+                    "research this",
+                    schema_name="judge_output",
+                    json_schema=schema,
+                    options=model_client.GenerateOptions(web_search=True),
+                )
+
+        get_litellm.assert_not_called()
+
+    async def test_generate_with_web_search_rejects_non_openai_provider(self) -> None:
+        with patch.object(model_client, "_get_litellm_module") as get_litellm:
+            with self.assertRaisesRegex(ValueError, "Disable web_search"):
+                await model_client.generate(
+                    "anthropic/claude-sonnet-4-20250514",
+                    "research this",
+                    options=model_client.GenerateOptions(web_search=True),
+                )
+
+        get_litellm.assert_not_called()
+
     async def test_generate_structured_with_web_search_uses_responses_api(self) -> None:
         captured: dict[str, object] = {}
 


### PR DESCRIPTION
## Summary

Adds a narrow provider capability gate for the current `web_search` transport path.

Today `web_search=True` always builds an OpenAI Responses API payload with `web_search_preview`. Gemini provider smoke testing showed that path fails before useful generation when combined with structured output, even though direct LiteLLM calls and a tiny manual rollout/judge smoke work.

This PR makes that mismatch explicit instead of letting non-OpenAI providers fail deep in LiteLLM/provider code.

## Review focus

- This is intentionally a small guardrail, not a full Gemini support PR.
- Main behavior to sanity-check: OpenAI / Azure OpenAI keep the existing `web_search_preview` path, while Gemini/Anthropic/etc. get a clear "disable `web_search`" error before provider calls.
- Follow-up remains separate: simplify/fallback the Gemini scenario-seed schema path.

## Changes

- Add a small model-family capability check in `p2m.core.model_client`.
- Allow the current `web_search_preview` path only for OpenAI / Azure OpenAI model families.
- Raise a clear `ValueError` for other providers telling users to disable `web_search` for that stage.
- Add unit coverage for Gemini structured generation and another non-OpenAI provider.

## Not included

This does **not** claim full Gemini support. The remaining Gemini-generated-path issue is scenario-seed schema complexity; that should be handled separately via schema simplification / fallback generation.

Related to #50.

## Test evidence

```bash
uv run pytest tests/test_model_client.py -q
# 7 passed
```

GitHub checks are green: Tier 1 unit tests, Tier 4 regression gate, and CLA.
