### PR TITLE
docs: add Codespaces devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+  "name": "Adaptive Eval",
+  "image": "mcr.microsoft.com/devcontainers/python:1-3.12-bookworm",
+  "postCreateCommand": "python -m pip install --upgrade pip && python -m pip install -e \".[otel,langgraph,dev]\" && cp -n .env.example .env",
+  "forwardPorts": [
+    6006
+  ],
+  "portsAttributes": {
+    "6006": {
+      "label": "Phoenix",
+      "onAutoForward": "notify"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "redhat.vscode-yaml"
+      ]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ p2m run --config examples/travel_planner_langgraph/eval_config.yaml
 p2m results status travel-planner-langgraph-v1 demo-1
 ```
 
+Codespaces / VS Code Dev Containers:
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/microsoft/adaptive-eval)
+
+The repo includes a minimal dev container for the LangGraph quickstart. It installs `.[otel,langgraph,dev]`, copies `.env.example` to `.env` if needed, and forwards Phoenix on port `6006`. After the container finishes setup, add your provider credentials to `.env` and run the same `p2m run` command above.
+
 Windows PowerShell equivalent:
 
 ```powershell


### PR DESCRIPTION
## Summary

Adds a minimal Codespaces / VS Code Dev Containers setup for the LangGraph quickstart.

This is the first small slice of #51. It gives demo speakers and preview users a one-click Linux dev environment instead of making each person assemble their own Codespaces/devcontainer setup.

## Review focus

- This is intentionally scoped to the smallest useful Codespaces/devcontainer path.
- It should unblock a clean Linux quickstart environment without taking on the full install-docs rewrite.
- Follow-ups can handle framework extras, per-OS setup notes, and broader onboarding cleanup.

## Changes

- Add `.devcontainer/devcontainer.json` using the Microsoft Python 3.12 devcontainer image.
- Install the quickstart dependency set with `python -m pip install -e ".[otel,langgraph,dev]"`.
- Copy `.env.example` to `.env` if needed.
- Forward Phoenix on port `6006`.
- Add a short README note and Codespaces badge.

## Not included

This does not try to solve the full #51 docs rewrite. Framework extras, per-OS notes, and broader install-path cleanup can stay as follow-ups.

## Validation

```bash
python3 -m json.tool .devcontainer/devcontainer.json
python3 -m venv /tmp/adaptive-eval-devcontainer-pipcheck
/tmp/adaptive-eval-devcontainer-pipcheck/bin/python -m pip install --upgrade pip
/tmp/adaptive-eval-devcontainer-pipcheck/bin/python -m pip install -e ".[otel,langgraph,dev]"
/tmp/adaptive-eval-devcontainer-pipcheck/bin/p2m --help
```

GitHub CLA check is green. This PR is docs/devcontainer-only, so there are no Python test changes.
