### PR TITLE
docs: add release checklist docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,10 @@
+# Microsoft Open Source Code of Conduct
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+
+Resources:
+
+- [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/)
+- [Microsoft Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
+- Contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with questions or concerns.
+- Microsoft employees can use [aka.ms/opensource/moderation-support](https://aka.ms/opensource/moderation-support) for moderation support.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,88 @@
+# Contributing to Adaptive Eval
+
+Thank you for your interest in contributing to Adaptive Eval. This project is in customer preview, so the fastest way to help is to keep changes small, reviewable, and tied to a specific issue or customer-facing problem.
+
+## Before you start
+
+- Check the open issues for the problem you want to fix.
+- For customer-facing fixes, make sure the issue describes the user problem, expected behavior, and validation plan.
+- Keep pull requests focused. Prefer one small fix per pull request over one broad cleanup.
+- Do not include secrets, customer data, internal service names, or private preview artifacts in commits, issues, or pull requests.
+
+## Development setup
+
+Adaptive Eval requires Python 3.11 or later. Node.js is needed only for viewer work and tests that exercise viewer assets.
+
+```bash
+git clone https://github.com/microsoft/adaptive-eval.git
+cd adaptive-eval
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -e ".[otel,langgraph,dev]"
+cp .env.example .env
+```
+
+Windows PowerShell equivalent:
+
+```powershell
+git clone https://github.com/microsoft/adaptive-eval.git
+cd adaptive-eval
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install --upgrade pip
+python -m pip install -e ".[otel,langgraph,dev]"
+Copy-Item .env.example .env
+```
+
+If you are changing the viewer or running tests that import viewer packages, install viewer dependencies too:
+
+```bash
+npm ci --prefix viewer
+```
+
+## Common validation commands
+
+Run the smallest validation that covers your change, and include the command output in the pull request description.
+
+```bash
+python -m pytest tests/test_model_client.py -q
+python -m pytest tests/ -x -q
+```
+
+For docs-only changes, validate links and examples manually. If you change setup instructions, test them in a clean virtual environment when practical.
+
+## Pull request checklist
+
+Before opening a pull request:
+
+- Link the issue or workback item the pull request addresses.
+- Explain the customer-facing problem or release-checklist item.
+- Describe the expected behavior after the change.
+- Include validation evidence.
+- Keep generated artifacts, local run outputs, `.env` files, and credentials out of the diff.
+- Call out any follow-up work that is intentionally not included.
+
+## Code and documentation guidelines
+
+- Match the existing project style and terminology.
+- Prefer clear user-facing errors over provider-specific stack traces.
+- Keep preview-language honest. Do not imply that Adaptive Eval certifies safety, compliance, or production readiness.
+- For docs, distinguish current YAML keys from intended developer-facing terminology when both matter.
+- For examples, use synthetic data only.
+
+## Security issues
+
+Do not report security vulnerabilities through public GitHub issues. Follow the reporting guidance in [`SECURITY.md`](SECURITY.md).
+
+## Contributor License Agreement
+
+Most contributions require agreement to a Contributor License Agreement (CLA). When you open a pull request, the CLA bot will indicate whether any action is required. For details, see <https://cla.opensource.microsoft.com>.
+
+## Code of Conduct
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For questions or concerns, see [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,33 @@
+# Support
+
+Adaptive Eval is currently a customer preview / POC distribution. This repository is the primary place to track setup issues, documentation gaps, and product feedback during preview.
+
+## Getting help
+
+Use GitHub issues for:
+
+- setup or installation problems,
+- confusing documentation,
+- example or quickstart failures,
+- provider compatibility problems,
+- unexpected CLI or viewer behavior, and
+- feature requests.
+
+When opening an issue, include:
+
+- the command or workflow you ran,
+- the expected behavior,
+- the actual behavior,
+- your operating system and Python version,
+- the model provider or target type if relevant, and
+- the validation you already tried.
+
+Please do not include secrets, API keys, customer data, production logs, or private artifacts in issues or attachments. Use synthetic examples when possible.
+
+## Security vulnerabilities
+
+Do not report security vulnerabilities through public GitHub issues. Follow the reporting guidance in [`SECURITY.md`](SECURITY.md).
+
+## Microsoft support
+
+Unless a separate support agreement says otherwise, this preview repository does not provide a formal support SLA. The project team reviews issues and pull requests as part of preview development and release readiness.


### PR DESCRIPTION
## Summary

Adds the missing standard OSS release-checklist docs at the repository root:

- `CONTRIBUTING.md`
- `CODE_OF_CONDUCT.md`
- `SUPPORT.md`

This is intentionally a small, reviewable first pass for the OSS workback checklist so stakeholders can comment before EOW.

## Scope

- `CONTRIBUTING.md`: preview-aware contribution workflow, local setup, validation expectations, PR checklist, CLA, code of conduct, and security-reporting pointers.
- `CODE_OF_CONDUCT.md`: Microsoft Open Source Code of Conduct pointer and support links.
- `SUPPORT.md`: preview support expectations, issue guidance, sensitive-data warning, and security-reporting pointer.

## Not included

- No changes to `README.md`, `SECURITY.md`, or `LICENSE` because those already exist.
- No legal/PMM-specific wording beyond standard Microsoft OSS pointers.
- No PyPI publishing or install-path rewrite. Those should stay separate.

## Validation

```bash
python3 - <<'PY'
from pathlib import Path
bad=[]
for p in [Path('CONTRIBUTING.md'), Path('CODE_OF_CONDUCT.md'), Path('SUPPORT.md')]:
    for i,line in enumerate(p.read_text().splitlines(),1):
        if line.rstrip()!=line:
            bad.append((str(p),i))
if bad:
    print(bad)
    raise SystemExit(1)
print('ok')
PY

python3 - <<'PY'
from pathlib import Path
import re
for p in [Path('CONTRIBUTING.md'), Path('CODE_OF_CONDUCT.md'), Path('SUPPORT.md')]:
    text=p.read_text()
    for label,target in re.findall(r'\[([^\]]+)\]\(([^)]+)\)', text):
        if target.startswith(('http://','https://','mailto:','#')):
            continue
        target_path=(p.parent/target.split('#')[0]).resolve()
        if not target_path.exists():
            raise SystemExit(f'{p}: missing link target {target}')
print('ok')
PY
```
