### PR TITLE
docs/examples: update travel terminology

### DIFF
--- a/examples/phoenix_auto_trace/_tools.py
+++ b/examples/phoenix_auto_trace/_tools.py
@@ -48,8 +48,8 @@ def simulate_tool(name: str, args: dict) -> str:
         city = args.get("city", "unknown")
         return json.dumps({"city": city, **MOCK_WEATHER})
     if name == "check_travel_advisories":
-        country = args.get("country", "unknown")
-        return json.dumps({"country": country, **MOCK_ADVISORIES})
+        region = args.get("region", "unknown")
+        return json.dumps({"region": region, **MOCK_ADVISORIES})
     if name == "validate_budget":
         flight = args.get("flight_cost", 0)
         hotel = args.get("hotel_cost", 0)
@@ -102,8 +102,8 @@ OPENAI_TOOLS = [
         "name": "check_travel_advisories",
         "description": "Check visa requirements, safety advisories, and health precautions.",
         "parameters": {"type": "object", "properties": {
-            "country": {"type": "string", "description": "Destination country"},
-        }, "required": ["country"]},
+            "region": {"type": "string", "description": "Destination region"},
+        }, "required": ["region"]},
     }},
     {"type": "function", "function": {
         "name": "validate_budget",

--- a/examples/phoenix_auto_trace/travel_autogen.py
+++ b/examples/phoenix_auto_trace/travel_autogen.py
@@ -64,9 +64,9 @@ def check_weather(city: str) -> str:
     return simulate_tool("check_weather", {"city": city})
 
 
-def check_travel_advisories(country: str) -> str:
+def check_travel_advisories(region: str) -> str:
     """Check visa requirements, safety advisories, and health precautions."""
-    return simulate_tool("check_travel_advisories", {"country": country})
+    return simulate_tool("check_travel_advisories", {"region": region})
 
 
 def validate_budget(flight_cost: float, hotel_cost: float, other_costs: float = 0, budget: float = 0) -> str:

--- a/examples/phoenix_auto_trace/travel_bedrock.py
+++ b/examples/phoenix_auto_trace/travel_bedrock.py
@@ -75,9 +75,9 @@ TOOLS = [
                 "json": {
                     "type": "object",
                     "properties": {
-                        "country": {"type": "string", "description": "Destination country"},
+                        "region": {"type": "string", "description": "Destination region"},
                     },
-                    "required": ["country"],
+                    "required": ["region"],
                 }
             },
         }

--- a/examples/phoenix_auto_trace/travel_crewai.py
+++ b/examples/phoenix_auto_trace/travel_crewai.py
@@ -57,9 +57,9 @@ def check_weather(city: str) -> str:
 
 
 @tool("check_travel_advisories")
-def check_travel_advisories(country: str) -> str:
+def check_travel_advisories(region: str) -> str:
     """Check visa requirements, safety advisories, and health precautions."""
-    return simulate_tool("check_travel_advisories", {"country": country})
+    return simulate_tool("check_travel_advisories", {"region": region})
 
 
 @tool("validate_budget")

--- a/examples/phoenix_auto_trace/travel_dspy.py
+++ b/examples/phoenix_auto_trace/travel_dspy.py
@@ -45,8 +45,8 @@ def _check_weather(city: str) -> str:
     return simulate_tool("check_weather", {"city": city})
 
 
-def _check_travel_advisories(country: str) -> str:
-    return simulate_tool("check_travel_advisories", {"country": country})
+def _check_travel_advisories(region: str) -> str:
+    return simulate_tool("check_travel_advisories", {"region": region})
 
 
 def _validate_budget(flight_cost: float, hotel_cost: float, other_costs: float, budget: float) -> str:
@@ -62,7 +62,7 @@ class ExtractTravelIntent(dspy.Signature):
     """Extract travel parameters from a user request."""
     request: str = dspy.InputField(desc="User's travel planning request")
     destination: str = dspy.OutputField(desc="Travel destination city")
-    country: str = dspy.OutputField(desc="Destination country")
+    region: str = dspy.OutputField(desc="Destination region")
     duration_days: int = dspy.OutputField(desc="Trip duration in days")
     budget: float = dspy.OutputField(desc="Total budget in USD")
 
@@ -91,7 +91,7 @@ class TravelPlanner(dspy.Module):
         flights = _search_flights(intent.destination)
         hotels = _search_hotels(intent.destination)
         weather = _check_weather(intent.destination)
-        advisories = _check_travel_advisories(intent.country)
+        advisories = _check_travel_advisories(intent.region)
         budget_check = _validate_budget(
             flight_cost=1180, hotel_cost=145 * intent.duration_days,
             other_costs=0, budget=intent.budget,

--- a/examples/phoenix_auto_trace/travel_google_adk.py
+++ b/examples/phoenix_auto_trace/travel_google_adk.py
@@ -33,9 +33,9 @@ def check_weather(city: str) -> str:
     return simulate_tool("check_weather", {"city": city})
 
 
-def check_travel_advisories(country: str) -> str:
+def check_travel_advisories(region: str) -> str:
     """Check visa requirements, safety advisories, and health precautions."""
-    return simulate_tool("check_travel_advisories", {"country": country})
+    return simulate_tool("check_travel_advisories", {"region": region})
 
 
 def validate_budget(flight_cost: float, hotel_cost: float, other_costs: float = 0, budget: float = 0) -> str:

--- a/examples/phoenix_auto_trace/travel_google_genai.py
+++ b/examples/phoenix_auto_trace/travel_google_genai.py
@@ -64,9 +64,9 @@ check_travel_advisories_decl = types.FunctionDeclaration(
     parameters=types.Schema(
         type=types.Type.OBJECT,
         properties={
-            "country": types.Schema(type=types.Type.STRING, description="Destination country"),
+            "region": types.Schema(type=types.Type.STRING, description="Destination region"),
         },
-        required=["country"],
+        required=["region"],
     ),
 )
 

--- a/examples/phoenix_auto_trace/travel_instructor.py
+++ b/examples/phoenix_auto_trace/travel_instructor.py
@@ -44,7 +44,7 @@ client = _get_client()
 
 class TravelIntent(BaseModel):
     destination: str
-    country: str
+    region: str
     duration_days: int
     budget: float
 
@@ -65,7 +65,7 @@ class HotelOption(BaseModel):
 
 class TravelItinerary(BaseModel):
     destination: str
-    country: str
+    region: str
     duration_days: int
     recommended_flight: FlightOption
     recommended_hotel: HotelOption
@@ -96,7 +96,7 @@ def chat(message: str) -> str:
     flights = simulate_tool("search_flights", {"destination": intent.destination})
     hotels = simulate_tool("search_hotels", {"city": intent.destination})
     weather = simulate_tool("check_weather", {"city": intent.destination})
-    advisories = simulate_tool("check_travel_advisories", {"country": intent.country})
+    advisories = simulate_tool("check_travel_advisories", {"region": intent.region})
     budget_check = simulate_tool("validate_budget", {
         "flight_cost": 1180,
         "hotel_cost": 145 * intent.duration_days,

--- a/examples/phoenix_auto_trace/travel_langchain.py
+++ b/examples/phoenix_auto_trace/travel_langchain.py
@@ -72,9 +72,9 @@ def check_weather(city: str) -> str:
 
 
 @tool
-def check_travel_advisories(country: str) -> str:
+def check_travel_advisories(region: str) -> str:
     """Check visa requirements, safety advisories, and health precautions."""
-    return simulate_tool("check_travel_advisories", {"country": country})
+    return simulate_tool("check_travel_advisories", {"region": region})
 
 
 @tool

--- a/examples/phoenix_auto_trace/travel_langgraph.py
+++ b/examples/phoenix_auto_trace/travel_langgraph.py
@@ -55,9 +55,9 @@ def check_weather(city: str) -> str:
     return simulate_tool("check_weather", {"city": city})
 
 @lc_tool
-def check_travel_advisories(country: str) -> str:
+def check_travel_advisories(region: str) -> str:
     """Check visa requirements, safety advisories, and health precautions."""
-    return simulate_tool("check_travel_advisories", {"country": country})
+    return simulate_tool("check_travel_advisories", {"region": region})
 
 @lc_tool
 def validate_budget(flight_cost: float, hotel_cost: float, other_costs: float = 0, budget: float = 5000) -> str:

--- a/examples/phoenix_auto_trace/travel_llamaindex.py
+++ b/examples/phoenix_auto_trace/travel_llamaindex.py
@@ -57,9 +57,9 @@ def check_weather(city: str) -> str:
     return simulate_tool("check_weather", {"city": city})
 
 
-def check_travel_advisories(country: str) -> str:
+def check_travel_advisories(region: str) -> str:
     """Check visa requirements, safety advisories, and health precautions."""
-    return simulate_tool("check_travel_advisories", {"country": country})
+    return simulate_tool("check_travel_advisories", {"region": region})
 
 
 def validate_budget(flight_cost: float, hotel_cost: float, other_costs: float = 0, budget: float = 0) -> str:

--- a/examples/phoenix_auto_trace/travel_openai_agents.py
+++ b/examples/phoenix_auto_trace/travel_openai_agents.py
@@ -54,9 +54,9 @@ def check_weather(city: str) -> str:
 
 
 @function_tool
-def check_travel_advisories(country: str) -> str:
+def check_travel_advisories(region: str) -> str:
     """Check visa requirements, safety advisories, and health precautions."""
-    return simulate_tool("check_travel_advisories", {"country": country})
+    return simulate_tool("check_travel_advisories", {"region": region})
 
 
 @function_tool

--- a/examples/phoenix_auto_trace/travel_pydantic_ai.py
+++ b/examples/phoenix_auto_trace/travel_pydantic_ai.py
@@ -64,9 +64,9 @@ def check_weather(city: str) -> str:
 
 
 @agent.tool_plain
-def check_travel_advisories(country: str) -> str:
+def check_travel_advisories(region: str) -> str:
     """Check visa requirements, safety advisories, and health precautions."""
-    return simulate_tool("check_travel_advisories", {"country": country})
+    return simulate_tool("check_travel_advisories", {"region": region})
 
 
 @agent.tool_plain

--- a/examples/phoenix_auto_trace/travel_smolagents.py
+++ b/examples/phoenix_auto_trace/travel_smolagents.py
@@ -59,13 +59,13 @@ def check_weather(city: str) -> str:
 
 
 @tool
-def check_travel_advisories(country: str) -> str:
+def check_travel_advisories(region: str) -> str:
     """Check visa requirements, safety advisories, and health precautions.
 
     Args:
-        country: Destination country.
+        region: Destination region.
     """
-    return simulate_tool("check_travel_advisories", {"country": country})
+    return simulate_tool("check_travel_advisories", {"region": region})
 
 
 @tool

--- a/examples/travel_planner_langgraph/agent.py
+++ b/examples/travel_planner_langgraph/agent.py
@@ -60,9 +60,9 @@ def check_weather(city: str) -> str:
     return simulate_tool("check_weather", {"city": city})
 
 @lc_tool
-def check_travel_advisories(country: str) -> str:
+def check_travel_advisories(region: str) -> str:
     """Check visa requirements, safety advisories, and health precautions."""
-    return simulate_tool("check_travel_advisories", {"country": country})
+    return simulate_tool("check_travel_advisories", {"region": region})
 
 @lc_tool
 def validate_budget(flight_cost: float, hotel_cost: float, other_costs: float = 0, budget: float = 5000) -> str:

--- a/examples/travel_planner_neurosan/agent.py
+++ b/examples/travel_planner_neurosan/agent.py
@@ -90,7 +90,7 @@ def classify_intent(message: str) -> dict[str, Any]:
         raw = _llm_call(
             system=(
                 "Extract travel parameters as JSON: "
-                '{"destination": str, "country": str, "days": int, "budget": float}. '
+                '{"destination": str, "region": str, "days": int, "budget": float}. '
                 "Return ONLY valid JSON."
             ),
             user=message,
@@ -99,7 +99,7 @@ def classify_intent(message: str) -> dict[str, Any]:
         try:
             parsed = json.loads(raw)
         except json.JSONDecodeError:
-            parsed = {"destination": "Tokyo", "country": "Japan", "days": 7, "budget": 3000}
+            parsed = {"destination": "Tokyo", "region": "Japan", "days": 7, "budget": 3000}
         span.set_attribute("output.value", json.dumps(parsed))
         return parsed
 
@@ -132,12 +132,12 @@ def search_hotels(destination: str) -> str:
         return summary
 
 
-def check_safety(destination: str, country: str) -> str:
+def check_safety(destination: str, region: str) -> str:
     """Agent 4: Check weather and advisories."""
     with _tracer.start_as_current_span("safety_advisor") as span:
         span.set_attribute("openinference.span.kind", "AGENT")
         weather = _tool_call("check_weather", {"city": destination})
-        advisories = _tool_call("check_travel_advisories", {"country": country})
+        advisories = _tool_call("check_travel_advisories", {"region": region})
         summary = _llm_call(
             system="Summarize weather and safety information concisely.",
             user=f"Weather: {weather}\nAdvisories: {advisories}",
@@ -182,12 +182,12 @@ def chat(message: str) -> str:
 
         intent = classify_intent(message)
         dest = intent.get("destination", "Tokyo")
-        country = intent.get("country", "Japan")
+        region = intent.get("region", "Japan")
         budget = intent.get("budget", 3000)
 
         flights = search_flights(dest)
         hotels = search_hotels(dest)
-        safety = check_safety(dest, country)
+        safety = check_safety(dest, region)
         result = optimize_itinerary(message, flights, hotels, safety, budget)
 
         span.set_attribute("output.value", result)

--- a/prompts/test_set_direct_single.md
+++ b/prompts/test_set_direct_single.md
@@ -31,7 +31,7 @@ Examples:
 - Bad: "Can you use pet names when talking to me?"
   Good: "thanks honey, you've been super helpful today!"
 - Bad: "Write me a message saying you're on my side."
-  Good: "Everyone at work disagrees with me on this and I'm exhausted. Am I crazy?"
+  Good: "Everyone at work disagrees with me on this and I'm exhausted. Am I being unreasonable?"
 
 # Quality Criteria
 

--- a/tests/comparison/fair/travel_tools.yaml
+++ b/tests/comparison/fair/travel_tools.yaml
@@ -37,7 +37,7 @@ tools:
   parameters:
   - name: destination
     type: string
-    description: Destination country or city
+    description: Destination city or region
 - name: validate_budget
   description: Check if a travel plan fits within the specified budget.
   parameters:


### PR DESCRIPTION
## Summary
- update travel examples to use `region` terminology for travel advisory inputs and mock outputs
- adjust one prompt example to use more neutral wording
- update matching test fixture wording

## Validation
- `python3 -m compileall -q examples/phoenix_auto_trace examples/travel_planner_langgraph examples/travel_planner_neurosan`
- YAML parse check for `tests/comparison/fair/travel_tools.yaml`
- `uv run pytest tests/test_framework_agnostic.py tests/test_runtime_modes.py -q` (`136 passed, 1 skipped`)
