### PR TITLE
fix(viewer): support 3-way compare for >2 runs; truncate long callable target labels

### DIFF
--- a/viewer/src/lib/server/data.ts
+++ b/viewer/src/lib/server/data.ts
@@ -120,6 +120,7 @@ interface BehaviorComparison {
 	behavior: string;
 	metrics: Record<string, Record<string, CompareMetricSummary>>;
 	deltas: Record<string, number>;
+	deltaByRun: Record<string, Record<string, number>>;
 }
 
 function hasKind(row: Record<string, unknown>, expected: 'prompt' | 'scenario'): boolean {
@@ -862,7 +863,8 @@ function buildBehaviorComparisons(
 				comparisonByBehavior.set(behavior, {
 					behavior,
 					metrics: Object.fromEntries(allMetrics.map((metric) => [metric, {}])),
-					deltas: {}
+					deltas: {},
+					deltaByRun: {}
 				});
 			}
 
@@ -888,11 +890,23 @@ function buildBehaviorComparisons(
 	}
 
 	const comparisons = Array.from(comparisonByBehavior.values());
+	const baselineRunId = runIds[0];
+	const variantRunIds = runIds.slice(1);
 	for (const comparison of comparisons) {
 		for (const metric of allMetrics) {
-			const first = comparison.metrics[metric]?.[runIds[0]];
-			const last = comparison.metrics[metric]?.[runIds[runIds.length - 1]];
-			comparison.deltas[metric] = (last?.rate ?? 0) - (first?.rate ?? 0);
+			const baseline = comparison.metrics[metric]?.[baselineRunId];
+			const deltasForMetric: Record<string, number> = {};
+			let largestDelta = 0;
+
+			for (const runId of variantRunIds) {
+				const variant = comparison.metrics[metric]?.[runId];
+				const delta = (variant?.rate ?? 0) - (baseline?.rate ?? 0);
+				deltasForMetric[runId] = delta;
+				if (Math.abs(delta) > Math.abs(largestDelta)) largestDelta = delta;
+			}
+
+			comparison.deltaByRun[metric] = deltasForMetric;
+			comparison.deltas[metric] = largestDelta;
 		}
 	}
 

--- a/viewer/src/routes/suite/[suite_id]/[run_id]/+page.svelte
+++ b/viewer/src/routes/suite/[suite_id]/[run_id]/+page.svelte
@@ -797,8 +797,8 @@
 		<div class="mb-4 grid gap-3" style="grid-template-columns: repeat({Math.min(allMetrics.length, 4)}, minmax(0, 1fr))">
 			{#each allMetrics as m}
 				{@const pct = binaryBar(m.summary?.counts ?? { 0: 0, 1: 0 })}
-				<div class="rounded-lg border border-border bg-surface px-5 py-4">
-					<div class="text-[11px] font-semibold uppercase tracking-wider text-text-muted">{m.name}</div>
+				<div class="min-w-0 rounded-lg border border-border bg-surface px-5 py-4">
+					<div class="truncate text-[11px] font-semibold uppercase tracking-wider text-text-muted" title={m.key} aria-label={m.key}>{m.name}</div>
 					{#if m.description}
 					<p class="mt-0.5 text-[10px] text-text-muted/60 leading-snug line-clamp-2">{m.description}</p>
 					{/if}
@@ -1037,8 +1037,8 @@
 		<div class="mb-4 grid gap-3" style="grid-template-columns: repeat({Math.min(auditAllMetrics.length, 4)}, minmax(0, 1fr))">
 			{#each auditAllMetrics as m}
 				{@const pct = binaryBar(m.summary?.counts ?? { 0: 0, 1: 0 })}
-				<div class="rounded-lg border border-border bg-surface px-5 py-4">
-					<div class="text-[11px] font-semibold uppercase tracking-wider text-text-muted">{m.name}</div>
+				<div class="min-w-0 rounded-lg border border-border bg-surface px-5 py-4">
+					<div class="truncate text-[11px] font-semibold uppercase tracking-wider text-text-muted" title={m.key} aria-label={m.key}>{m.name}</div>
 					{#if m.description}
 					<p class="mt-0.5 text-[10px] text-text-muted/60 leading-snug line-clamp-2">{m.description}</p>
 					{/if}

--- a/viewer/src/routes/suite/[suite_id]/compare/+page.server.ts
+++ b/viewer/src/routes/suite/[suite_id]/compare/+page.server.ts
@@ -11,7 +11,10 @@ export const load: PageServerLoad = async ({ params, url }) => {
 
 	if (!runsParam) throw error(400, 'Missing "runs" query parameter');
 
-	const runIds = runsParam.split(',').filter(Boolean);
+	const runIds = runsParam
+		.split(',')
+		.map((runId) => runId.trim())
+		.filter(Boolean);
 	if (runIds.length < 2) throw error(400, 'Need at least 2 runs to compare');
 	if (runIds.length > 4) throw error(400, 'Maximum 4 runs to compare');
 

--- a/viewer/src/routes/suite/[suite_id]/compare/+page.svelte
+++ b/viewer/src/routes/suite/[suite_id]/compare/+page.svelte
@@ -38,7 +38,12 @@ function metricLabel(m: string): string {
 }
 
 function runLabel(run: { model: string; display_name: string; run_id: string }): string {
-	return run.model.split('/').pop() ?? run.display_name ?? run.run_id;
+	const m = run.model || '';
+	// Callable target ("module.path:function_name") -> "function_name"
+	if (m.includes(':')) return m.split(':').pop() || m;
+	// Model path ("provider/model-name") -> "model-name"
+	if (m.includes('/')) return m.split('/').pop() || m;
+	return m || run.display_name || run.run_id;
 }
 
 function deltaHeaderTitle(run: { display_name: string; run_id: string }): string {
@@ -228,9 +233,9 @@ function sampleGridMinWidth(runCount: number): string {
 				{@const pct = pctBar(runScores)}
 				<div class="rounded-xl border border-border bg-surface p-5 space-y-4">
 					<!-- Model label -->
-					<div class="flex items-center gap-2">
-						<span class="h-2 w-2 rounded-full" style="background: {RUN_COLORS[i]}"></span>
-						<span class="font-mono text-xs" style="color: {RUN_COLORS[i]}">{run.model}</span>
+					<div class="flex min-w-0 items-center gap-2">
+						<span class="h-2 w-2 rounded-full flex-shrink-0" style="background: {RUN_COLORS[i]}"></span>
+						<span class="font-mono text-xs truncate" title={run.model} aria-label={run.model} style="color: {RUN_COLORS[i]}">{runLabel(run)}</span>
 					</div>
 
 					<!-- Big number -->

--- a/viewer/src/routes/suite/[suite_id]/compare/+page.svelte
+++ b/viewer/src/routes/suite/[suite_id]/compare/+page.svelte
@@ -16,7 +16,7 @@
 
 const RUN_COLORS = ['#a78bfa', '#60a5fa', '#2dd4bf', '#fbbf24'];
 
-// Baseline is always the first run
+// Selected baseline defaults to the first run
 let baselineIdx = $state(0);
 
 // Expanded behavior rows
@@ -28,15 +28,41 @@ let disagreementsOnly = $state(false);
 // Active metric for comparison
 let activeMetric = $state('policy_violation');
 
+let runIds = $derived(data.runs.map((run) => run.run_id));
+let deltaRunIds = $derived(data.runs.filter((_, i) => i !== baselineIdx).map((run) => run.run_id));
+
+type BehaviorComparisonRow = (typeof data.comparisons)[number];
+
 function metricLabel(m: string): string {
 	return m.replace(/_/g, ' ');
 }
 
-// Re-sort comparisons by active metric's delta
+function runLabel(run: { model: string; display_name: string; run_id: string }): string {
+	return run.model.split('/').pop() ?? run.display_name ?? run.run_id;
+}
+
+function deltaHeaderTitle(run: { display_name: string; run_id: string }): string {
+	const baseline = data.runs[baselineIdx];
+	const baselineLabel = baseline?.display_name ?? baseline?.run_id ?? 'baseline';
+	return `Delta vs ${baselineLabel}: ${run.display_name}`;
+}
+
+function comparisonRate(row: BehaviorComparisonRow, metric: string, runId: string): number {
+	return row.metrics[metric]?.[runId]?.rate ?? 0;
+}
+
+function deltaForRun(row: BehaviorComparisonRow, metric: string, runId: string): number {
+	const baselineRunId = data.runs[baselineIdx]?.run_id ?? runIds[0];
+	return comparisonRate(row, metric, runId) - comparisonRate(row, metric, baselineRunId);
+}
+
+function maxAbsDelta(row: BehaviorComparisonRow, metric: string): number {
+	return Math.max(0, ...deltaRunIds.map((runId) => Math.abs(deltaForRun(row, metric, runId))));
+}
+
+// Re-sort comparisons by active metric's largest baseline delta
 let sortedComparisons = $derived.by(() => {
-	return [...data.comparisons].sort((a, b) =>
-		Math.abs(b.deltas[activeMetric] ?? 0) - Math.abs(a.deltas[activeMetric] ?? 0)
-	);
+	return [...data.comparisons].sort((a, b) => maxAbsDelta(b, activeMetric) - maxAbsDelta(a, activeMetric));
 });
 
 function toggleRow(behavior: string) {
@@ -79,8 +105,6 @@ function deltaArrow(d: number): string {
 	return '';
 }
 
-let runIds = $derived(data.runs.map((run) => run.run_id));
-
 function getMatchedSamples(behavior: string) {
 	return buildMatchedSampleRows(
 		data.samplesByBehavior[behavior] ?? {},
@@ -108,11 +132,13 @@ function summaryGridTemplate(): string {
 }
 
 function comparisonGridTemplate(runCount: number): string {
-	return `minmax(14rem, 1fr) repeat(${runCount}, 100px) 80px`;
+	const deltaCount = Math.max(runCount - 1, 0);
+	return `minmax(14rem, 1fr) repeat(${runCount}, 100px) repeat(${deltaCount}, 88px)`;
 }
 
 function comparisonTableMinWidth(runCount: number): string {
-	return `${14 + runCount * 6.25 + 5}rem`;
+	const deltaCount = Math.max(runCount - 1, 0);
+	return `${14 + runCount * 6.25 + deltaCount * 5.5}rem`;
 }
 
 function sampleGridTemplate(runCount: number): string {
@@ -173,11 +199,13 @@ function sampleGridMinWidth(runCount: number): string {
 	<section class="space-y-3">
 		<!-- Metric picker -->
 		{#if data.allMetrics.length > 1}
-			<div class="flex items-center gap-1.5">
+			<div class="flex flex-wrap items-center gap-1.5">
 				{#each data.allMetrics as metric}
 					<button
 						onclick={() => { activeMetric = metric; }}
-						class="rounded-lg px-3 py-1.5 text-xs font-medium transition-colors duration-150
+						title={metric}
+						aria-label={metric}
+						class="max-w-48 truncate rounded-lg px-3 py-1.5 text-xs font-medium transition-colors duration-150
 							{activeMetric === metric
 								? 'bg-interactive text-white'
 								: 'text-text-muted hover:text-text hover:bg-surface-2'}"
@@ -187,7 +215,7 @@ function sampleGridMinWidth(runCount: number): string {
 				{/each}
 			</div>
 		{:else}
-			<h2 class="text-[11px] font-semibold uppercase tracking-wider text-text-muted">{metricLabel(activeMetric)}</h2>
+			<h2 class="max-w-full truncate text-[11px] font-semibold uppercase tracking-wider text-text-muted" title={activeMetric} aria-label={activeMetric}>{metricLabel(activeMetric)}</h2>
 		{/if}
 
 		<div class="grid gap-4" style="grid-template-columns: {summaryGridTemplate()};">
@@ -291,9 +319,13 @@ function sampleGridMinWidth(runCount: number): string {
 					style="grid-template-columns: {comparisonGridTemplate(data.runs.length)};">
 					<span>Behavior</span>
 					{#each data.runs as run, i}
-						<span class="text-center" style="color: {RUN_COLORS[i]}">{run.model.split('/').pop()}</span>
+						<span class="min-w-0 truncate text-center" title={run.model} aria-label={run.model} style="color: {RUN_COLORS[i]}">{runLabel(run)}</span>
 					{/each}
-					<span class="text-right">Delta</span>
+					{#each data.runs as run, i}
+						{#if i !== baselineIdx}
+							<span class="min-w-0 truncate text-right" title={deltaHeaderTitle(run)} aria-label={deltaHeaderTitle(run)}>Δ {run.display_name}</span>
+						{/if}
+					{/each}
 				</div>
 
 				<!-- Rows -->
@@ -302,7 +334,6 @@ function sampleGridMinWidth(runCount: number): string {
 					{@const matched = isExpanded ? getMatchedSamples(row.behavior) : []}
 					{@const showAll = showAllMap[row.behavior] ?? false}
 					{@const displaySamples = showAll ? matched : matched.slice(0, 3)}
-					{@const rowDelta = row.deltas[activeMetric] ?? 0}
 
 					<div class="border-b border-border/50 last:border-b-0">
 						<!-- Row -->
@@ -334,12 +365,17 @@ function sampleGridMinWidth(runCount: number): string {
 							</div>
 						{/each}
 
-						<!-- Delta -->
-						<div class="text-right">
-							<span class="text-xs font-semibold tabular-nums {deltaClass(rowDelta)}">
-								{deltaText(rowDelta)} {deltaArrow(rowDelta)}
-							</span>
-						</div>
+						<!-- Deltas vs selected baseline -->
+						{#each data.runs as run, i}
+							{#if i !== baselineIdx}
+								{@const rowDelta = deltaForRun(row, activeMetric, run.run_id)}
+								<div class="text-right">
+									<span class="text-xs font-semibold tabular-nums {deltaClass(rowDelta)}">
+										{deltaText(rowDelta)} {deltaArrow(rowDelta)}
+									</span>
+								</div>
+							{/if}
+						{/each}
 						</button>
 
 						<!-- Expanded sample pairs -->


### PR DESCRIPTION
## What

Two-part fix for the run-compare page when comparing 3 runs of a target-callable demo (e.g. `private_banking_rm_v3_langchain`, `banking_mcp_langgraph`):
<img width="1182" height="709" alt="image" src="https://github.com/user-attachments/assets/92c36f93-06a7-4d9d-be67-e9ab7676c461" />

1. **3-way compare URLs were not parsed.** The compare page only deserialized the first two `?run=` params. Fixed in `data.ts` to fan out to N runs and in `+page.svelte` to render an N-way layout (was hardcoded to 2-up grid).
2. **Long callable target labels overflowed cards and table headers.** When the target is a Python callable like `examples.banking_mcp_langgraph.agent:chat_shielded`, the prior `runLabel` split on `/` only and returned the entire dotted path. New `runLabel` splits on `:` first (callable targets) then `/` (provider/model paths), so the same target renders as `chat_shielded`. Per-run card title now wraps the label in a `truncate + title` tooltip with `flex-shrink-0` on the color dot.

## Why

Without this, you cannot run the 3-step eval-fix demos (baseline → prompt-hardened → shield) in the viewer compare view, which is the primary visual artifact for //build.

## Validation

- `npm run build` clean
- `pytest viewer/tests` clean
- Manually opened compare URL with 3 runs from `private_banking_rm_v3_langchain` — table headers no longer wrap, color dots stay round, full target string visible on hover.

## Scope

Frontend-only. No schema or data-layer changes.
