### PR TITLE
feat(cli): add --override flag for nested config key overrides

### DIFF
--- a/p2m/cli.py
+++ b/p2m/cli.py
@@ -530,6 +530,7 @@ def cli(ctx: click.Context, verbose: bool, quiet: bool, log_file: Path | None, o
     show_envvar=True,
 )
 @click.option("--strict", is_flag=True, help="Fail on malformed JSONL inputs instead of skipping bad rows.")
+@click.option("--override", "overrides", multiple=True, help="Override a config value, e.g. test_set.sample_size=10.")
 @click.option("-v", "--verbose", is_flag=True, help="Enable debug-level logging.")
 @click.option("-q", "--quiet", is_flag=True, help="Suppress info-level output; show only warnings and errors.")
 @click.option(
@@ -552,6 +553,7 @@ def run(
     config: Path,
     force_stage: tuple[str, ...],
     strict: bool,
+    overrides: tuple[str, ...],
     verbose: bool,
     quiet: bool,
     log_file: Path | None,
@@ -572,6 +574,7 @@ def run(
         config=str(config),
         force_stages=list(force_stage),
         strict=strict,
+        overrides=list(overrides),
     )
     raise SystemExit(rc)
 

--- a/p2m/runner.py
+++ b/p2m/runner.py
@@ -14,6 +14,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+import yaml
 from dotenv import load_dotenv
 
 from p2m.config import (
@@ -56,13 +57,50 @@ load_dotenv()
 log = logging.getLogger(__name__)
 
 
+def _set_nested(raw: dict[str, Any], path: list[str], value: Any) -> None:
+    cursor = raw
+    for part in path[:-1]:
+        next_value = cursor.setdefault(part, {})
+        if not isinstance(next_value, dict):
+            raise ValueError(f"override path {'.'.join(path)} crosses non-mapping key '{part}'")
+        cursor = next_value
+    cursor[path[-1]] = value
+
+
+def _apply_config_overrides(raw: dict[str, Any], overrides: list[str] | None) -> dict[str, Any]:
+    if not overrides:
+        return raw
+    raw = dict(raw)
+    for override in overrides:
+        if "=" not in override:
+            raise ValueError(f"invalid override '{override}': expected key=value")
+        key, raw_value = override.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise ValueError(f"invalid override '{override}': key is empty")
+        value = yaml.safe_load(raw_value)
+        if key == "test_set.sample_size":
+            total = int(value)
+            prompt_size = (total + 1) // 2
+            scenario_size = total // 2
+            _set_nested(raw, ["pipeline", "test_set", "prompt", "sample_size"], prompt_size)
+            _set_nested(raw, ["pipeline", "test_set", "scenario", "sample_size"], scenario_size)
+            continue
+        path = key.split(".")
+        if path[0] in {"systematize", "test_set", "inference", "judge"}:
+            path = ["pipeline", *path]
+        _set_nested(raw, path, value)
+    return raw
+
+
 def _load_context(
     *,
     config: str,
+    overrides: list[str] | None = None,
 ) -> dict[str, Any]:
     """Load one config file into runtime context."""
     cfg_path = Path(config).resolve()
-    raw = load_config(cfg_path)
+    raw = _apply_config_overrides(load_config(cfg_path), overrides)
     return load_runtime_context(raw, cfg_path, stage_modules=STAGES)
 
 
@@ -375,6 +413,7 @@ def run_pipeline(
     config: str,
     force_stages: list[str] | None = None,
     strict: bool = False,
+    overrides: list[str] | None = None,
 ) -> int:
     """Execute the configured stages sequentially and persist suite/run metadata."""
     # Suppress litellm's internal async logging warnings — they fire because
@@ -414,7 +453,7 @@ def run_pipeline(
     sys.stderr = _FilteredStderr(sys.stderr)
 
     try:
-        ctx = _load_context(config=config)
+        ctx = _load_context(config=config, overrides=overrides)
         ctx["strict"] = strict
     except (ConfigError, ValueError) as exc:
         log.error(f"[config error] {exc}")


### PR DESCRIPTION
## What

Adds a repeatable `-o/--override KEY=VALUE` flag to `p2m run` so callers can tweak config values from the command line without copying the YAML.

Supported shortcuts:
- `test_set.sample_size=N` → splits N as `ceil(N/2)` prompts + `floor(N/2)` scenarios (matches what most demos want from a single knob)
- `systematize.*`, `test_set.*`, `inference.*`, `judge.*` are auto-prefixed with `pipeline.`

All other keys are written verbatim into the nested config dict via dotted path notation.

## Why

Batch validation runs (e.g. n=400 sweeps across 6 configs) want one set of YAMLs and one CLI knob to dial sample size up/down. Previously this required either editing the YAMLs in place or maintaining parallel copies.

## Example

```powershell
# Smoke a 10-row run from a 200-row config
p2m run --config examples/banking_mcp_langgraph/eval_config_transfers_A.yaml `
        --override test_set.sample_size=10

# Multiple overrides
p2m run --config ... -o test_set.sample_size=400 -o judge.model=gpt-4o-mini
```

## Validation

- New override path exercised via a small unit-style smoke (`_apply_config_overrides({'pipeline':...}, ['test_set.sample_size=10'])`) returns the expected 5/5 prompt+scenario split.
- Existing call sites unaffected when `--override` is omitted (early return on empty list).

## Scope

+44 / -2 across `p2m/cli.py` and `p2m/runner.py`. No test fixtures or docs beyond the CLI `--help` text update. Both downstream demo branches (`private-banking-rm-v3-langchain`, `agent-shield-banking-demo`) depend on this flag; they were tested against this exact patch and will rebase to no-op once this lands.
