### PR TITLE
Improve error message when viewer encounters outdated artifacts

### DIFF
--- a/p2m/core/runtime_safety.py
+++ b/p2m/core/runtime_safety.py
@@ -448,6 +448,21 @@ def _bounded_loop_teardown(
                     loop.run_until_complete(loop.shutdown_asyncgens())
             except Exception as exc:  # noqa: BLE001
                 err_holder[0] = exc
+            # Cancel all pending tasks (e.g. litellm's LoggingWorker)
+            # before closing the loop. Without this, pending coroutines
+            # get garbage-collected against a closed loop and produce
+            # noisy "Task was destroyed but it is pending!" errors.
+            try:
+                if not loop.is_closed():
+                    pending = asyncio.all_tasks(loop)
+                    for task in pending:
+                        task.cancel()
+                    if pending:
+                        loop.run_until_complete(
+                            asyncio.gather(*pending, return_exceptions=True)
+                        )
+            except Exception as exc:  # noqa: BLE001
+                err_holder[0] = err_holder[0] or exc
             try:
                 executor.shutdown(wait=True, cancel_futures=True)
             except Exception as exc:  # noqa: BLE001

--- a/p2m/viewer_read_model.py
+++ b/p2m/viewer_read_model.py
@@ -170,10 +170,31 @@ def _kind_and_test_case_id(row: dict[str, Any], *, path: Path) -> tuple[str, str
     kind = row.get("type")
     test_case_id = row.get("test_case_id")
     if not isinstance(kind, str) or kind not in {"prompt", "scenario"}:
-        raise ViewerReadModelBuildError(f"Missing or invalid kind in {path}")
+        _raise_schema_hint(row, path, field="type", expected='"prompt" or "scenario"')
     if not isinstance(test_case_id, str) or not test_case_id:
-        raise ViewerReadModelBuildError(f"Missing or invalid test_case_id in {path}")
+        _raise_schema_hint(row, path, field="test_case_id", expected="a non-empty string")
     return kind, test_case_id
+
+
+def _raise_schema_hint(
+    row: dict[str, Any], path: Path, *, field: str, expected: str
+) -> None:
+    """Raise a *ViewerReadModelBuildError* with actionable guidance.
+
+    When cached artifacts are left over from a previous run that used a
+    different schema, the error message tells the user to delete the stale
+    run directory and re-run the pipeline — without exposing internal
+    migration details.
+    """
+    actual_keys = ", ".join(sorted(row.keys())[:10])
+    raise ViewerReadModelBuildError(
+        f'{path.name}: expected field "{field}" ({expected}) but the row '
+        f"contains [{actual_keys}]. The file appears to use an outdated "
+        f"format that is incompatible with the current version of p2m.\n"
+        f"  To fix: delete the run directory\n"
+        f"    rm -rf {path.parent}\n"
+        f"  and re-run the pipeline so all artifacts are regenerated."
+    )
 
 
 def _viewer_index_key(kind: str, test_case_id: str) -> str:


### PR DESCRIPTION
## Summary

Two small fixes for the `p2m` CLI:

### 1. Actionable error message for outdated artifacts

When cached artifacts from a previous run use an older schema (e.g. `kind` instead of `type`), the viewer now shows an actionable error message instead of a generic failure.

**Before**
```
ViewerReadModelBuildError: Missing or invalid kind in /path/to/scores.jsonl
```

**After**
```
scores.jsonl: expected field "type" ("prompt" or "scenario") but the row
contains [auditor_model, concept, judge_error, ...]. The file appears to use
an outdated format that is incompatible with the current version of p2m.
  To fix: delete the run directory
    rm -rf artifacts/results/my-suite/my-run
  and re-run the pipeline so all artifacts are regenerated.
```

- Replace generic errors in `_kind_and_test_case_id` with a `_raise_schema_hint` helper
- Show which field is missing, what was expected, and the actual keys in the row
- Provide a concrete `rm -rf` command pointing at the stale run directory

### 2. Clean shutdown of async tasks (litellm noise fix)

Cancel pending async tasks during event loop teardown in `_bounded_loop_teardown()`. Without this, litellm's internal `LoggingWorker` coroutine gets garbage-collected against a closed loop and produces noisy `Task was destroyed but it is pending!` / `RuntimeError: Event loop is closed` errors on every pipeline run.

- Enumerate and cancel all pending tasks before `loop.close()`, mirroring what `asyncio.run()` does internally
- Validated with 125 live litellm inference calls — no shutdown noise

### Tests
All 58 viewer tests pass.