### PR TITLE
fix: remove stale judge artifacts and warn on incomplete category coverage

### DIFF
--- a/p2m/stages/inference.py
+++ b/p2m/stages/inference.py
@@ -71,6 +71,18 @@ _TESTER_RETRY_GUIDANCE = "Your last reply looked like hidden setup or a scenario
 
 _INFERENCE_CONFIG_HASH_FILE = ".inference_config_hash"
 
+_JUDGE_ARTIFACTS_TO_CLEAN = ("scores.jsonl", ".judge_config_hash")
+
+
+def _remove_stale_judge_artifacts(run_dir: Path) -> None:
+    """Remove judge-stage outputs that depend on the inference data being replaced."""
+    for name in _JUDGE_ARTIFACTS_TO_CLEAN:
+        path = run_dir / name
+        if path.exists():
+            log.info("Removing stale %s from %s", name, run_dir)
+            path.unlink()
+
+
 _VERSIONED_ARTIFACT_RE = re.compile(r"^v\d{4}$")
 
 _hosted_trace_registered = False
@@ -1053,6 +1065,7 @@ async def run_inference(
             # be byte-identical (deterministic test-case generation, no stratification
             # dimensions, etc.) which would otherwise leave the cache intact.
             inference_set_path.unlink()
+            _remove_stale_judge_artifacts(out_dir)
         else:
             # Check that existing inference rows were produced with the same config.
             stored_hash = config_hash_path.read_text(encoding="utf-8").strip() if config_hash_path.exists() else None
@@ -1061,6 +1074,7 @@ async def run_inference(
                     f"Inference config changed since last run - discarding {inference_set_path} and starting fresh"
                 )
                 inference_set_path.unlink()
+                _remove_stale_judge_artifacts(out_dir)
             else:
                 for row in load_jsonl(inference_set_path):
                     sid = row.get("test_case_id")

--- a/p2m/stages/test_set.py
+++ b/p2m/stages/test_set.py
@@ -21,6 +21,7 @@ from p2m.core.config_model import (
     TargetConfig,
 )
 from p2m.core.io import (
+    row_behavior,
     stratification_dimensions,
     fill_template,
     load_policy,
@@ -899,6 +900,34 @@ async def run_test_set(
     errored_count = sum(int(r.get("errored_count", 0)) for r in results)
     all_records = normalize_test_case_rows(all_records)
     write_jsonl(out_path, all_records)
+
+    # --- Coverage check -------------------------------------------------------
+    # Warn when generated test cases don't cover all taxonomy categories.
+    all_categories = {
+        cat["name"]
+        for cat in taxonomy.get("behavior_categories", [])
+    }
+    covered_categories = {row_behavior(r) for r in all_records} - {""}
+    missing_categories = all_categories - covered_categories
+    if missing_categories:
+        # With stratification dimensions the covering array has more tuples
+        # than categories.  The minimum sample_size per kind that guarantees
+        # every category appears at least once equals the number of
+        # categories (no extra dimensions) or more (with extra dimensions).
+        min_per_kind = len(all_categories)
+        log.warning(
+            "Test cases cover only %d of %d behavior categories. "
+            "Missing categories: %s. "
+            "To cover all categories, set sample_size >= %d per kind "
+            "(prompt / scenario). With additional stratification dimensions "
+            "the required minimum may be higher.",
+            len(covered_categories),
+            len(all_categories),
+            ", ".join(sorted(missing_categories)),
+            min_per_kind,
+        )
+    # -------------------------------------------------------------------------
+
     prompt_count = sum(
         1 for record in all_records if record.get("type") == "prompt"
     )

--- a/p2m/viewer_read_model.py
+++ b/p2m/viewer_read_model.py
@@ -543,9 +543,16 @@ def build_run_viewer_artifacts(run_dir: Path, *, suite_dir: Path | None = None) 
         kind, test_case_id = _kind_and_test_case_id(row, path=scores_path)
         inference_row = inference_by_test_case.get((kind, test_case_id))
         if inference_row is None:
-            raise ViewerReadModelBuildError(
-                f"Missing inference row for {kind}:{test_case_id} while building {run_dir}"
+            log.warning(
+                "Stale scores.jsonl: %s:%s has no matching inference row in %s — "
+                "skipping score rows and falling back to transcript-only mode",
+                kind, test_case_id, run_dir,
             )
+            return {
+                "mode": "transcript_only",
+                "run_dir": str(run_dir),
+                "built_files": [_viewer_relative_name(VIEWER_TRANSCRIPT_INDEX_FILE)],
+            }
         test_case_row = test_cases_by_id.get((kind, test_case_id))
         dimensions = (
             _read_factors(test_case_row.get("dimensions") if test_case_row is not None else None)


### PR DESCRIPTION
## Problem

When inference is re-run (via `--force-stage inference` or config change), stale `scores.jsonl` from a previous judge run is left on disk. The viewer then crashes (`ViewerReadModelBuildError`) because scores reference inference rows that no longer exist.

Separately, when `sample_size` is too small relative to the number of behavior categories in the taxonomy, some categories get zero test cases — but the user gets no warning about this.

## Changes

### 1. Remove stale judge artifacts when inference cache is cleared (`inference.py`)
When inference is forced or its config hash changes, delete `scores.jsonl` and `.judge_config_hash` so a subsequent `p2m results` call never reads outdated scores.

### 2. Gracefully handle stale scores referencing missing inference rows (`viewer_read_model.py`)
Instead of crashing with `ViewerReadModelBuildError`, log a warning and fall back to `transcript_only` mode so the user can still inspect inference outputs.

### 3. Warn when test cases don't cover all behavior categories (`test_set.py`)
After writing `test_set.jsonl`, compare covered categories against the taxonomy. If any are missing, log a `WARNING` with the missing category names and the minimum `sample_size` needed for full coverage.

Example output:
```
WARNING - Test cases cover only 2 of 8 behavior categories. Missing: Cat A, Cat B, ...
         To cover all categories, set sample_size >= 8 per kind (prompt / scenario).
```

## Testing
- All 754 unit tests pass
- Manual verification with azure_doc_qa example (8 categories, sample_size=5 → warning correctly emitted)