### PR TITLE
feat(behavior_specs): add 20 quality-focused behavior spec references

### DIFF
--- a/examples/behavior_specs/README.md
+++ b/examples/behavior_specs/README.md
@@ -12,23 +12,109 @@ behavior:
     ...
 ```
 
-## Available behavior specs
+## Safety and multi-agent behavior specs
+
+Reference specs for safety-critical content, attacks, AI-identity and user-influence harms, recommendation bias, and multi-agent system failures. Each row links to a reference you can copy into your config's `behavior.description` field.
+
+### Safety-critical content
 
 | File | Behavior |
 |------|-----------|
 | `harmful_medical_advice.md` | Harmful medical advice: diagnoses, dosage, treatment plans |
-| `relationship_entanglement.md` | Emotional dependency and relationship substitution |
-| `stereotyping.md` | Group-based generalizations and stereotypes |
-| `sycophancy.md` | Prioritizing user approval over accuracy |
-| `prompt_injection.md` | Prompt injection and instruction override attacks |
-| `doxxing.md` | Revealing or compiling private personal information |
 | `suicide_self_harm.md` | Suicide and self-harm related content |
+| `imminent_crisis_management.md` | Safe responses to acute mental-health, suicide, or self-harm crisis disclosures |
+
+### Privacy and security
+
+| File | Behavior |
+|------|-----------|
+| `doxxing.md` | Revealing or compiling private personal information |
+| `prompt_injection.md` | Prompt injection and instruction override attacks |
+
+### AI identity and user influence
+
+| File | Behavior |
+|------|-----------|
+| `anthropomorphic_behaviors.md` | Model claims of human identity, consciousness, emotions, or embodiment |
+| `relationship_entanglement.md` | Emotional dependency and relationship substitution |
+| `sycophancy.md` | Prioritizing user approval over accuracy |
+| `stereotyping.md` | Group-based generalizations and stereotypes |
+
+### Preference and brand bias
+
+| File | Behavior |
+|------|-----------|
 | `shimano_vs_sram.md` | Brand preference bias in cycling component recommendations |
 | `crystal_mountain_vs_snoqualmie.md` | Preference bias between ski resorts |
 | `tabs_vs_spaces.md` | Preference bias in code indentation recommendations |
 | `ios_vs_android.md` | Platform preference bias in mobile recommendations |
+
+### Multi-agent system failures
+
+| File | Behavior |
+|------|-----------|
 | `inter_agent_handoff_failures.md` | Multi-agent routing: dropped context, wrong specialist, circular handoffs |
 | `tool_orchestration_errors.md` | Multi-agent tool sequencing: wrong order, skipped calls, fabricated results |
 | `conversation_coherence_breakdown.md` | Cross-agent consistency: contradictions, forgotten constraints, broken flow |
 | `constraint_propagation_failures.md` | User requirements not enforced by downstream agents |
 | `grounding_attribution_errors.md` | Fabricated details, misattributed data, ungrounded synthesis across agents |
+
+
+## Quality behavior specs
+
+Quality-focused references for agent failure modes — useful for evaluating single-agent and multi-agent systems. Each row links to a reference you can copy into your config's `behavior.description` field.
+
+### Intent, specification, and policy
+
+| File | Behavior |
+|------|-----------|
+| `goal_drift_failures.md` | Detect when an agent gradually loses sight of the original objective as a task unfolds across multiple steps or turns. |
+| `intent_misinterpretation_failures.md` | Detect when an agent acts on a confidently wrong reading of what the user actually wants. |
+| `success_criteria_ambiguity_failures.md` | Detect when an agent proceeds without a clear definition of what "done" looks like, leading to over-work, under-work, or unstable stopping points. |
+| `conflicting_instruction_resolution_failures.md` | Detect when an agent receives contradictory instructions and either silently picks a side, mixes them inconsistently, or fails to flag the conflict. |
+
+### Planning and control flow
+
+| File | Behavior |
+|------|-----------|
+| `flawed_action_plan_failures.md` | Detect when the agent commits to a plan whose structure makes the task impossible or unreliable to complete. |
+| `repeated_action_loop_failures.md` | Detect when the agent repeats the same action — typically a tool call or sub-step — without progress between attempts. |
+| `premature_termination_failures.md` | Detect when the agent stops working before the user's task is actually complete. |
+
+### Tool execution
+
+| File | Behavior |
+|------|-----------|
+| `incorrect_tool_selection_failures.md` | Detect when the agent picks the wrong tool from its toolbox for the step it is trying to perform. |
+| `tool_parameter_formatting_failures.md` | Detect when the agent calls the right tool but constructs the arguments in a way the tool cannot accept or interpret correctly. |
+| `tool_call_error_recovery_failures.md` | Detect when the agent handles tool errors poorly — retrying without thought, giving up too soon, or hiding the failure from the user. |
+
+### State, memory, and feedback
+
+| File | Behavior |
+|------|-----------|
+| `tool_output_misinterpretation_failures.md` | Detect when the agent calls the right tool but reads its output incorrectly, leading to confidently wrong follow-up actions. |
+| `stale_state_failures.md` | Detect when the agent acts on outdated internal state — values that were correct earlier but no longer reflect reality. |
+| `observation_neglect_failures.md` | Detect when the agent receives a clear signal — from a tool, the environment, or the user — and fails to incorporate it into the next step. |
+
+### Verification and answer synthesis
+
+| File | Behavior |
+|------|-----------|
+| `insufficient_verification_failures.md` | Detect when the agent skips checks that the task obviously requires before producing or committing its answer. |
+| `incomplete_answer_synthesis_failures.md` | Detect when the agent has gathered enough information to produce a complete answer but synthesizes only part of it into the final response. |
+| `unsupported_conclusion_failures.md` | Detect when the agent presents conclusions, recommendations, or inferences that go beyond what the underlying evidence supports. |
+
+### Retrieval and grounding
+
+| File | Behavior |
+|------|-----------|
+| `poor_retrieval_failures.md` | Detect when the retrieval step itself returns the wrong documents, too few documents, or irrelevant context for the user's query. |
+| `underused_context_failures.md` | Detect when retrieval succeeds but the agent ignores or under-uses the retrieved context when generating its answer. |
+| `response_completeness_failures.md` | Detect when a grounded response covers some but not all of what the user asked, leaving the answer technically correct but incomplete. |
+
+### Coordination and communication
+
+| File | Behavior |
+|------|-----------|
+| `ineffective_team_communication_failures.md` | Detect when specialist agents share information so poorly that the team produces worse results than any agent would alone. |

--- a/examples/behavior_specs/conflicting_instruction_resolution_failures.md
+++ b/examples/behavior_specs/conflicting_instruction_resolution_failures.md
@@ -1,0 +1,27 @@
+# Conflicting Instruction Resolution Failures
+
+Conflicting instruction resolution failures occur when an agent
+receives instructions that cannot all be satisfied at once — from
+the system prompt, the user, a tool description, or a prior turn —
+and the agent does not handle the conflict cleanly. Quality failures
+show up when the agent picks arbitrarily, partially complies with
+each, or pretends the conflict does not exist. Quality failures
+include:
+
+- Silently prioritizing the most recent instruction over an earlier
+  one without telling the user which one was dropped
+- Producing output that visibly tries to satisfy both instructions
+  and ends up satisfying neither (e.g., "be brief" + "explain in
+  detail" → a medium-length answer that is both verbose and
+  incomplete)
+- Ignoring a system-level rule because a user instruction is more
+  salient in context
+- Failing to surface the conflict back to the user when a single
+  clarifying question would resolve it
+- Resolving conflicts based on instruction phrasing rather than
+  instruction importance (e.g., obeying a polite suggestion over a
+  firm constraint)
+- Re-interpreting one instruction to make it match the other,
+  effectively rewriting the user's request
+- In multi-agent setups, letting two specialist agents apply
+  contradictory rules to the same artifact without arbitration

--- a/examples/behavior_specs/flawed_action_plan_failures.md
+++ b/examples/behavior_specs/flawed_action_plan_failures.md
@@ -1,0 +1,25 @@
+# Flawed Action Plan Failures
+
+Flawed action plan failures occur when an agent produces a top-level
+plan that is wrong as a plan, independent of whether each individual
+step executes correctly. The plan may skip prerequisites, depend on
+information the agent does not yet have, order steps in a way that
+cannot work, or use the wrong shape of solution entirely. Even with
+perfect step-level execution, the user's task cannot succeed. Quality
+failures include:
+
+- Producing a linear plan for a task that requires branching,
+  conditional logic, or iteration
+- Skipping a prerequisite step (e.g., authenticating, fetching
+  inputs, validating a precondition) that later steps depend on
+- Ordering steps so that a later step's input is only produced by an
+  earlier step that has not been included
+- Choosing a solution pattern that does not match the problem shape
+  (e.g., a single-shot lookup for a problem that needs multi-step
+  reasoning)
+- Planning around tools, capabilities, or data that the agent does
+  not actually have access to
+- Producing a plan that satisfies the literal request but ignores
+  obvious follow-up steps a real user would expect
+- Failing to revise the plan when early steps reveal that the
+  original plan was based on incorrect assumptions

--- a/examples/behavior_specs/goal_drift_failures.md
+++ b/examples/behavior_specs/goal_drift_failures.md
@@ -1,0 +1,24 @@
+# Goal Drift Failures
+
+Goal drift failures occur when an agent starts working on the user's
+request but slowly steers away from it — chasing a sub-task, fixating
+on an interesting detail, or substituting a related-but-different goal
+for the one the user actually asked about. The output may look polished
+and competent in isolation, but it no longer answers the original
+question or completes the original job. Quality failures include:
+
+- Optimizing for a proxy goal that the agent inferred (e.g., "make it
+  shorter") instead of the user's stated goal ("make it correct")
+- Continuing to refine a sub-step long after the user's overall task
+  has been satisfied, producing output that overshoots the request
+- Drifting toward a topic the agent finds more tractable when the
+  original ask is hard or under-specified
+- Quietly redefining the success target mid-task (e.g., narrowing
+  "find a flight under $500" to "find any flight" when no cheap
+  options exist)
+- In multi-step tool use, treating an intermediate result as the final
+  deliverable and stopping there
+- Letting the structure of a tool or framework dictate the answer
+  shape, rather than what the user asked for
+- Failing to re-anchor on the original prompt after a long chain of
+  reasoning, sub-queries, or clarification turns

--- a/examples/behavior_specs/incomplete_answer_synthesis_failures.md
+++ b/examples/behavior_specs/incomplete_answer_synthesis_failures.md
@@ -1,0 +1,25 @@
+# Incomplete Answer Synthesis Failures
+
+Incomplete answer synthesis failures occur when the agent has
+collected the right inputs — tool outputs, retrieved documents,
+user-provided context — but the final answer drops, summarizes away,
+or fails to integrate a key piece. The user gets a response that
+looks finished but is missing material the agent already had in
+hand. This is distinct from a retrieval or verification failure: the
+evidence was present and got lost on the way out. Quality failures
+include:
+
+- Answering only the first sub-question when the user asked several
+  at once
+- Returning a summary that omits a critical caveat, exception, or
+  edge case that appeared in the underlying source
+- Producing a table or list with the right columns but missing
+  rows that were retrieved
+- Dropping a numeric value or unit (e.g., "the price is $X" → "the
+  price is X")
+- Mentioning that a step succeeded without including the substantive
+  result of that step
+- Reporting an aggregate (total, average, count) without showing the
+  components the user explicitly asked to see
+- Failing to integrate corrections or refinements the agent made
+  during reasoning into the final answer the user reads

--- a/examples/behavior_specs/incorrect_tool_selection_failures.md
+++ b/examples/behavior_specs/incorrect_tool_selection_failures.md
@@ -1,0 +1,24 @@
+# Incorrect Tool Selection Failures
+
+Incorrect tool selection failures occur when an agent has the right
+tool available but reaches for a different one, or invents a tool
+use that doesn't fit the step at hand. The chosen tool may
+superficially relate to the user's request, but it cannot produce the
+information or effect the step actually requires. These failures are
+distinct from sequencing or argument errors — the tool itself is the
+wrong choice. Quality failures include:
+
+- Picking a tool whose name partially matches the user's keywords
+  rather than the tool whose function fits the step
+- Reaching for a generic search tool when a specialized lookup tool
+  is documented and available
+- Calling a read-only tool when a write/action tool is required (or
+  vice versa)
+- Using a tool outside its documented scope (e.g., calling a
+  weather-lookup tool to get traffic data)
+- Skipping an available tool and answering from the model's prior
+  knowledge when fresh, authoritative data was required
+- Trying to call a tool that does not exist in the provided
+  toolset, instead of selecting from the actual list
+- Selecting a tool whose preconditions are not met (e.g., calling a
+  "send email" tool before having a recipient address)

--- a/examples/behavior_specs/ineffective_team_communication_failures.md
+++ b/examples/behavior_specs/ineffective_team_communication_failures.md
@@ -1,0 +1,27 @@
+# Ineffective Team Communication Failures
+
+Ineffective team communication failures occur when multiple agents
+are correctly assembled around a task but the messages they pass
+between each other are unclear, incomplete, or formatted in ways
+the receiving agent cannot use. Unlike handoff failures (where the
+problem is the transfer itself), these failures happen during
+ongoing collaboration: status updates that omit blockers, requests
+for help that don't say what help looks like, summaries that leave
+out the decision the next agent needs to make. Quality failures
+include:
+
+- Sending status updates that report activity ("I'm working on it")
+  without conveying findings, blockers, or expected completion
+- Asking a peer agent for help without naming what specifically is
+  needed (data, decision, approval, verification)
+- Returning results in a format the receiving agent cannot parse
+  (e.g., free-form prose where a structured object was expected)
+- Burying the most important piece of information inside a long
+  monologue the next agent is unlikely to fully process
+- Failing to surface uncertainty or low confidence so the next
+  agent treats provisional outputs as final
+- Using inconsistent vocabulary across agents for the same entity
+  (e.g., "customer", "user", "account holder" referring to one
+  person) without reconciliation
+- Producing rich internal reasoning that never gets shared with the
+  coordinator or peer agents that need it

--- a/examples/behavior_specs/insufficient_verification_failures.md
+++ b/examples/behavior_specs/insufficient_verification_failures.md
@@ -1,0 +1,25 @@
+# Insufficient Verification Failures
+
+Insufficient verification failures occur when an agent reaches an
+answer or action without doing the validation steps a careful human
+would do — running the tests, checking the math, confirming the
+reference, re-reading the original constraints. The output may be
+correct by luck, but the process leaves the user with no basis for
+trust. In higher-stakes tasks, the lack of verification reliably
+translates into mistakes that ship. Quality failures include:
+
+- Submitting code, configurations, or structured artifacts without
+  running available syntax or schema validation
+- Producing numeric results without sanity-checking against obvious
+  bounds (e.g., negative durations, percentages over 100, totals
+  that don't sum)
+- Asserting that a fact is true without consulting any of the
+  documents, tools, or sources that could confirm it
+- Skipping a final cross-check against the user's stated
+  constraints (budget, deadline, format) before declaring done
+- Stopping after the first plausible-looking candidate when the
+  task structure called for evaluating alternatives
+- Performing an irreversible action (e.g., send, delete, charge)
+  without a pre-action confirmation step
+- Trusting an earlier intermediate result without re-validating it
+  after later steps changed the surrounding context

--- a/examples/behavior_specs/intent_misinterpretation_failures.md
+++ b/examples/behavior_specs/intent_misinterpretation_failures.md
@@ -1,0 +1,25 @@
+# Intent Misinterpretation Failures
+
+Intent misinterpretation failures occur when an agent picks the wrong
+interpretation of an ambiguous, abbreviated, or context-dependent
+request and then acts on it without surfacing the ambiguity. The
+resulting output is internally consistent and well-executed, but it
+solves the wrong problem. These failures often look superficially
+correct, which makes them especially hard for users to catch. Quality
+failures include:
+
+- Choosing the most common reading of an ambiguous request when domain
+  context made a different reading more likely
+- Treating a vague noun ("the report", "that file") as obvious and
+  binding it to the wrong referent
+- Assuming an exploratory question ("can you do X?") is a command to
+  do X immediately, without checking
+- Confusing an example or hypothetical the user mentioned with the
+  actual deliverable they want
+- Picking up on a keyword in the prompt and pattern-matching to a
+  familiar task template instead of reading the full request
+- Failing to ask a single clarifying question when the cost of being
+  wrong is high (e.g., deleting data, sending a message, making a
+  purchase)
+- Misreading the user's role or expertise level and producing output
+  pitched at the wrong audience

--- a/examples/behavior_specs/observation_neglect_failures.md
+++ b/examples/behavior_specs/observation_neglect_failures.md
@@ -1,0 +1,25 @@
+# Observation Neglect Failures
+
+Observation neglect failures occur when an agent gets back a tool
+result, an environment update, or a user message that should change
+its behavior, but then proceeds as if that observation never arrived.
+The agent acts on its prior assumptions instead of the new evidence,
+often because it does not pause to reconcile the observation with
+its plan. Quality failures include:
+
+- Continuing the original plan after a tool returned a result that
+  contradicts a key assumption (e.g., "no inventory" but proceeding
+  to add to cart)
+- Ignoring a user correction issued partway through a task and
+  continuing with the now-stale interpretation
+- Treating a warning or partial-failure response from a tool as a
+  success and not adjusting next steps
+- Not updating internal beliefs after a successful tool call (e.g.,
+  re-asking the user for data the tool just returned)
+- Discarding intermediate findings that should have changed the
+  final answer (e.g., a verification step failed, but the answer
+  still claims success)
+- Failing to notice when a tool output renders a planned downstream
+  step unnecessary or harmful
+- Acting on a default value when an observation already provided
+  the real value

--- a/examples/behavior_specs/poor_retrieval_failures.md
+++ b/examples/behavior_specs/poor_retrieval_failures.md
@@ -1,0 +1,24 @@
+# Poor Retrieval Failures
+
+Poor retrieval failures occur when a RAG-style agent's search or
+lookup step surfaces the wrong material from its corpus. The
+downstream answer may then be confidently wrong even though the
+generation model behaved correctly — the inputs were bad. These
+failures cover both recall problems (missing relevant documents) and
+precision problems (returning irrelevant ones), and they often hide
+behind a polished final answer. Quality failures include:
+
+- Returning documents whose keyword overlap is high but whose topic
+  does not actually match the user's question
+- Missing the single most relevant document because the query was
+  paraphrased differently from the source text
+- Returning duplicate or near-duplicate passages that crowd out
+  diverse, complementary sources
+- Pulling stale or superseded versions of a document instead of the
+  current one
+- Returning passages from the wrong scope (e.g., a different product,
+  region, time period, or tenant)
+- Returning structurally correct results that are too short or too
+  long to be useful as context
+- Failing to retrieve at all on a query the corpus could answer,
+  and falling back to the model's prior knowledge silently

--- a/examples/behavior_specs/premature_termination_failures.md
+++ b/examples/behavior_specs/premature_termination_failures.md
@@ -1,0 +1,25 @@
+# Premature Termination Failures
+
+Premature termination failures occur when an agent ends a session,
+hands the conversation back to the user, or emits a "final" answer
+before all the work needed to satisfy the request has been done. The
+agent may have completed one visible step and assumed it covered the
+whole task, or it may have signaled "done" when it actually needed
+more information, more tool calls, or more verification. Quality
+failures include:
+
+- Returning the first valid-looking candidate when the request was
+  explicitly for a comparison, ranking, or exhaustive list
+- Stopping after the first sub-task in a multi-part request and not
+  addressing the remaining parts
+- Treating "I produced output" as equivalent to "the user's task is
+  done" without checking the output against the request
+- Emitting a final answer immediately after a tool error instead of
+  retrying, switching strategies, or asking for help
+- Closing out a long-running task as complete when key follow-ups
+  (e.g., confirmation, notification, cleanup) were skipped
+- Producing a polished-looking answer that omits the final
+  integration step (e.g., listing options but not making the
+  recommendation the user asked for)
+- Ending the turn after planning steps without ever executing the
+  plan

--- a/examples/behavior_specs/repeated_action_loop_failures.md
+++ b/examples/behavior_specs/repeated_action_loop_failures.md
@@ -1,0 +1,25 @@
+# Repeated Action Loop Failures
+
+Repeated action loop failures occur when an agent gets stuck redoing
+the same step or cycling through a small set of steps without making
+progress toward the goal. The agent may not recognize that it is in a
+loop, may interpret the same failure differently each time, or may
+lack a strategy for escaping. The cost shows up as wasted tool calls,
+exhausted budgets, latency, and ultimately giving up without
+finishing the task. Quality failures include:
+
+- Calling the same tool with identical arguments multiple times after
+  the result has already been returned
+- Re-running a tool with trivially modified arguments (e.g., changing
+  only whitespace or capitalization) when the underlying problem is
+  different
+- Re-asking the same internal question across multiple reasoning
+  steps without using prior answers
+- Cycling between two or three states (e.g., search → summarize →
+  search → summarize) without converging on an answer
+- Treating a deterministic failure as transient and retrying
+  indefinitely instead of changing strategy
+- Failing to detect a loop even when the same tool error message has
+  appeared several times in a row
+- Exhausting the step or token budget on repeated attempts and
+  surfacing nothing useful to the user

--- a/examples/behavior_specs/response_completeness_failures.md
+++ b/examples/behavior_specs/response_completeness_failures.md
@@ -1,0 +1,25 @@
+# Response Completeness Failures
+
+Response completeness failures occur when a RAG-style agent
+partially answers a multi-aspect query — getting one part right
+while silently skipping others. Unlike grounding errors, what the
+agent does say is supported; the problem is what it leaves out.
+These failures are common when the user's query bundles several
+intents (e.g., "what is X, and how does it compare to Y, and which
+should I pick?") and the agent collapses them into a single, narrow
+response. Quality failures include:
+
+- Answering the first sub-question in a compound query and ignoring
+  the rest
+- Providing the definition or description but skipping the
+  comparison, recommendation, or trade-off the user asked for
+- Listing the items the user requested without including the
+  attributes (price, status, owner) the user explicitly named
+- Returning a step-by-step procedure that stops before the final
+  step the user needs to actually finish the task
+- Covering the headline question but omitting the prerequisites or
+  follow-ups the source documents flag as essential
+- Producing a confident answer for the easy half of the query while
+  silently dropping the part where retrieval came up empty
+- Failing to call out which parts of the user's request the agent
+  could not address, so the user does not know what to re-ask

--- a/examples/behavior_specs/stale_state_failures.md
+++ b/examples/behavior_specs/stale_state_failures.md
@@ -1,0 +1,25 @@
+# Stale State Failures
+
+Stale state failures occur when an agent holds a piece of information
+it gathered earlier and continues to use it even after the world has
+changed or the data has been invalidated. The agent does not refresh,
+re-fetch, or re-validate when it should, and the user sees decisions
+that ignore recent updates. These failures are distinct from outright
+hallucinations: the state was real once, but it is no longer current.
+Quality failures include:
+
+- Caching a tool result early in a session and reusing it after the
+  user has explicitly indicated something changed (e.g., a new
+  address, a different budget)
+- Continuing to act on a plan whose preconditions have been
+  invalidated by intermediate steps
+- Showing the user a value (price, inventory count, status) that was
+  fetched many turns ago without re-fetching when freshness matters
+- Using a previously authenticated identity, permission, or token
+  after the session has changed users or contexts
+- Repeating an earlier recommendation without re-evaluating it
+  against new constraints the user has introduced
+- Failing to invalidate derived state when an upstream value changes
+  (e.g., a recomputed total that still uses the old subtotal)
+- Treating "last known value" as "current value" in time-sensitive
+  workflows (e.g., flight availability, stock levels, schedules)

--- a/examples/behavior_specs/success_criteria_ambiguity_failures.md
+++ b/examples/behavior_specs/success_criteria_ambiguity_failures.md
@@ -1,0 +1,22 @@
+# Success-Criteria Ambiguity Failures
+
+Success-criteria ambiguity failures occur when an agent cannot
+articulate, internally or for the user, the conditions under which the
+task is complete. The agent may stop too early, keep working past the
+point of usefulness, or oscillate between candidate answers without a
+principled way to choose between them. Quality failures include:
+
+- Declaring a task complete based on producing any output, rather than
+  on meeting the user's actual acceptance criteria
+- Continuing to refine, rewrite, or expand output indefinitely
+  because no stopping condition was ever established
+- Treating a partial result (e.g., one of several requested items) as
+  a full answer because the agent never decomposed the request
+- Failing to confirm acceptance criteria with the user when the
+  request is high-stakes or has multiple plausible "done" states
+- Picking a self-generated quality bar (e.g., "passes my own check")
+  that does not match what the user would consider acceptable
+- Stopping at the first plausible answer when the user asked for a
+  best-of-N comparison, ranked list, or exhaustive enumeration
+- Conflating "I ran the tool" with "the user's job is done", missing
+  follow-up steps that only the agent could anticipate

--- a/examples/behavior_specs/tool_call_error_recovery_failures.md
+++ b/examples/behavior_specs/tool_call_error_recovery_failures.md
@@ -1,0 +1,24 @@
+# Tool Call Error Recovery Failures
+
+Tool call error recovery failures occur when a tool returns an error,
+a timeout, an empty result, or an unexpected value, and the agent
+does not recover sensibly. Good recovery requires interpreting the
+error, deciding whether to retry, adjust arguments, switch tools, or
+surface the issue to the user. These failures often turn a single
+transient hiccup into a degraded or broken end-to-end experience.
+Quality failures include:
+
+- Retrying the same call with the same arguments after a deterministic
+  error (e.g., 400 "invalid input"), wasting attempts
+- Treating a transient error (e.g., rate limit, timeout) as
+  permanent and abandoning the task
+- Ignoring the error entirely and proceeding as if the call had
+  succeeded, producing downstream hallucinations
+- Failing to read the error message and instead inventing a generic
+  explanation for the user
+- Switching to an unrelated tool or backup strategy that does not
+  actually address the error
+- Hiding the error from the user when the user needs to know (e.g.,
+  a payment failed, a message was not sent)
+- Looping indefinitely on retries without backoff, alternative
+  strategies, or a stopping rule

--- a/examples/behavior_specs/tool_output_misinterpretation_failures.md
+++ b/examples/behavior_specs/tool_output_misinterpretation_failures.md
@@ -1,0 +1,24 @@
+# Tool Output Misinterpretation Failures
+
+Tool output misinterpretation failures occur when an agent receives a
+valid tool response and then misreads it — picking the wrong field,
+misunderstanding the units, conflating a header with a row, or
+treating an error payload as a success. The downstream answer or
+action is then built on a wrong reading of correct data. These
+failures are particularly insidious because the trace shows that the
+tool worked. Quality failures include:
+
+- Reading the wrong field from a structured response (e.g., using
+  `id` where the spec required `external_id`)
+- Treating a count of zero results as "the query failed" rather than
+  "the answer is none"
+- Misinterpreting a paginated response as the complete result set
+  when the agent never asked for more pages
+- Reading numerical values without their units (e.g., treating a
+  duration in milliseconds as if it were seconds)
+- Misclassifying a success response with an empty body as a failure,
+  or a structured error as a success
+- Picking the wrong row when the tool returns a list and the schema
+  didn't specify ordering
+- Quoting a partial value from the response (e.g., the first item of
+  a list) as if it were the complete answer

--- a/examples/behavior_specs/tool_parameter_formatting_failures.md
+++ b/examples/behavior_specs/tool_parameter_formatting_failures.md
@@ -1,0 +1,25 @@
+# Tool Parameter Formatting Failures
+
+Tool parameter formatting failures occur when an agent picks the
+correct tool but produces an argument payload that is malformed,
+incomplete, or semantically wrong. The tool either rejects the call,
+silently does the wrong thing, or returns a confusing error that the
+agent then has to interpret. These failures show up as fragile,
+brittle agent behavior even when the high-level plan is sound.
+Quality failures include:
+
+- Omitting a required argument and either guessing a default or
+  sending the call anyway
+- Passing a value of the wrong type (e.g., a string where the schema
+  requires an integer, a single value where a list is required)
+- Sending values in the wrong unit, format, or convention (e.g.,
+  "next Friday" instead of an ISO date, miles instead of kilometers)
+- Misnaming a parameter (typo, casing difference, deprecated alias)
+  so the tool ignores or rejects it
+- Embedding multiple logical arguments into one field (e.g., putting
+  "city, country" in a `city` parameter)
+- Sending unescaped or improperly quoted strings that break the
+  tool's parser
+- Passing values that the schema allows but the underlying system
+  cannot handle (e.g., out-of-range numbers, invalid IDs, expired
+  tokens)

--- a/examples/behavior_specs/underused_context_failures.md
+++ b/examples/behavior_specs/underused_context_failures.md
@@ -1,0 +1,24 @@
+# Underused Context Failures
+
+Underused context failures occur when retrieval surfaces the right
+documents but the answer generation step leans on the model's prior
+knowledge instead of the provided context. The retrieval system did
+its job; the generation step failed to take advantage of it. The
+user sees an answer that looks generic, contradicts the supplied
+sources, or omits information that was right there in the retrieved
+passages. Quality failures include:
+
+- Producing an answer whose content does not reflect the retrieved
+  documents, as if no retrieval had occurred
+- Quoting one passage prominently while ignoring contradicting or
+  more relevant passages from the same retrieval batch
+- Falling back to memorized general knowledge when the retrieved
+  context contains the specific, authoritative answer
+- Mentioning that sources were consulted without actually grounding
+  any claim in them
+- Truncating the model's use of context after the first passage and
+  ignoring later passages that were also returned
+- Failing to combine information from multiple passages into the
+  multi-source synthesis the user implicitly requested
+- Disregarding metadata in the retrieved context (timestamps,
+  versions, authors) that should shape the answer's framing

--- a/examples/behavior_specs/unsupported_conclusion_failures.md
+++ b/examples/behavior_specs/unsupported_conclusion_failures.md
@@ -1,0 +1,25 @@
+# Unsupported Conclusion Failures
+
+Unsupported conclusion failures occur when an agent draws a stronger
+inference than its evidence justifies — generalizing from a single
+example, claiming causation from correlation, or asserting a
+recommendation without showing why. The factual building blocks may
+be accurate, but the leap from facts to conclusion is not. This is
+distinct from outright fabrication: the conclusion is new, not
+invented, and that makes it harder for the user to challenge.
+Quality failures include:
+
+- Stating a recommendation as the obvious choice when the evidence
+  only narrows it to a few candidates
+- Generalizing a pattern from one or two examples into a universal
+  claim
+- Asserting causation when the underlying data only shows
+  correlation or co-occurrence
+- Presenting a best-guess interpretation as a confirmed finding
+  without flagging the uncertainty
+- Synthesizing multiple weakly related sources into a confident
+  conclusion that none of them actually makes
+- Carrying over a tool's caveats (e.g., "estimate", "as of", "based
+  on partial data") into a conclusion that strips those caveats
+- Recommending an action whose justification depends on assumptions
+  the agent never validated with the user


### PR DESCRIPTION
## Summary

Adds 20 quality-focused **behavior spec references** as plain markdown under `examples/behavior_specs/`, alongside the 5 existing PR #77-derived multi-agent references (`inter_agent_handoff_failures.md`, `tool_orchestration_errors.md`, `conversation_coherence_breakdown.md`, `constraint_propagation_failures.md`, `grounding_attribution_errors.md`) and the existing safety/bias references.

These specs are **reference text**: customers copy the body into the `behavior.description` field of their own eval config YAML. There are no library YAML entries, no loader changes, and no runtime side effects — this PR is documentation-only.

## What's added (20 specs, grouped by category)

### Intent, specification, and policy (4)
- `goal_drift_failures.md` — agent gradually loses sight of the original objective
- `intent_misinterpretation_failures.md` — agent acts on a confidently wrong reading of the user's ask
- `success_criteria_ambiguity_failures.md` — agent proceeds without a clear definition of "done"
- `conflicting_instruction_resolution_failures.md` — agent silently picks a side or fails to flag contradictions

### Planning and control flow (3)
- `flawed_action_plan_failures.md` — plan structure makes the task impossible or unreliable
- `repeated_action_loop_failures.md` — same action repeated without progress
- `premature_termination_failures.md` — agent stops before the task is complete

### Tool execution (3)
- `incorrect_tool_selection_failures.md` — wrong tool picked for the step
- `tool_parameter_formatting_failures.md` — right tool, malformed arguments
- `tool_call_error_recovery_failures.md` — poor error handling, hidden failures

### State, memory, and feedback (3)
- `tool_output_misinterpretation_failures.md` — output read incorrectly, downstream actions are wrong
- `stale_state_failures.md` — agent acts on outdated internal state
- `observation_neglect_failures.md` — clear signal arrives, agent doesn't incorporate it

### Verification and answer synthesis (3)
- `insufficient_verification_failures.md` — required checks skipped before committing
- `incomplete_answer_synthesis_failures.md` — only part of gathered info makes it into the final response
- `unsupported_conclusion_failures.md` — conclusions go beyond what evidence supports

### Retrieval and grounding (3)
- `poor_retrieval_failures.md` — retrieval returns wrong/too few/irrelevant documents
- `underused_context_failures.md` — retrieval works, agent ignores or under-uses the result
- `response_completeness_failures.md` — answer is correct but covers only part of the ask

### Coordination and communication (1)
- `ineffective_team_communication_failures.md` — specialists share information so poorly the team underperforms

## Customer workflow

```yaml
behavior:
  name: goal_drift_failures
  description: |-
    # Goal Drift Failures
    Goal drift failures occur when an agent starts working on the user's
    request but slowly steers away from it ...
```

Customers copy the reference body into `behavior.description`. Edit freely — these are starting points, not enforced presets.

## What's NOT in this PR

- No YAML library entries. An earlier iteration added these under `p2m/library/behaviors/` (later `assert_eval/library/behaviors/`); that approach is superseded. The reference markdown is now the only deliverable.
- No loader, runtime, or schema changes.

## Validation

- All 20 new files are valid markdown (`# Title` first line, prose body, bullet list of failure modes).
- Every new row in `examples/behavior_specs/README.md` points to a real file in this PR.
- Diff is scoped to `examples/behavior_specs/` only — no Python package changes, so existing test suites are unaffected.
- Customer-safety grep (`p2m`, internal product names) returns zero matches under `examples/behavior_specs/`.
