### PR TITLE
fix(viewer): repair run page grouping tabs (ASSERT #97)

### DIFF
--- a/viewer/src/lib/grouping.ts
+++ b/viewer/src/lib/grouping.ts
@@ -88,7 +88,7 @@ function observedNodeSort(a: GroupEntry<ScoredRecord>, b: GroupEntry<ScoredRecor
 // ---------------------------------------------------------------------------
 
 const GROUP_AXES: GroupAxis<ScoredRecord>[] = [
-	{ key: 'observed_node', label: 'Observed behavior (judge)', accessor: observedNodeAccessor, sortGroups: observedNodeSort },
+	{ key: 'observed_node', label: 'Behavior category', accessor: observedNodeAccessor, sortGroups: observedNodeSort },
 ];
 
 export const AUDIT_GROUP_AXES: GroupAxis<AuditScore>[] = GROUP_AXES;
@@ -110,22 +110,6 @@ export function buildFactorAxes<T extends { dimensions?: Record<string, string> 
 		label: formatFactorLabel(name),
 		accessor: (item) => item.dimensions?.[name]
 	}));
-
-	for (let index = 0; index < orderedFactorNames.length; index += 1) {
-		for (let otherIndex = index + 1; otherIndex < orderedFactorNames.length; otherIndex += 1) {
-			const first = orderedFactorNames[index];
-			const second = orderedFactorNames[otherIndex];
-			axes.push({
-				key: `dimension:${first}:${second}`,
-				label: `${formatFactorLabel(first)} × ${formatFactorLabel(second)}`,
-				accessor: (item) => {
-					const a = item.dimensions?.[first];
-					const b = item.dimensions?.[second];
-					return a && b ? `${formatFactorLabel(first)}: ${a} · ${formatFactorLabel(second)}: ${b}` : undefined;
-				}
-			});
-		}
-	}
 
 	return axes;
 }

--- a/viewer/src/routes/suite/[suite_id]/[run_id]/+page.svelte
+++ b/viewer/src/routes/suite/[suite_id]/[run_id]/+page.svelte
@@ -872,10 +872,10 @@
 		{@const allMetrics = metricNames.map((dim) => ({ key: dim, name: metricLabel(dim), summary: activePromptDimensions[dim], description: data.dimensionDefs?.[dim]?.description ?? '' }))}
 		<div class="mb-4 border-b border-border pb-2">
 			<div class="flex items-center gap-3">
-				<h2 class="min-w-0 flex-1 text-lg font-semibold text-text">Evaluation summary</h2>
+				<h2 class="min-w-0 flex-1 truncate text-lg font-semibold text-text">Evaluation summary</h2>
 				<span class="shrink-0 text-xs text-text-muted">{allMetrics.length} test set dimensions</span>
 			</div>
-			<p class="mt-1 text-sm leading-5 text-text-muted">Pass and Flagged rates across every judge dimension in this run.</p>
+			<p class="mt-1 line-clamp-2 text-sm leading-5 text-text-muted">Pass and Flagged rates across every judge dimension in this run.</p>
 		</div>
 		<div class="mb-8 grid gap-3" style="grid-template-columns: repeat({Math.min(allMetrics.length, 4)}, minmax(0, 1fr))">
 			{#each allMetrics as m}
@@ -922,35 +922,11 @@
 		<!-- Category Accordion -->
 		<section class="mb-8">
 			<div class="mb-4 border-b border-border pb-2">
-				<div class="flex items-end gap-3">
-					<div class="min-w-0 flex-1">
-						<h2 class="min-w-0 flex-1 text-lg font-semibold text-text">{promptGroupBy === 'none' ? 'All evaluation results' : 'Results by behavior category'}</h2>
-						<p class="mt-1 text-sm leading-5 text-text-muted">Per-prompt judgements with verdicts, evidence, and target responses.</p>
-					</div>
-					<div class="flex shrink-0 flex-col items-end gap-2">
-						<span class="text-xs text-text-muted">{data.samples.length} prompts{#if promptGroupBy !== 'none'} · {promptGroups.length} groups{/if}</span>
-						<div class="SegmentedControl" role="tablist" aria-label="Grouping">
-							<button
-								type="button"
-								role="tab"
-								aria-selected={promptGroupBy === 'none'}
-								class="SegmentedControl-item"
-								class:SegmentedControl-item--selected={promptGroupBy === 'none'}
-								onclick={() => setPromptGroupBy('none')}
-							><span class="SegmentedControl-content">Flat view</span></button>
-							{#each availablePromptAxes as axis}
-								<button
-									type="button"
-									role="tab"
-									aria-selected={promptGroupBy === axis.key}
-									class="SegmentedControl-item"
-									class:SegmentedControl-item--selected={promptGroupBy === axis.key}
-									onclick={() => setPromptGroupBy(axis.key)}
-								><span class="SegmentedControl-content">Grouped by behavior category</span></button>
-							{/each}
-						</div>
-					</div>
+				<div class="flex items-baseline gap-3">
+					<h2 class="min-w-0 flex-1 truncate text-lg font-semibold text-text">{promptGroupBy === 'none' ? 'All evaluation results' : `Results by ${activePromptAxis.label.toLowerCase()}`}</h2>
+					<span class="shrink-0 text-xs text-text-muted">{data.samples.length} prompts{#if promptGroupBy !== 'none'} · {promptGroups.length} groups{/if}</span>
 				</div>
+				<p class="mt-1 line-clamp-2 text-sm leading-5 text-text-muted">Per-prompt judgements with verdicts, evidence, and target responses.</p>
 			</div>
 
 			<!-- Controls row: search + filter -->
@@ -983,7 +959,15 @@
 					/>
 				</div>
 				<div class="ml-auto flex items-center gap-2">
-					<span class="text-xs text-text-muted">Filter by</span>
+					<span class="text-xs text-text-muted">Group by</span>
+					<PrimerDropdown
+						label=""
+						ariaLabel="Group by"
+						options={[{ value: 'none', label: 'Flat view' }, ...availablePromptAxes.map(a => ({ value: a.key, label: a.label }))]}
+						selected={promptGroupBy}
+						onSelect={(v) => setPromptGroupBy(v)}
+					/>
+					<span class="ml-2 text-xs text-text-muted">Filter by</span>
 					<PrimerDropdown
 						label=""
 						ariaLabel="Filter by metric"
@@ -1156,10 +1140,10 @@
 		{@const auditAllMetrics = auditMetricNames.map((dim) => ({ key: dim, name: metricLabel(dim), summary: activeAuditDimensions[dim], description: data.dimensionDefs?.[dim]?.description ?? '' }))}
 		<div class="mb-4 border-b border-border pb-2">
 			<div class="flex items-center gap-3">
-				<h2 class="min-w-0 flex-1 text-lg font-semibold text-text">Evaluation summary</h2>
+				<h2 class="min-w-0 flex-1 truncate text-lg font-semibold text-text">Evaluation summary</h2>
 				<span class="shrink-0 text-xs text-text-muted">{auditAllMetrics.length} test set dimensions</span>
 			</div>
-			<p class="mt-1 text-sm leading-5 text-text-muted">Pass and Flagged rates across every judge dimension in this run.</p>
+			<p class="mt-1 line-clamp-2 text-sm leading-5 text-text-muted">Pass and Flagged rates across every judge dimension in this run.</p>
 		</div>
 		<div class="mb-8 grid gap-3" style="grid-template-columns: repeat({Math.min(auditAllMetrics.length, 4)}, minmax(0, 1fr))">
 			{#each auditAllMetrics as m}
@@ -1202,35 +1186,11 @@
 		<!-- Audit Category Accordion -->
 		<section class="mb-8">
 			<div class="mb-4 border-b border-border pb-2">
-				<div class="flex items-end gap-3">
-					<div class="min-w-0 flex-1">
-						<h2 class="min-w-0 flex-1 text-lg font-semibold text-text">{auditGroupBy === 'none' ? 'All evaluation results' : 'Results by behavior category'}</h2>
-						<p class="mt-1 text-sm leading-5 text-text-muted">Per-scenario judgements across multi-turn conversations.</p>
-					</div>
-					<div class="flex shrink-0 flex-col items-end gap-2">
-						<span class="text-xs text-text-muted">{data.auditScores.length} conversations{#if auditGroupBy !== 'none'} · {auditGroups.length} groups{/if}</span>
-						<div class="SegmentedControl" role="tablist" aria-label="Grouping">
-							<button
-								type="button"
-								role="tab"
-								aria-selected={auditGroupBy === 'none'}
-								class="SegmentedControl-item"
-								class:SegmentedControl-item--selected={auditGroupBy === 'none'}
-								onclick={() => setAuditGroupBy('none')}
-							><span class="SegmentedControl-content">Flat view</span></button>
-							{#each availableAxes as axis}
-								<button
-									type="button"
-									role="tab"
-									aria-selected={auditGroupBy === axis.key}
-									class="SegmentedControl-item"
-									class:SegmentedControl-item--selected={auditGroupBy === axis.key}
-									onclick={() => setAuditGroupBy(axis.key)}
-								><span class="SegmentedControl-content">Grouped by behavior category</span></button>
-							{/each}
-						</div>
-					</div>
+				<div class="flex items-baseline gap-3">
+					<h2 class="min-w-0 flex-1 truncate text-lg font-semibold text-text">{auditGroupBy === 'none' ? 'All evaluation results' : `Results by ${activeAuditAxis.label.toLowerCase()}`}</h2>
+					<span class="shrink-0 text-xs text-text-muted">{data.auditScores.length} conversations{#if auditGroupBy !== 'none'} · {auditGroups.length} groups{/if}</span>
 				</div>
+				<p class="mt-1 line-clamp-2 text-sm leading-5 text-text-muted">Per-scenario judgements across multi-turn conversations.</p>
 			</div>
 
 			<!-- Controls row: search + filter -->
@@ -1263,7 +1223,15 @@
 					/>
 				</div>
 				<div class="ml-auto flex items-center gap-2">
-					<span class="text-xs text-text-muted">Filter by</span>
+					<span class="text-xs text-text-muted">Group by</span>
+					<PrimerDropdown
+						label=""
+						ariaLabel="Group by"
+						options={[{ value: 'none', label: 'Flat view' }, ...availableAxes.map(a => ({ value: a.key, label: a.label }))]}
+						selected={auditGroupBy}
+						onSelect={(v) => setAuditGroupBy(v)}
+					/>
+					<span class="ml-2 text-xs text-text-muted">Filter by</span>
 					<PrimerDropdown
 						label=""
 						ariaLabel="Filter by metric"


### PR DESCRIPTION
The run page rendered duplicate "Grouped by behavior category" tabs because the segmented control hardcoded the label instead of using each axis's own label, and buildFactorAxes() generated an O(N^2) explosion of single + pairwise axes.

Changes:
- grouping.ts: rename observed_node axis label to "Behavior category" and drop the pairwise axis loop so we only emit one axis per dimension (linear growth).
- run page: replace the SegmentedControl with a "Group by" PrimerDropdown placed next to the existing "Filter by" dropdown in both prompt and audit sections, so the header scales to any number of dimensions.
- run page: restructure the section header so the H2 + description stack above the controls instead of sharing a row, and add truncate / line-clamp-2 so long titles and descriptions can never collapse the layout.

<img width="2051" height="846" alt="image" src="https://github.com/user-attachments/assets/fcfbfa80-7f8d-4970-8e0a-a9c206770ad5" />
