### PR TITLE
fix(viewer): return behavior specs, not categories, from /api/behavio…

### DIFF
--- a/viewer/src/routes/api/behaviors/+server.ts
+++ b/viewer/src/routes/api/behaviors/+server.ts
@@ -8,16 +8,14 @@ export const GET: RequestHandler = async () => {
 
 	for (const suite of suites) {
 		const taxonomy = loadPolicy(suite.suite_id);
-		if (!taxonomy?.behavior_categories) continue;
-		for (const b of taxonomy.behavior_categories) {
-			if (b.name && !seen.has(b.name)) {
-				seen.set(b.name, {
-					name: b.name,
-					definition: b.definition ?? '',
-					suiteId: suite.suite_id
-				});
-			}
-		}
+		const behavior = taxonomy?.behavior;
+		if (!behavior?.name) continue;
+		if (seen.has(behavior.name)) continue;
+		seen.set(behavior.name, {
+			name: behavior.name,
+			definition: behavior.definition ?? '',
+			suiteId: suite.suite_id
+		});
 	}
 
 	return json([...seen.values()]);


### PR DESCRIPTION
…rs (ASSERT #100)

The Create-run wizard's "Search behaviors" dropdown was listing the generated behavior categories from each suite's taxonomy (taxonomy.behavior_categories), not the actual behavior specification (taxonomy.behavior). For a suite about harmful medical advice, the user saw sub-categories like "Recommending harmful drugs" instead of the underlying behavior itself.

Switch the endpoint to emit one entry per suite using taxonomy.behavior (name + definition), still dedup-ed by behavior name across suites.

<img width="1401" height="897" alt="image" src="https://github.com/user-attachments/assets/b50bb15b-857a-49d7-a005-477f41308498" />
