### PR TITLE
feat(config): multi-preset judge dimensions

### DIFF
--- a/p2m/config.py
+++ b/p2m/config.py
@@ -334,6 +334,35 @@ def _optional_str(value: Any, *, field_name: str) -> str | None:
     return stripped or None
 
 
+def _parse_preset_names(value: Any, *, field_name: str) -> list[str]:
+    """Accept a single preset name (str) or a list of preset names.
+
+    Returns a list of stripped, non-empty names preserving order. Duplicates are
+    removed (first occurrence wins) so callers can rely on deterministic
+    merge order. Returns [] when value is None or empty.
+    """
+    if value is None:
+        return []
+    if isinstance(value, str):
+        name = value.strip()
+        return [name] if name else []
+    if isinstance(value, list):
+        names: list[str] = []
+        seen: set[str] = set()
+        for index, item in enumerate(value):
+            if not isinstance(item, str):
+                raise ValueError(f"{field_name}[{index}] must be a string")
+            stripped = item.strip()
+            if not stripped:
+                raise ValueError(f"{field_name}[{index}] must not be empty")
+            if stripped in seen:
+                continue
+            seen.add(stripped)
+            names.append(stripped)
+        return names
+    raise ValueError(f"{field_name} must be a string or a list of strings")
+
+
 def _optional_float(value: Any, *, field_name: str) -> float | None:
     if value is None:
         return None
@@ -726,15 +755,23 @@ def parse_pipeline_config(raw: dict[str, Any]) -> PipelineConfig | None:
         if judge_enabled:
             model_raw = scorer_stage.get("model", default_model_raw)
             require(model_raw is not None, "pipeline.judge.model or default_model is required when judge is configured")
-            judge_preset_name = _optional_str(scorer_stage.get("preset"), field_name="pipeline.judge.preset")
+            judge_preset_names = _parse_preset_names(
+                scorer_stage.get("preset"),
+                field_name="pipeline.judge.preset",
+            )
             preset_dims: list[dict[str, Any]] = []
-            if judge_preset_name:
+            if judge_preset_names:
                 from p2m.library.loader import load_preset
-                preset = load_preset("judge_preset", judge_preset_name)
-                preset_dims = parse_judge_dimensions(
-                    preset.get("dimensions"),
-                    field_name=f"pipeline.judge.preset({judge_preset_name}).dimensions",
-                )
+                # Later presets override earlier ones on dimension-name conflict.
+                merged: dict[str, dict[str, Any]] = {}
+                for preset_name in judge_preset_names:
+                    preset = load_preset("judge_preset", preset_name)
+                    for dim in parse_judge_dimensions(
+                        preset.get("dimensions"),
+                        field_name=f"pipeline.judge.preset({preset_name}).dimensions",
+                    ):
+                        merged[dim["name"]] = dim
+                preset_dims = list(merged.values())
             inline_dims = parse_judge_dimensions(
                 scorer_stage.get("dimensions"),
                 field_name="pipeline.judge.dimensions",

--- a/p2m/config.py
+++ b/p2m/config.py
@@ -322,7 +322,7 @@ def resolve_stage_paths(
     return resolved
 
 
-# ΓöÇΓöÇ Config parsing ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
+# ── Config parsing ─────────────────────────────────────────────
 
 
 def _optional_str(value: Any, *, field_name: str) -> str | None:

--- a/tests/test_library_e2e.py
+++ b/tests/test_library_e2e.py
@@ -448,6 +448,81 @@ class OverrideSemanticsTest(unittest.TestCase):
 
 
 # ===================================================================
+# 6b. Multi-preset combining — pipeline.judge.preset accepts list
+# ===================================================================
+
+class MultiPresetTest(unittest.TestCase):
+    """`pipeline.judge.preset` accepts a single name or a list of names."""
+
+    def test_list_with_single_preset_equivalent_to_string(self):
+        ctx_str = _load_ctx(judge_overrides={"preset": "safety-core"})
+        ctx_list = _load_ctx(judge_overrides={"preset": ["safety-core"]})
+        names_str = [d["name"] for d in ctx_str["evaluation"].judge.dimensions]
+        names_list = [d["name"] for d in ctx_list["evaluation"].judge.dimensions]
+        self.assertEqual(names_str, names_list)
+
+    def test_list_combines_dimensions_from_all_presets(self):
+        ctx = _load_ctx(judge_overrides={"preset": ["safety-core", "grounding"]})
+        names = [d["name"] for d in ctx["evaluation"].judge.dimensions]
+        # safety-core contributes: policy_violation, overrefusal
+        # grounding contributes:    hallucination, attribution_error
+        self.assertIn("policy_violation", names)
+        self.assertIn("overrefusal", names)
+        self.assertIn("hallucination", names)
+        self.assertIn("attribution_error", names)
+        self.assertEqual(len(names), 4)
+
+    def test_list_deduplicates_repeated_preset_name(self):
+        ctx = _load_ctx(judge_overrides={"preset": ["safety-core", "safety-core"]})
+        single = _load_ctx(judge_overrides={"preset": "safety-core"})
+        self.assertEqual(
+            [d["name"] for d in ctx["evaluation"].judge.dimensions],
+            [d["name"] for d in single["evaluation"].judge.dimensions],
+        )
+
+    def test_inline_dim_overrides_dim_from_any_preset_in_list(self):
+        ctx = _load_ctx(judge_overrides={
+            "preset": ["safety-core", "grounding"],
+            "dimensions": {
+                "hallucination": {
+                    "description": "inline override",
+                    "rubric": "inline rubric",
+                },
+            },
+        })
+        dims = ctx["evaluation"].judge.dimensions
+        hallucination = next(d for d in dims if d["name"] == "hallucination")
+        self.assertEqual(hallucination["description"], "inline override")
+        self.assertEqual(hallucination["rubric"], "inline rubric")
+
+    def test_empty_list_treated_as_no_preset(self):
+        ctx = _load_ctx(judge_overrides={
+            "preset": [],
+            "dimensions": {
+                "only_inline": {"description": "x", "rubric": "y"},
+            },
+        })
+        names = [d["name"] for d in ctx["evaluation"].judge.dimensions]
+        self.assertEqual(names, ["only_inline"])
+
+    def test_invalid_preset_type_raises(self):
+        with self.assertRaisesRegex(ValueError, "pipeline.judge.preset"):
+            _load_ctx(judge_overrides={"preset": 42})
+
+    def test_non_string_list_item_raises(self):
+        with self.assertRaisesRegex(ValueError, r"pipeline\.judge\.preset\[1\]"):
+            _load_ctx(judge_overrides={"preset": ["safety-core", 7]})
+
+    def test_empty_string_in_list_raises(self):
+        with self.assertRaisesRegex(ValueError, r"pipeline\.judge\.preset\[0\]"):
+            _load_ctx(judge_overrides={"preset": ["  "]})
+
+    def test_unknown_preset_in_list_raises(self):
+        with self.assertRaises(ValueError):
+            _load_ctx(judge_overrides={"preset": ["safety-core", "does-not-exist"]})
+
+
+# ===================================================================
 # 7. Cross-reference integrity
 # ===================================================================
 


### PR DESCRIPTION
## Summary

Two config-layer changes, each as its own commit:

1. **`fix(config)`** — Repair UTF-8 mojibake on the `Config parsing` section header in `p2m/config.py`. The original `─` (U+2500, bytes `E2 94 80`) had been decoded as CP437 and re-encoded as UTF-8, producing 47 `ΓöÇ` triples on one line. One-line revert; no behavior change.
2. **`feat(config)`** — Allow `pipeline.judge.preset` to accept either a single preset name (existing behavior) **or** a list of preset names. Dimensions from multiple presets are merged in list order; later presets override earlier ones on dimension-name conflict, and inline `pipeline.judge.dimensions` still take final priority. Adds a `_parse_preset_names` helper that validates input (rejects non-string items, empty strings, unsupported types) and deduplicates repeated names while preserving first-occurrence order.
3. **`test(config)`** — 9 new subtests in `MultiPresetTest` covering: single-element list equivalence, multi-preset union, dedupe, inline override priority, empty list, and four validation error paths (wrong type, non-string item, empty string item, unknown preset name).

## Tests

```
python3 -m pytest tests/test_library_e2e.py
# 65 passed, 403 subtests passed
```