### PR TITLE
chore: add MIT license headers

### DIFF
--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.

--- a/examples/agents/__init__.py
+++ b/examples/agents/__init__.py
@@ -1,1 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Example agent integrations: tool modules, toolsets, and external connectors."""

--- a/examples/agents/health_assistant.py
+++ b/examples/agents/health_assistant.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Docker-backed tool module for health-assistant evals.
 
 Config key: tools.module: examples.agents.health_assistant

--- a/examples/agents/openclaw/__init__.py
+++ b/examples/agents/openclaw/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """External connector for OpenClaw.
 
 Config key: connector: examples.agents.openclaw

--- a/examples/agents/openclaw/entrypoint.sh
+++ b/examples/agents/openclaw/entrypoint.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 set -e
 
 AZURE_BASE_URL="${AZURE_OPENAI_ENDPOINT%/}"

--- a/examples/azure_doc_qa/__init__.py
+++ b/examples/azure_doc_qa/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.

--- a/examples/azure_doc_qa/agent.py
+++ b/examples/azure_doc_qa/agent.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Multi-agent Azure Doc QA system built with LangGraph.
 
 Multi-agent graph with triage routing, specialist agents, and escalation.

--- a/examples/azure_doc_qa/auto_trace.py
+++ b/examples/azure_doc_qa/auto_trace.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Phoenix OTel auto-instrumentation for the Azure Doc QA agent.
 
 2 lines to instrument, then run the agent unchanged. Phoenix auto-discovers

--- a/examples/azure_doc_qa/mcp_tools.py
+++ b/examples/azure_doc_qa/mcp_tools.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Real MCP client setup for Foundry IQ + Microsoft Learn MCP servers.
 
 Used by ProductDocsAgent in real (non-mock) mode. Requires:

--- a/examples/azure_doc_qa/mock_tools.py
+++ b/examples/azure_doc_qa/mock_tools.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Mock tool implementations for offline / CI use.
 
 Provides mock versions of all tools used by the azure_doc_qa agents:

--- a/examples/incident_triage_agent/__init__.py
+++ b/examples/incident_triage_agent/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.

--- a/examples/incident_triage_agent/agent.py
+++ b/examples/incident_triage_agent/agent.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 from __future__ import annotations
 
 import json

--- a/examples/incident_triage_agent/agent_guarded.py
+++ b/examples/incident_triage_agent/agent_guarded.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Incident-triage agent wrapped with the AgentShield SDK.
 
 Same callable contract as :mod:`agent` (`chat(message: str) -> str`) so this

--- a/examples/incident_triage_simple/__init__.py
+++ b/examples/incident_triage_simple/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.

--- a/examples/incident_triage_simple/agent.py
+++ b/examples/incident_triage_simple/agent.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 from __future__ import annotations
 
 import json

--- a/examples/incident_triage_simple/agent_guarded.py
+++ b/examples/incident_triage_simple/agent_guarded.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Same agent, wrapped by the AgentShield runtime defined in guardrails.yaml.
 
 Drop-in callable replacement: same `chat(message: str) -> str` signature,

--- a/examples/phoenix_auto_trace/__init__.py
+++ b/examples/phoenix_auto_trace/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.

--- a/examples/phoenix_auto_trace/_tools.py
+++ b/examples/phoenix_auto_trace/_tools.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Shared mock tool data for phoenix_auto_trace demos.
 
 All 14 demos use the same 5 tools with the same mock responses.

--- a/examples/phoenix_auto_trace/travel_anthropic.py
+++ b/examples/phoenix_auto_trace/travel_anthropic.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Travel planner — Anthropic Claude (native tool use).
 
 Instrumentation: 2 lines. Agent code: standard Anthropic SDK.

--- a/examples/phoenix_auto_trace/travel_autogen.py
+++ b/examples/phoenix_auto_trace/travel_autogen.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Travel planner — AutoGen AgentChat (multi-agent conversation).
 
 Instrumentation: 2 lines. Agent code: standard AutoGen AgentChat.

--- a/examples/phoenix_auto_trace/travel_bedrock.py
+++ b/examples/phoenix_auto_trace/travel_bedrock.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Travel planner — AWS Bedrock (Anthropic Claude on AWS).
 
 Instrumentation: 2 lines. Agent code: standard Bedrock via boto3.

--- a/examples/phoenix_auto_trace/travel_crewai.py
+++ b/examples/phoenix_auto_trace/travel_crewai.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Travel planner — CrewAI (multi-agent crew).
 
 Instrumentation: 2 lines. Agent code: standard CrewAI.

--- a/examples/phoenix_auto_trace/travel_dspy.py
+++ b/examples/phoenix_auto_trace/travel_dspy.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Travel planner — DSPy (declarative signatures).
 
 Instrumentation: 2 lines. Agent code: standard DSPy.

--- a/examples/phoenix_auto_trace/travel_google_adk.py
+++ b/examples/phoenix_auto_trace/travel_google_adk.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Travel planner — Google ADK (Agent Development Kit).
 
 Instrumentation: 2 lines. Agent code: standard Google ADK.

--- a/examples/phoenix_auto_trace/travel_google_genai.py
+++ b/examples/phoenix_auto_trace/travel_google_genai.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Travel planner — Google GenAI (Gemini).
 
 Instrumentation: 2 lines. Agent code: standard google-genai SDK.

--- a/examples/phoenix_auto_trace/travel_groq.py
+++ b/examples/phoenix_auto_trace/travel_groq.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Travel planner — Groq (fast inference).
 
 Instrumentation: 2 lines. Agent code: standard Groq SDK (OpenAI-compatible).

--- a/examples/phoenix_auto_trace/travel_haystack.py
+++ b/examples/phoenix_auto_trace/travel_haystack.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Travel planner — Haystack (pipeline with tool-calling loop).
 
 Instrumentation: 2 lines. Agent code: standard Haystack 2.x.

--- a/examples/phoenix_auto_trace/travel_instructor.py
+++ b/examples/phoenix_auto_trace/travel_instructor.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Travel planner — Instructor (structured LLM output via Pydantic).
 
 Instrumentation: 2 lines. Agent code: Instructor-patched OpenAI client.

--- a/examples/phoenix_auto_trace/travel_langchain.py
+++ b/examples/phoenix_auto_trace/travel_langchain.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Travel planner — LangChain/LangGraph (multi-node graph).
 
 Instrumentation: 2 lines. Agent code: standard LangGraph.

--- a/examples/phoenix_auto_trace/travel_langgraph.py
+++ b/examples/phoenix_auto_trace/travel_langgraph.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """LangGraph travel planner — OTel auto-instrumented agent.
 
 Multi-node graph with mock tools: agent calls tools, OTel captures every

--- a/examples/phoenix_auto_trace/travel_litellm.py
+++ b/examples/phoenix_auto_trace/travel_litellm.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Travel planner — LiteLLM (provider-agnostic).
 
 Instrumentation: 2 lines. Agent code: LiteLLM completion with tools.

--- a/examples/phoenix_auto_trace/travel_llamaindex.py
+++ b/examples/phoenix_auto_trace/travel_llamaindex.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Travel planner — LlamaIndex (ReAct agent).
 
 Instrumentation: 2 lines. Agent code: standard LlamaIndex.

--- a/examples/phoenix_auto_trace/travel_mistralai.py
+++ b/examples/phoenix_auto_trace/travel_mistralai.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Travel planner — MistralAI.
 
 Instrumentation: 2 lines. Agent code: standard Mistral SDK.

--- a/examples/phoenix_auto_trace/travel_openai.py
+++ b/examples/phoenix_auto_trace/travel_openai.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Travel planner — OpenAI direct (function calling).
 
 Instrumentation: 2 lines. Agent code: standard OpenAI SDK.

--- a/examples/phoenix_auto_trace/travel_openai_agents.py
+++ b/examples/phoenix_auto_trace/travel_openai_agents.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Travel planner — OpenAI Agents SDK (multi-agent orchestration).
 
 Instrumentation: 2 lines. Agent code: standard openai-agents SDK.

--- a/examples/phoenix_auto_trace/travel_openai_router.py
+++ b/examples/phoenix_auto_trace/travel_openai_router.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Travel planner — model-router (SWC endpoint, multi-model ensemble)."""
 from phoenix.otel import register
 register(auto_instrument=True)

--- a/examples/phoenix_auto_trace/travel_portkey.py
+++ b/examples/phoenix_auto_trace/travel_portkey.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Travel planner — Portkey AI Gateway.
 
 Instrumentation: 2 lines. Agent code: Portkey SDK (OpenAI-compatible).

--- a/examples/phoenix_auto_trace/travel_pydantic_ai.py
+++ b/examples/phoenix_auto_trace/travel_pydantic_ai.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Travel planner — PydanticAI (agent framework with typed tools).
 
 Instrumentation: 2 lines. Agent code: standard PydanticAI.

--- a/examples/phoenix_auto_trace/travel_smolagents.py
+++ b/examples/phoenix_auto_trace/travel_smolagents.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Travel planner — smolagents (HuggingFace tool-calling agent).
 
 Instrumentation: 2 lines. Agent code: standard smolagents.

--- a/examples/travel_planner_langgraph/agent.py
+++ b/examples/travel_planner_langgraph/agent.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Multi-agent travel planner built with LangGraph.
 
 Multi-node graph with conditional routing, tool calling, and shared state.

--- a/examples/travel_planner_langgraph/auto_trace.py
+++ b/examples/travel_planner_langgraph/auto_trace.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Phoenix OTel auto-instrumentation for the LangGraph travel planner.
 
 2 lines to instrument, then run the agent unchanged. Phoenix auto-discovers

--- a/examples/travel_planner_neurosan/__init__.py
+++ b/examples/travel_planner_neurosan/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.

--- a/examples/travel_planner_neurosan/agent.py
+++ b/examples/travel_planner_neurosan/agent.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Custom-instrumented multi-agent travel planner — manual OTel spans.
 
 Unlike the phoenix_auto_trace demos (which use Phoenix's auto-instrumentors),

--- a/p2m/__init__.py
+++ b/p2m/__init__.py
@@ -1,1 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Top-level package for the measurements application."""

--- a/p2m/analysis/__init__.py
+++ b/p2m/analysis/__init__.py
@@ -1,1 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Analysis helpers exposed through the packaged CLI."""

--- a/p2m/analysis/inference_metrics.py
+++ b/p2m/analysis/inference_metrics.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Inference-stage metrics computed from inference-set rows.
 
 Aggregates stop-reason distribution, turn counts, truncation rates,

--- a/p2m/analysis/stability.py
+++ b/p2m/analysis/stability.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Outcome stability analysis across multiple runs.
 
 Provides two distinct analyses:

--- a/p2m/analysis/stats.py
+++ b/p2m/analysis/stats.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Core statistical utilities for pipeline analysis.
 
 Provides cluster-bootstrapped confidence intervals, binary prediction metrics,

--- a/p2m/analysis/stratification_metrics.py
+++ b/p2m/analysis/stratification_metrics.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Stratification quality and labeling metrics.
 
 Pure post-hoc statistics computed over test-case assignments and stratification catalogs:

--- a/p2m/analysis/suite_analysis.py
+++ b/p2m/analysis/suite_analysis.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Suite-level analysis that combines metrics across stages.
 
 Computes judge rates with confidence intervals, inference health,

--- a/p2m/analysis/test_case_labeling.py
+++ b/p2m/analysis/test_case_labeling.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Post-generation labeling of test_set against stratification dimensions.
 
 LLM-driven classification: given generated test_set and a stratification catalog,

--- a/p2m/analysis/test_set_metrics.py
+++ b/p2m/analysis/test_set_metrics.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 from __future__ import annotations
 
 import json

--- a/p2m/cli.py
+++ b/p2m/cli.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Click CLI for the measurements pipeline (p2m)."""
 
 from __future__ import annotations

--- a/p2m/config.py
+++ b/p2m/config.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Load YAML configs and build the minimal runtime context for p2m."""
 
 from __future__ import annotations

--- a/p2m/core/__init__.py
+++ b/p2m/core/__init__.py
@@ -1,1 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Core runtime, model-client, transcript, and shared helper modules."""

--- a/p2m/core/artifact_cache.py
+++ b/p2m/core/artifact_cache.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Artifact-level cache and version helpers for suite-scoped outputs.
 
 Cacheable upstream stages (``systematize``, ``test_set``) write their

--- a/p2m/core/async_utils.py
+++ b/p2m/core/async_utils.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Small asyncio helpers for bounded workflow fan-out."""
 
 from __future__ import annotations

--- a/p2m/core/collector.py
+++ b/p2m/core/collector.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """SpanCollector Protocol — decouples P2M from any specific trace backend.
 
 P2M's OTel integration depends on this Protocol, not on Phoenix.

--- a/p2m/core/config_model.py
+++ b/p2m/core/config_model.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Typed runtime config model derived from the canonical pipeline YAML."""
 
 from __future__ import annotations

--- a/p2m/core/io.py
+++ b/p2m/core/io.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Path, JSON, and JSONL helpers used across p2m workflows."""
 
 from __future__ import annotations

--- a/p2m/core/judge.py
+++ b/p2m/core/judge.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Judge schemas, scoring utilities, and verdict aggregation."""
 
 from __future__ import annotations

--- a/p2m/core/judge_citations.py
+++ b/p2m/core/judge_citations.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Citation extraction and repair helpers for transcript judge outputs."""
 
 from __future__ import annotations

--- a/p2m/core/judge_normalization.py
+++ b/p2m/core/judge_normalization.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Transcript-specific normalization for judge verdicts."""
 
 from __future__ import annotations

--- a/p2m/core/model_client.py
+++ b/p2m/core/model_client.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """LiteLLM-backed model helpers for the measurements pipeline."""
 
 from __future__ import annotations

--- a/p2m/core/otel.py
+++ b/p2m/core/otel.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """OTel trace parser — converts OTLP JSON to p2m transcript events.
 
 Supports traces exported from Phoenix, Jaeger, or any OpenTelemetry collector.

--- a/p2m/core/otel_session.py
+++ b/p2m/core/otel_session.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """OTel-traced session for multi-turn adversarial evaluation.
 
 Architecture:

--- a/p2m/core/runtime_safety.py
+++ b/p2m/core/runtime_safety.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Runtime safety: heartbeat + watchdog daemons + bounded stage teardown.
 
 These primitives defend the harness against well-meaning user targets that

--- a/p2m/core/security.py
+++ b/p2m/core/security.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Security utilities for the p2m pipeline.
 
 Provides validation helpers for dynamic module loading, URL validation,

--- a/p2m/core/session.py
+++ b/p2m/core/session.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Hosted and external session execution paths for eval targets."""
 
 from __future__ import annotations

--- a/p2m/core/tool_backend.py
+++ b/p2m/core/tool_backend.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Tool module loading, tool schema derivation, and tool dispatch."""
 
 from __future__ import annotations

--- a/p2m/core/tools.py
+++ b/p2m/core/tools.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Target tool conversion helpers."""
 
 from __future__ import annotations

--- a/p2m/core/transcript.py
+++ b/p2m/core/transcript.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """
 Event-based transcript for multi-turn audits.
 

--- a/p2m/library/loader.py
+++ b/p2m/library/loader.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Discover and load preset YAML files from the library directory."""
 
 from __future__ import annotations

--- a/p2m/logging_config.py
+++ b/p2m/logging_config.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Centralized logging configuration for p2m."""
 
 from __future__ import annotations

--- a/p2m/results.py
+++ b/p2m/results.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Helpers for loading results artifacts and computing summary metrics."""
 
 from __future__ import annotations

--- a/p2m/runner.py
+++ b/p2m/runner.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Minimal sequential runner for the p2m stage pipeline."""
 
 from __future__ import annotations

--- a/p2m/stages/__init__.py
+++ b/p2m/stages/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Concrete stage modules for the p2m pipeline."""
 
 from __future__ import annotations

--- a/p2m/stages/inference.py
+++ b/p2m/stages/inference.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Run unified prompt/scenario inferences and write inference-set rows."""
 
 from __future__ import annotations

--- a/p2m/stages/judge.py
+++ b/p2m/stages/judge.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Score unified inference-set artifacts."""
 
 from __future__ import annotations

--- a/p2m/stages/stratification.py
+++ b/p2m/stages/stratification.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Stratification: dimension normalization, generation, and catalog rendering."""
 
 from __future__ import annotations

--- a/p2m/stages/systematization.py
+++ b/p2m/stages/systematization.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Generate a systematization artifact."""
 
 from __future__ import annotations

--- a/p2m/stages/systematization_convert.py
+++ b/p2m/stages/systematization_convert.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Convert a systematization artifact to a structured taxonomy JSON."""
 
 from __future__ import annotations

--- a/p2m/stages/systematize.py
+++ b/p2m/stages/systematize.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Generate a taxonomy artifact from a behavior description."""
 
 from __future__ import annotations

--- a/p2m/stages/test_set.py
+++ b/p2m/stages/test_set.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Generate prompt and scenario test_set for the unified pipeline."""
 
 from __future__ import annotations

--- a/p2m/viewer_read_model.py
+++ b/p2m/viewer_read_model.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Build compact run-level viewer artifacts from canonical run outputs."""
 
 from __future__ import annotations

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Concurrency / throughput benchmark harness.
 
 Drives the full p2m pipeline against a base benchmark config, with

--- a/scripts/export_suite_results.py
+++ b/scripts/export_suite_results.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Export one suite's results as csv tables, an Excel workbook, or html."""
 
 from __future__ import annotations

--- a/scripts/judge_stability_experiment.py
+++ b/scripts/judge_stability_experiment.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Judge stability experiment: score full conversations with different models, temperatures, and n values."""
 
 from __future__ import annotations

--- a/scripts/migrate_artifacts_to_pr23_vocab.py
+++ b/scripts/migrate_artifacts_to_pr23_vocab.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Migrate local run artifacts to the PR #23 vocabulary."""
 
 from __future__ import annotations

--- a/scripts/regression_test.py
+++ b/scripts/regression_test.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """PR regression test — placeholder stub.
 
 The full implementation (defined in ``.github/copilot-instructions.md``)

--- a/scripts/render_trade_off.py
+++ b/scripts/render_trade_off.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Render the trade-off chart for a 4-variant ASSERT demo.
 
 Supports multiple demo suites via the ``--suite`` flag (default:

--- a/scripts/scenario_failure_prediction.py
+++ b/scripts/scenario_failure_prediction.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Predict taxonomy violations from scenario metadata before running conversations.
 
 Runs four analysis stages:

--- a/scripts/tester_pairwise_eval.py
+++ b/scripts/tester_pairwise_eval.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Compare two tester runs seed-by-seed and aggregate pairwise judgments."""
 
 from __future__ import annotations

--- a/scripts/turn_checkpoint_judge.py
+++ b/scripts/turn_checkpoint_judge.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Judge transcript prefixes at fixed inference-turn checkpoints and plot flagged rate."""
 
 from __future__ import annotations

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Test helpers package."""

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 from __future__ import annotations
 
 import asyncio

--- a/tests/node_runner.py
+++ b/tests/node_runner.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Helpers for running Node.js + TypeScript snippets from tests.
 
 Node ≥ 23.6 strips TypeScript by default for ``.ts`` file imports. Node

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Tests for p2m.analysis modules — stats, inference_metrics, stability, suite_analysis."""
 
 import json

--- a/tests/test_artifact_cache.py
+++ b/tests/test_artifact_cache.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import logging
 import shutil
 import unittest

--- a/tests/test_benchmark_summary.py
+++ b/tests/test_benchmark_summary.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Regression tests for ``scripts/benchmark.py``'s outcome-CSV reader.
 
 Background: PR #45 added per-stage token-usage telemetry to

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import unittest
 from pathlib import Path
 from unittest.mock import patch

--- a/tests/test_exception_handling.py
+++ b/tests/test_exception_handling.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Tests for exception handling and error reporting across p2m modules."""
 
 from __future__ import annotations

--- a/tests/test_framework_agnostic.py
+++ b/tests/test_framework_agnostic.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Tests for framework-agnostic agent support POC.
 
 Tests both Approach A (OTel trace parser) and Approach B (CallableSession).

--- a/tests/test_hosted_trace_registration.py
+++ b/tests/test_hosted_trace_registration.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Tests for _ensure_hosted_trace_instrumentation in inference stage."""
 
 import unittest

--- a/tests/test_import_smoke.py
+++ b/tests/test_import_smoke.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import importlib
 import unittest
 

--- a/tests/test_incident_triage_smoke.py
+++ b/tests/test_incident_triage_smoke.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Smoke test for the joint AgentShield + p2m incident-triage demo.
 
 Validates the demo's static surface without making any LLM calls:

--- a/tests/test_inference_stage.py
+++ b/tests/test_inference_stage.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import asyncio
 import json
 import os

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import json
 import unittest
 from pathlib import Path

--- a/tests/test_library_e2e.py
+++ b/tests/test_library_e2e.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """End-to-end tests for the preset library feature.
 
 Covers:

--- a/tests/test_library_loader.py
+++ b/tests/test_library_loader.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Tests for library.loader — preset discovery and loading."""
 
 import unittest

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Tests for p2m.logging_config."""
 
 from __future__ import annotations

--- a/tests/test_measurement_fixes.py
+++ b/tests/test_measurement_fixes.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import asyncio
 import json
 import unittest

--- a/tests/test_model_client.py
+++ b/tests/test_model_client.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import unittest
 from types import SimpleNamespace
 from unittest.mock import patch

--- a/tests/test_openclaw_driver.py
+++ b/tests/test_openclaw_driver.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import unittest
 from unittest import mock
 

--- a/tests/test_preset_integration.py
+++ b/tests/test_preset_integration.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Tests for behavior.preset and judge.preset integration in config loading."""
 import unittest
 from pathlib import Path

--- a/tests/test_rate_limit_retry.py
+++ b/tests/test_rate_limit_retry.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Tests for the per-model adaptive rate limiter and retry logic."""
 
 import asyncio

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import unittest
 
 from p2m.results import compute_prompt_metrics

--- a/tests/test_run_metadata.py
+++ b/tests/test_run_metadata.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import json
 import unittest
 from pathlib import Path

--- a/tests/test_runner_artifact_cache.py
+++ b/tests/test_runner_artifact_cache.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import io
 import json
 import unittest

--- a/tests/test_runner_progress.py
+++ b/tests/test_runner_progress.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import json
 import unittest
 from pathlib import Path

--- a/tests/test_runner_stage_filters.py
+++ b/tests/test_runner_stage_filters.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import io
 import unittest
 from pathlib import Path

--- a/tests/test_runner_usage_metrics.py
+++ b/tests/test_runner_usage_metrics.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Tests for token-usage reporting in the runner.
 
 Covers the helpers that surface ``UsageAccumulator`` data on stage completion

--- a/tests/test_runtime_modes.py
+++ b/tests/test_runtime_modes.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import json
 import unittest
 from pathlib import Path

--- a/tests/test_runtime_safety.py
+++ b/tests/test_runtime_safety.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Tests for the runtime-safety layer: heartbeat, watchdog, bounded teardown.
 
 The motivating bug: a multi-agent LangGraph travel-planner target leaked

--- a/tests/test_schema_contracts.py
+++ b/tests/test_schema_contracts.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Tests for schema contracts across the prompt/code boundary.
 
 Phase 1b of the prompt revision plan: verify that independently defined

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Tests for p2m.core.security — input validation, SSRF prevention, and credential sanitization."""
 
 from __future__ import annotations

--- a/tests/test_shared_infra_helpers.py
+++ b/tests/test_shared_infra_helpers.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import json
 from pathlib import Path
 from tempfile import TemporaryDirectory

--- a/tests/test_stage_runner_smoke.py
+++ b/tests/test_stage_runner_smoke.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import asyncio
 import unittest
 from tempfile import TemporaryDirectory

--- a/tests/test_stratification_stage.py
+++ b/tests/test_stratification_stage.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Tests for the stratification pipeline stage."""
 
 import asyncio

--- a/tests/test_suite_results_export.py
+++ b/tests/test_suite_results_export.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import importlib.util
 import csv
 import json

--- a/tests/test_systematization_convert_stage.py
+++ b/tests/test_systematization_convert_stage.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import json
 import unittest
 from pathlib import Path

--- a/tests/test_systematization_stage.py
+++ b/tests/test_systematization_stage.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import json
 import unittest
 import pytest

--- a/tests/test_systematize_stage.py
+++ b/tests/test_systematize_stage.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import json
 import unittest
 from pathlib import Path

--- a/tests/test_test_case_sampling_characterization.py
+++ b/tests/test_test_case_sampling_characterization.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Characterization tests for the test-case domain modules."""
 
 from __future__ import annotations

--- a/tests/test_test_set.py
+++ b/tests/test_test_set.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Tests for the shared test-case sampling engine."""
 
 import random

--- a/tests/test_test_set_metrics_analysis.py
+++ b/tests/test_test_set_metrics_analysis.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import unittest
 
 from p2m.analysis.test_set_metrics import _prompt_test_case_text

--- a/tests/test_test_set_stage.py
+++ b/tests/test_test_set_stage.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import json
 import unittest
 import warnings

--- a/tests/test_tester_pairwise_eval.py
+++ b/tests/test_tester_pairwise_eval.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import importlib.util
 import json
 import sys

--- a/tests/test_tester_target_loop.py
+++ b/tests/test_tester_target_loop.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Tests for the multi-turn tester–target loop in inference.py.
 
 Verifies the core plumbing: message routing between tester and target,

--- a/tests/test_tool_module_sandbox.py
+++ b/tests/test_tool_module_sandbox.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import json
 import subprocess
 import unittest

--- a/tests/test_turn_checkpoint_judge.py
+++ b/tests/test_turn_checkpoint_judge.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import asyncio
 import importlib.util
 import json

--- a/tests/test_viewer_citation_resolution.py
+++ b/tests/test_viewer_citation_resolution.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import json
 import subprocess
 import textwrap

--- a/tests/test_viewer_compare_view.py
+++ b/tests/test_viewer_compare_view.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import json
 import shutil
 import subprocess

--- a/tests/test_viewer_download_api.py
+++ b/tests/test_viewer_download_api.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import json
 import os
 import shutil

--- a/tests/test_viewer_policy_api.py
+++ b/tests/test_viewer_policy_api.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import json
 import os
 import subprocess

--- a/tests/test_viewer_read_model_turns.py
+++ b/tests/test_viewer_read_model_turns.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Unit tests for `_materialize_target_messages` turn semantics.
 
 Only the tester (user) and the target (assistant) emit "turns".

--- a/tests/test_viewer_run_page_server.py
+++ b/tests/test_viewer_run_page_server.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import json
 import os
 import subprocess

--- a/tests/test_viewer_runner.py
+++ b/tests/test_viewer_runner.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import json
 import os
 import shutil

--- a/tests/test_viewer_server_artifacts.py
+++ b/tests/test_viewer_server_artifacts.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import json
 import os
 import shutil

--- a/viewer/src/app.css
+++ b/viewer/src/app.css
@@ -1,3 +1,6 @@
+/* Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License. */
+
 @import '@primer/primitives/dist/css/functional/themes/dark.css';
 @import '@primer/primitives/dist/css/functional/themes/light.css';
 @import '@primer/css/dist/primer.css';

--- a/viewer/src/app.d.ts
+++ b/viewer/src/app.d.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 declare global {
 	namespace App {
 	}

--- a/viewer/src/app.html
+++ b/viewer/src/app.html
@@ -1,3 +1,6 @@
+<!-- Copyright (c) Microsoft Corporation.
+     Licensed under the MIT License. -->
+
 <!doctype html>
 <html lang="en" data-color-mode="dark" data-dark-theme="dark" data-light-theme="light">
 	<head>

--- a/viewer/src/lib/PrimerDropdown.svelte
+++ b/viewer/src/lib/PrimerDropdown.svelte
@@ -1,3 +1,6 @@
+<!-- Copyright (c) Microsoft Corporation.
+     Licensed under the MIT License. -->
+
 <script lang="ts">
   import { onMount } from 'svelte';
 

--- a/viewer/src/lib/PrimerPagination.svelte
+++ b/viewer/src/lib/PrimerPagination.svelte
@@ -1,3 +1,6 @@
+<!-- Copyright (c) Microsoft Corporation.
+     Licensed under the MIT License. -->
+
 <!--
   Primer-style pagination.
   https://primer.style/product/components/pagination/

--- a/viewer/src/lib/ResultDrawer.svelte
+++ b/viewer/src/lib/ResultDrawer.svelte
@@ -1,3 +1,6 @@
+<!-- Copyright (c) Microsoft Corporation.
+     Licensed under the MIT License. -->
+
 <script lang="ts">
 	import {
 		getJudgeError,

--- a/viewer/src/lib/SeedGroupList.svelte
+++ b/viewer/src/lib/SeedGroupList.svelte
@@ -1,3 +1,6 @@
+<!-- Copyright (c) Microsoft Corporation.
+     Licensed under the MIT License. -->
+
 <script lang="ts">
 	import { renderMarkdown } from '$lib/markdown';
 	import { formatFactorLabel } from '$lib/grouping.js';

--- a/viewer/src/lib/SystematizationModal.svelte
+++ b/viewer/src/lib/SystematizationModal.svelte
@@ -1,3 +1,6 @@
+<!-- Copyright (c) Microsoft Corporation.
+     Licensed under the MIT License. -->
+
 <script lang="ts">
 	import { renderMarkdown } from '$lib/markdown';
 

--- a/viewer/src/lib/active-runs.ts
+++ b/viewer/src/lib/active-runs.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { browser } from '$app/environment';
 import { readable } from 'svelte/store';
 

--- a/viewer/src/lib/citation-resolution.ts
+++ b/viewer/src/lib/citation-resolution.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 export interface CitationAnchorLike {
 	exact?: string | null;
 	prefix?: string | null;

--- a/viewer/src/lib/compare-view.ts
+++ b/viewer/src/lib/compare-view.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { getRecordFlag, getVerdictFlag, scoreSortValue } from '$lib/judgment.js';
 import type { JudgedSample } from '$lib/types.js';
 

--- a/viewer/src/lib/components/InfoTooltip.svelte
+++ b/viewer/src/lib/components/InfoTooltip.svelte
@@ -1,3 +1,6 @@
+<!-- Copyright (c) Microsoft Corporation.
+     Licensed under the MIT License. -->
+
 <!--
   Primer-style description tooltip.
   Follows https://primer.style/product/getting-started/rails/components/tooltip/

--- a/viewer/src/lib/factor-filters.ts
+++ b/viewer/src/lib/factor-filters.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Shared helpers for dimension filtering across test_set and results pages.
  */

--- a/viewer/src/lib/grouping.ts
+++ b/viewer/src/lib/grouping.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Generic grouping system for scored results.
  * New grouping axes can be added by pushing to GROUP_AXES.

--- a/viewer/src/lib/judgment.ts
+++ b/viewer/src/lib/judgment.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import type { DimensionDef, JudgeStatus } from './types.js';
 
 type VerdictLike = Record<string, unknown> | null | undefined;

--- a/viewer/src/lib/markdown.ts
+++ b/viewer/src/lib/markdown.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { marked, type RendererThis, type Tokens } from 'marked';
 import type { CitationDisplayRange } from '$lib/citation-resolution.js';
 

--- a/viewer/src/lib/result-view.ts
+++ b/viewer/src/lib/result-view.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import type {
 	AuditScore,
 	AuditTranscriptMessage,

--- a/viewer/src/lib/server/artifacts.ts
+++ b/viewer/src/lib/server/artifacts.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import fs from 'node:fs';
 import path from 'node:path';
 import readline from 'node:readline';

--- a/viewer/src/lib/server/config.ts
+++ b/viewer/src/lib/server/config.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 

--- a/viewer/src/lib/server/data.ts
+++ b/viewer/src/lib/server/data.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { ARTIFACTS_ROOT } from './config.js';
 import { loadDimensions } from './dimensions.js';
 import {

--- a/viewer/src/lib/server/dimensions.ts
+++ b/viewer/src/lib/server/dimensions.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import path from 'node:path';
 import { readYamlFile } from './artifacts.js';
 import { MEASUREMENTS_ROOT } from './config.js';

--- a/viewer/src/lib/server/metrics.ts
+++ b/viewer/src/lib/server/metrics.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import {
 	getRecordFlag,
 	getRequiredBaseMetricNames,

--- a/viewer/src/lib/server/models.ts
+++ b/viewer/src/lib/server/models.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Model catalog loader for the viewer.
  *

--- a/viewer/src/lib/server/run-spawn.ts
+++ b/viewer/src/lib/server/run-spawn.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
  * Translation + execution helpers for POST /api/runs.
  *

--- a/viewer/src/lib/server/run-status.ts
+++ b/viewer/src/lib/server/run-status.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { listSubdirectories, readJsonFile, isSafeArtifactId, runDirPath, RUN_MANIFEST_FILE } from './artifacts.js';
 import { ARTIFACTS_ROOT } from './config.js';
 import type { Manifest } from '$lib/types.js';

--- a/viewer/src/lib/server/runner.ts
+++ b/viewer/src/lib/server/runner.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 export {
 	getActiveRuns,
 	loadPersistedRunState,

--- a/viewer/src/lib/suite-view.ts
+++ b/viewer/src/lib/suite-view.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import type {
 	AuditRunListItem,
 	PromptSeed,

--- a/viewer/src/lib/types.ts
+++ b/viewer/src/lib/types.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Suite-level types (from suite.json, taxonomy.json, test_set.jsonl)
 
 export interface Suite {

--- a/viewer/src/routes/+layout.svelte
+++ b/viewer/src/routes/+layout.svelte
@@ -1,3 +1,6 @@
+<!-- Copyright (c) Microsoft Corporation.
+     Licensed under the MIT License. -->
+
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { activeRuns } from '$lib/active-runs.js';

--- a/viewer/src/routes/+page.server.ts
+++ b/viewer/src/routes/+page.server.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { listSuites } from '$lib/server/data.js';
 import type { PageServerLoad } from './$types.js';
 

--- a/viewer/src/routes/+page.svelte
+++ b/viewer/src/routes/+page.svelte
@@ -1,3 +1,6 @@
+<!-- Copyright (c) Microsoft Corporation.
+     Licensed under the MIT License. -->
+
 <script lang="ts">
 	import { activeRuns } from '$lib/active-runs.js';
 	import PrimerDropdown from '$lib/PrimerDropdown.svelte';

--- a/viewer/src/routes/api/behaviors/+server.ts
+++ b/viewer/src/routes/api/behaviors/+server.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { json } from '@sveltejs/kit';
 import { listSuites, loadPolicy } from '$lib/server/data.js';
 import type { RequestHandler } from './$types.js';

--- a/viewer/src/routes/api/dimensions/+server.ts
+++ b/viewer/src/routes/api/dimensions/+server.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { json } from '@sveltejs/kit';
 import { loadDimensions } from '$lib/server/dimensions.js';
 import type { RequestHandler } from './$types.js';

--- a/viewer/src/routes/api/download/[...path]/+server.ts
+++ b/viewer/src/routes/api/download/[...path]/+server.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { error } from '@sveltejs/kit';
 import { resolveArtifactPath } from '$lib/server/artifacts.js';
 import path from 'node:path';

--- a/viewer/src/routes/api/models/+server.ts
+++ b/viewer/src/routes/api/models/+server.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { json } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
 import { getModelCatalog } from '$lib/server/models.js';

--- a/viewer/src/routes/api/runs/+server.ts
+++ b/viewer/src/routes/api/runs/+server.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { json } from '@sveltejs/kit';
 import { getActiveRuns } from '$lib/server/runner.js';
 import {

--- a/viewer/src/routes/api/runs/[suite]/[run]/prompt/[seed]/+server.ts
+++ b/viewer/src/routes/api/runs/[suite]/[run]/prompt/[seed]/+server.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { loadPromptDrawerItem } from '$lib/server/data.js';
 import { isSafeArtifactId } from '$lib/server/artifacts.js';
 import { json } from '@sveltejs/kit';

--- a/viewer/src/routes/api/runs/[suite]/[run]/scenario/[seed]/+server.ts
+++ b/viewer/src/routes/api/runs/[suite]/[run]/scenario/[seed]/+server.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { json } from '@sveltejs/kit';
 import { isSafeArtifactId } from '$lib/server/artifacts.js';
 import { loadScenarioDrawerItem } from '$lib/server/data.js';

--- a/viewer/src/routes/api/runs/[suite]/[run]/status/+server.ts
+++ b/viewer/src/routes/api/runs/[suite]/[run]/status/+server.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { json } from '@sveltejs/kit';
 import { loadRunStatusPayload } from '$lib/server/runner.js';
 import type { RequestHandler } from './$types.js';

--- a/viewer/src/routes/api/suites/+server.ts
+++ b/viewer/src/routes/api/suites/+server.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { json } from '@sveltejs/kit';
 import { listSuites } from '$lib/server/data.js';
 import type { RequestHandler } from './$types.js';

--- a/viewer/src/routes/api/taxonomy/+server.ts
+++ b/viewer/src/routes/api/taxonomy/+server.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { json } from '@sveltejs/kit';
 import fs from 'node:fs';
 import path from 'node:path';

--- a/viewer/src/routes/new/+page.svelte
+++ b/viewer/src/routes/new/+page.svelte
@@ -1,3 +1,6 @@
+<!-- Copyright (c) Microsoft Corporation.
+     Licensed under the MIT License. -->
+
 <script lang="ts">
 	/*
 	 * New evaluation wizard.

--- a/viewer/src/routes/suite/[suite_id]/+page.server.ts
+++ b/viewer/src/routes/suite/[suite_id]/+page.server.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { loadSuitePageData } from '$lib/server/data.js';
 import { isSafeArtifactId } from '$lib/server/artifacts.js';
 import { error } from '@sveltejs/kit';

--- a/viewer/src/routes/suite/[suite_id]/+page.svelte
+++ b/viewer/src/routes/suite/[suite_id]/+page.svelte
@@ -1,3 +1,6 @@
+<!-- Copyright (c) Microsoft Corporation.
+     Licensed under the MIT License. -->
+
 <script lang="ts">
 	import ResultDrawer from '$lib/ResultDrawer.svelte';
 	import PrimerDropdown from '$lib/PrimerDropdown.svelte';

--- a/viewer/src/routes/suite/[suite_id]/[run_id]/+page.server.ts
+++ b/viewer/src/routes/suite/[suite_id]/[run_id]/+page.server.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { loadRunPageData } from '$lib/server/data.js';
 import { isSafeArtifactId } from '$lib/server/artifacts.js';
 import { error } from '@sveltejs/kit';

--- a/viewer/src/routes/suite/[suite_id]/[run_id]/+page.svelte
+++ b/viewer/src/routes/suite/[suite_id]/[run_id]/+page.svelte
@@ -1,3 +1,6 @@
+<!-- Copyright (c) Microsoft Corporation.
+     Licensed under the MIT License. -->
+
 <script lang="ts">
 	import type {
 		JudgedSample,

--- a/viewer/src/routes/suite/[suite_id]/[run_id]/monitor/+page.server.ts
+++ b/viewer/src/routes/suite/[suite_id]/[run_id]/monitor/+page.server.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { isSafeArtifactId } from '$lib/server/artifacts.js';
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types.js';

--- a/viewer/src/routes/suite/[suite_id]/[run_id]/monitor/+page.svelte
+++ b/viewer/src/routes/suite/[suite_id]/[run_id]/monitor/+page.svelte
@@ -1,3 +1,6 @@
+<!-- Copyright (c) Microsoft Corporation.
+     Licensed under the MIT License. -->
+
 <script lang="ts">
 import { onMount, onDestroy } from 'svelte';
 

--- a/viewer/src/routes/suite/[suite_id]/compare/+page.server.ts
+++ b/viewer/src/routes/suite/[suite_id]/compare/+page.server.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { loadComparePageData } from '$lib/server/data.js';
 import { isSafeArtifactId } from '$lib/server/artifacts.js';
 import { error } from '@sveltejs/kit';

--- a/viewer/src/routes/suite/[suite_id]/compare/+page.svelte
+++ b/viewer/src/routes/suite/[suite_id]/compare/+page.svelte
@@ -1,3 +1,6 @@
+<!-- Copyright (c) Microsoft Corporation.
+     Licensed under the MIT License. -->
+
 <script lang="ts">
 	import { getJudgeError, getRecordFlag, getRequiredBaseMetricNames, inferJudgeStatus } from '$lib/judgment.js';
 	import { buildMatchedSampleRows } from '$lib/compare-view.js';

--- a/viewer/svelte.config.js
+++ b/viewer/svelte.config.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import adapter from '@sveltejs/adapter-auto';
 
 /** @type {import('@sveltejs/kit').Config} */

--- a/viewer/vite.config.ts
+++ b/viewer/vite.config.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { sveltekit } from '@sveltejs/kit/vite';
 import tailwindcss from '@tailwindcss/vite';
 import { defineConfig, loadEnv } from 'vite';


### PR DESCRIPTION
## Summary
- Add MIT license headers to tracked Python, shell, TypeScript, JavaScript, Svelte, CSS, and HTML source files
- Preserve the existing root MIT LICENSE file text

## Validation
- python -m pytest tests/test_import_smoke.py tests/test_cli.py -q
- git diff --check
- python -m compileall -q p2m examples scripts tests

Note: npm --prefix viewer run check still reports pre-existing Svelte/TypeScript issues in PrimerPagination and +page.svelte that are unrelated to the header-only change.