### PR TITLE
fix(viewer): sort suite runs newest-first (ASSERT #102)

### DIFF
--- a/viewer/src/lib/server/data.ts
+++ b/viewer/src/lib/server/data.ts
@@ -627,6 +627,33 @@ function buildScenarioDrawerItem(
 	);
 }
 
+function runRecencyTimestamp(item: { manifest: Manifest | null }): number {
+	// Sort key for newest-first run lists. Prefer the manifest start time so
+	// completed and in-flight runs are ordered the same way; fall back to
+	// ended_at, then heartbeat_at for runs that crashed before any timestamp
+	// was recorded. Runs with no parseable timestamp sort to the bottom and
+	// then break ties on run_id below.
+	const manifest = item.manifest;
+	if (!manifest) return Number.NEGATIVE_INFINITY;
+	const candidates = [manifest.started_at, manifest.ended_at, manifest.heartbeat_at];
+	for (const value of candidates) {
+		if (!value) continue;
+		const ts = Date.parse(value);
+		if (!Number.isNaN(ts)) return ts;
+	}
+	return Number.NEGATIVE_INFINITY;
+}
+
+function sortRunsNewestFirst<T extends { run_id: string; manifest: Manifest | null }>(
+	items: T[]
+): T[] {
+	return [...items].sort((a, b) => {
+		const diff = runRecencyTimestamp(b) - runRecencyTimestamp(a);
+		if (diff !== 0) return diff;
+		return b.run_id.localeCompare(a.run_id);
+	});
+}
+
 function buildRunListEntries(snapshot: SuiteSnapshot): {
 	runs: RunListItem[];
 	auditRuns: AuditRunListItem[];
@@ -670,7 +697,7 @@ function buildRunListEntries(snapshot: SuiteSnapshot): {
 		}
 	}
 
-	return { runs, auditRuns };
+	return { runs: sortRunsNewestFirst(runs), auditRuns: sortRunsNewestFirst(auditRuns) };
 }
 
 function buildZeroPromptMetrics(): PromptMetricView {
@@ -1059,8 +1086,7 @@ async function loadSuiteHeavyData(
 	const runs: RunListItem[] = [];
 	const auditRuns: AuditRunListItem[] = [];
 	const evalCountsByBehavior: Record<string, number> = {};
-	let primaryEvalRunId: string | null = null;
-	let primaryRunSnapshot: RunSnapshot | null = null;
+	const candidateSnapshots = new Map<string, RunSnapshot>();
 
 	for (const runId of snapshot.runIds) {
 		const runSnapshot = loadRunSnapshot(suiteId, runId, snapshot.seedRows, {
@@ -1114,11 +1140,19 @@ async function loadSuiteHeavyData(
 			}
 		}
 
-		if (primaryEvalRunId === null && (addedToRuns || addedToAuditRuns)) {
-			primaryEvalRunId = runId;
-			primaryRunSnapshot = runSnapshot;
+		if (addedToRuns || addedToAuditRuns) {
+			candidateSnapshots.set(runId, runSnapshot);
 		}
 	}
+
+	const sortedRuns = sortRunsNewestFirst(runs);
+	const sortedAuditRuns = sortRunsNewestFirst(auditRuns);
+
+	// Primary run drives the "samples from a recent evaluation" panels on the
+	// suite page; pick the newest run so users see their latest results, not
+	// whichever run-id happens to sort first alphabetically.
+	const primaryRunId = sortedRuns[0]?.run_id ?? sortedAuditRuns[0]?.run_id ?? null;
+	const primaryRunSnapshot = primaryRunId ? candidateSnapshots.get(primaryRunId) ?? null : null;
 
 	const primaryRunPromptsByBehavior: Record<string, JudgedSample[]> = primaryRunSnapshot
 		? groupSamplesByBehavior(buildJudgedPromptsFromSnapshot(primaryRunSnapshot))
@@ -1128,10 +1162,10 @@ async function loadSuiteHeavyData(
 		: {};
 
 	return {
-		runs,
-		auditRuns,
+		runs: sortedRuns,
+		auditRuns: sortedAuditRuns,
 		evalCountsByBehavior,
-		primaryEvalRunId,
+		primaryEvalRunId: primaryRunId,
 		primaryRunPromptsByBehavior,
 		primaryRunScenariosByBehavior
 	};


### PR DESCRIPTION
The suite page rendered its runs list in filesystem readdir order (alphabetical on Windows/NTFS), so a later run like `gpt54-eval_v2` appeared underneath the older `gpt54-eval`. Min reported this as the latest run "should be at the top" of the runs table.

Sort the run lists newest-first inside both `buildRunListEntries` and `loadSuiteHeavyData` using the manifest's `started_at` (falling back to `ended_at` then `heartbeat_at`, then `run_id` lex desc for runs with no parseable timestamp). The "primary" run that drives the suite page's per-behavior sample panels now also picks the newest evaluation rather than the alphabetical-first one, which matches the same expectation.