### PR TITLE
docs: add telemetry and trademark notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,16 @@ Preview feedback is welcome: confusing names, missing target examples, trace gap
 - **Windows, `UnicodeEncodeError` when running auto-trace demos** — set `$env:PYTHONUTF8 = "1"` before `python -m examples.phoenix_auto_trace.travel_openai`.
 - **Docker-backed pipes fail with "docker daemon unavailable"** — `examples/pipes/health_assistant_sandbox.yaml` and `_external.yaml` need Docker Desktop running.
 
+## Telemetry
+
+This project does not collect or send telemetry to Microsoft by default. Runs write local artifacts under `artifacts/results/`, and optional OpenTelemetry trace capture is controlled by your configuration and local collector setup, such as Phoenix.
+
+If you configure a target, judge, trace collector, or model provider to send data to an external service, the prompts, responses, traces, metadata, and other evaluation artifacts sent to that service are governed by that service's terms and your configuration.
+
+## Trademarks
+
+This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft trademarks or logos is subject to and must follow [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks). Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship. Any use of third-party trademarks or logos is subject to those third party's policies.
+
 ## Important: Risks and limitations
 
 Adaptive Evaluation is designed to generate and run scenario-based evaluations for AI systems, including adversarial and edge-case tests. These scenarios are intended to help surface potential weaknesses, unsafe behaviors, and other undesirable outcomes. They do not guarantee that a system has failed, nor are they guarantees that a system is safe.


### PR DESCRIPTION
## Summary
- Add README telemetry notice stating Adaptive Eval does not send telemetry to Microsoft by default
- Add standard trademark notice and link to Microsoft's Trademark & Brand Guidelines
- Leave existing responsible-use / CELA-style language unchanged

## Validation
- git diff --check
- Verified README contains one Telemetry section and one Trademarks section