### PR TITLE
chore(.gitignore): ignore .github/instructions/session-hygiene.instructions.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ assert_eval_policy.*
 
 # Internal Copilot CLI instructions (per-repo, never committed)
 .github/instructions/preview-boundary.instructions.md
+.github/instructions/session-hygiene.instructions.md
 
 # Code Security Assessment artifacts
 .security-assessment/


### PR DESCRIPTION
## Summary

One-line addition to .gitignore. Mirrors the existing `preview-boundary.instructions.md` pattern.

## What this is for

`.github/instructions/session-hygiene.instructions.md` is a per-machine Copilot CLI instruction file that triggers a hand-off protocol at ~turn 60 / ~70% context to prevent long-session CAPI / context-overflow crashes. It is operational guidance for the agent on a developer's local machine — it should never be committed.

The file itself is created locally by the developer who wants the behavior; this PR just ensures it cannot accidentally be committed.

## Diff

\\\diff
 # Internal Copilot CLI instructions (per-repo, never committed)
 .github/instructions/preview-boundary.instructions.md
+.github/instructions/session-hygiene.instructions.md
\\\

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>