### PR TITLE
ci: allow Scorecard checkout in private repo

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -24,13 +24,13 @@ jobs:
     # `publish_results: true` only works when run from the default branch. conditional can be removed if disabled.
     if: github.event.repository.default_branch == github.ref_name || github.event_name == 'pull_request'
     permissions:
+      # Needed for actions/checkout and Scorecard checks in private repositories.
+      contents: read
+      actions: read
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
       # Needed to publish results and get a badge (see publish_results below).
       id-token: write
-      # Uncomment the permissions below if installing in a private repository.
-      # contents: read
-      # actions: read
 
     steps:
       - name: "Checkout code"


### PR DESCRIPTION
## Summary
- Grants the Scorecard job `contents: read` and `actions: read` so `actions/checkout` can fetch this private repository.
- Keeps the existing `security-events: write` and `id-token: write` permissions for SARIF upload and Scorecard publishing support.

## Validation
- Parsed `.github/workflows/scorecard.yml` and verified the job permissions.
- `git diff --check`

## Context
Recent Scorecard runs on `main` are failing before analysis starts because checkout cannot fetch `microsoft/ASSERT` from a private repo.