### PR TITLE
ci: grant Scorecard private repo read permissions

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -27,6 +27,9 @@ jobs:
       # Needed for actions/checkout and Scorecard checks in private repositories.
       contents: read
       actions: read
+      issues: read
+      pull-requests: read
+      checks: read
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
       # Needed to publish results and get a badge (see publish_results below).


### PR DESCRIPTION
## Summary
- Adds the remaining private-repo read permissions recommended by Scorecard: `issues: read`, `pull-requests: read`, and `checks: read`.
- Keeps the earlier `contents: read` / `actions: read` checkout fix and SARIF/publish permissions.

## Why
After #124, checkout succeeds, but Scorecard now fails during analysis with:

`ListCommits:error during graphqlHandler.setup: githubv4.Query: Resource not accessible by integration`

The Scorecard README calls out this exact private-repo failure mode and recommends these job-level read permissions.

## Validation
- Parsed `.github/workflows/scorecard.yml` and verified the job permission values.
- `git diff --check`