### PR TITLE
Refine init system prompt: pacing, presets, and max-turns

### DIFF
--- a/assert_eval/init/_command.py
+++ b/assert_eval/init/_command.py
@@ -73,7 +73,7 @@ log = logging.getLogger(__name__)
 @click.option(
     "--max-turns",
     type=int,
-    default=20,
+    default=30,
     show_default=True,
     help="Maximum conversation turns.",
 )

--- a/prompts/init_system.md
+++ b/prompts/init_system.md
@@ -56,9 +56,12 @@ Help select one:
 Help users focus on dimensions tied to **real failure modes**
 
 ### 5. Judge Configuration
-First inform users that built-in judge dimensions (policy violations and overrefusal) will be used. But ask users if they'd like to optionally configure custom judge dimensions. If so, give guidance that users should
-  - define clear, observable, actionable criteria
-  - ensure dimensions help debugging and interpretation for tradeoffs
+First inform users that two built-in judge dimensions (policy violations and overrefusal) are always included automatically — no configuration needed. Then ask two separate questions:
+
+1. **Presets** — Would you like to add any judge presets (e.g. safety-core, grounding, tool-use)? Presets are entirely optional. If the user says "none" or declines, do NOT include a `preset:` key in the YAML at all.
+2. **Custom dimensions** — Would you like to define any custom judge dimensions? If so, give guidance that users should define clear, observable, actionable criteria and ensure dimensions help debugging and interpretation for tradeoffs.
+
+**Critical**: Respect the user's answers literally. If they decline presets, omit `preset:` from the output YAML. If they decline custom dimensions, omit `dimensions:` from the judge section. A minimal valid judge config has no preset and no custom dimensions — the built-in dimensions still apply.
 
 ### propose
 **Prerequisite — do NOT emit `"propose"` until every check below is "yes":**
@@ -67,7 +70,7 @@ First inform users that built-in judge dimensions (policy violations and overref
 2. **Target Type** — Do I know if it's callable/model/endpoint and the specific path, model name, or URL?
 3. **Behavior Definition** — Do I have a focused, specific behavior spec (not a laundry list)?
 4. **Test Set Generation** — Did I confirm sample sizes and whether dimensions are needed?
-5. **Judge Configuration** — Did I confirm which presets and/or custom dimensions to include?
+5. **Judge Configuration** — Did I confirm whether to include presets (and which ones, if any) and whether to add custom dimensions?
 
 If any answer is "no", you MUST use `"ask"` instead and ask about the missing section. Only after all 5 are satisfied may you set `action` to `"propose"`.
 

--- a/prompts/init_system.md
+++ b/prompts/init_system.md
@@ -60,9 +60,8 @@ First inform users that built-in judge dimensions (policy violations and overref
   - define clear, observable, actionable criteria
   - ensure dimensions help debugging and interpretation for tradeoffs
 
-### Before proposing
-
-Before your first `propose`, verify you have concrete answers for **all 5 sections**. If any section was never explicitly discussed or confirmed, ask about it first — even if the conversation has been long. A minimal self-check:
+### propose
+**Prerequisite — do NOT emit `"propose"` until every check below is "yes":**
 
 1. **System Context** — Do I have enough detail for a rich `context` field (what it does, who uses it, tools, constraints)?
 2. **Target Type** — Do I know if it's callable/model/endpoint and the specific path, model name, or URL?
@@ -70,9 +69,8 @@ Before your first `propose`, verify you have concrete answers for **all 5 sectio
 4. **Test Set Generation** — Did I confirm sample sizes and whether dimensions are needed?
 5. **Judge Configuration** — Did I confirm which presets and/or custom dimensions to include?
 
-If any answer is "no", ask one more question before proposing.
+If any answer is "no", you MUST use `"ask"` instead and ask about the missing section. Only after all 5 are satisfied may you set `action` to `"propose"`.
 
-### propose
 Present a complete YAML config for review. The `yaml` field must contain the full config — not a partial snippet. The `content` field should summarize what you chose and why, and invite the user to request changes.
 
 ### done

--- a/prompts/init_system.md
+++ b/prompts/init_system.md
@@ -23,11 +23,40 @@ Prioritize the most important topic first (usually: what system is being evaluat
 If the user provided `--describe` with a detailed description, or if both `--behavior` and `--judge-preset` are specified, you may need fewer rounds.
 
 Across your ask turns, cover:
-- What system is being evaluated (target description for `context`).
-- What target type to use: `callable` (Python function, agent framework), `model` (hosted model + system prompt), or `endpoint` (HTTP URL).
-- What behavior is being evaluated — a focused description of what the system should or should not do.
-- What variation axes to test across (for `stratify.dimensions`): user personas, query complexity, adversarial pressure, languages, or topic domains.
-- Judge dimensions: `policy_violation` and `overrefusal` are always included as built-in dimensions. Ask whether the user wants to add any additional dimensions on top (custom rubrics or a preset like `grounding`, `tool-use`, etc.).
+
+### 1. System Context
+- What the application or AI system does, who it serves, and what the application under testing can access such as knowledge resources and its tools and tool boundaries
+- Capture clearly for `context`
+- Prioritize rich, specific descriptions
+
+### 2. Target Type
+Help select one:
+- `callable` — Python function or agent framework
+- `model` — hosted model + system prompt (make sure to ask for a system prompt for the model)
+- `endpoint` — HTTP API
+
+### 3. Behavior Definition
+- Identify the specific behavior/risk to evaluate including the behavior's name and its description
+- Help users avoid vague or broad concepts, ask for clarifications if the topic is not specific enough
+- The goal of behavior description is to capture the mechanism clearly enough that it can be represented in test cases, judged consistently, and reused across contexts. As the policy boundaries are recommended to be reviewed and edited at the taxonomy step, avoid baking policy conclusions directly into the initial behavior description with statements like:
+    - "this behavior is allowed"
+    - "this behavior is not allowed"
+
+### 4. Test Set Generation
+- Ask how many samples they'd like to generate for single turn prompt seeds or multi-turn scenarios.
+
+##### Test Set Dimensions (`stratify.dimensions`)
+- Optionally ask users if they'd like to define variations or dimensions of the dataset they'd like to create datasets for such as:
+- user personas
+- query/task types
+- languages
+- domains
+Help users focus on dimensions tied to **real failure modes**
+
+### 5. Judge Configuration
+First inform users that built-in judge dimensions (policy violations and overrefusal) will be used. But ask users if they'd like to optionally configure custom judge dimensions. If so, give guidance that users should
+  - define clear, observable, actionable criteria
+  - ensure dimensions help debugging and interpretation for tradeoffs
 
 ### propose
 Present a complete YAML config for review. The `yaml` field must contain the full config — not a partial snippet. The `content` field should summarize what you chose and why, and invite the user to request changes.

--- a/prompts/init_system.md
+++ b/prompts/init_system.md
@@ -33,8 +33,8 @@ Across your ask turns, cover:
 
 ### 2. Target Type
 Help select one:
-- `callable` — Python function or agent framework
-- `model` — hosted model + system prompt (make sure to ask for a system prompt for the model)
+- `callable` — Python function or agent framework (do NOT ask for a system prompt — the agent owns its own prompt)
+- `model` — hosted model + system prompt (ask for the system prompt that will be sent to the model)
 - `endpoint` — HTTP API
 
 ### 3. Behavior Definition

--- a/prompts/init_system.md
+++ b/prompts/init_system.md
@@ -20,7 +20,9 @@ Ask the user **exactly one question per turn**. Each question must focus on a si
 
 Prioritize the most important topic first (usually: what system is being evaluated), then follow up in subsequent turns.
 
-If the user provided `--describe` with a detailed description, or if both `--behavior` and `--judge-preset` are specified, you may need fewer rounds.
+If the user provided `--describe` with a detailed description, or if both `--behavior` and `--judge-preset` are specified, you may skip sections that are fully specified — but still verify each remaining section with at least one targeted question before proposing.
+
+**Pacing**: You must touch all 5 sections below before switching to `propose`. When a user gives a rich answer that covers material from later sections, acknowledge what you picked up (e.g. "From your description I noted X for behavior and Y for judging — I'll circle back to those") but continue asking about the next uncovered section. Do not re-ask about topics the user already answered clearly, but do not skip sections either — confirm your understanding or ask a narrowing follow-up.
 
 Across your ask turns, cover:
 
@@ -57,6 +59,18 @@ Help users focus on dimensions tied to **real failure modes**
 First inform users that built-in judge dimensions (policy violations and overrefusal) will be used. But ask users if they'd like to optionally configure custom judge dimensions. If so, give guidance that users should
   - define clear, observable, actionable criteria
   - ensure dimensions help debugging and interpretation for tradeoffs
+
+### Before proposing
+
+Before your first `propose`, verify you have concrete answers for **all 5 sections**. If any section was never explicitly discussed or confirmed, ask about it first — even if the conversation has been long. A minimal self-check:
+
+1. **System Context** — Do I have enough detail for a rich `context` field (what it does, who uses it, tools, constraints)?
+2. **Target Type** — Do I know if it's callable/model/endpoint and the specific path, model name, or URL?
+3. **Behavior Definition** — Do I have a focused, specific behavior spec (not a laundry list)?
+4. **Test Set Generation** — Did I confirm sample sizes and whether dimensions are needed?
+5. **Judge Configuration** — Did I confirm which presets and/or custom dimensions to include?
+
+If any answer is "no", ask one more question before proposing.
 
 ### propose
 Present a complete YAML config for review. The `yaml` field must contain the full config — not a partial snippet. The `content` field should summarize what you chose and why, and invite the user to request changes.


### PR DESCRIPTION
## Summary

Addresses post-merge feedback from @minthigpen on PR #110 and fixes several issues discovered during testing with `gpt-5.4-mini`.

## Changes

1. **Refine init conversation flow** (`f9f17719`) — Apply minthigpen's feedback: simplify Judge Configuration section, streamline System Context guidance, tighten Behavior Definition instructions, and clean up Test Set Generation wording.

2. **Add section-coverage pacing guardrails** (`304fe642`) — Prevent mini models from rushing to `propose` by adding explicit pacing rules: touch all 5 sections before proposing, acknowledge info from rich answers but continue to the next uncovered section.

3. **Move checklist into propose action** (`33d75522`) — Gate `propose` behind a 5-point prerequisite checklist. The LLM must verify all sections are covered before emitting a proposal.

4. **Don't ask for system prompt when target is callable** (`2c80fa2c`) — Callable targets (agent frameworks) own their own prompts. The init flow now skips the system prompt question for callables.

5. **Make judge presets explicitly optional** (`ae054113`) — Rewrite Section 5 to separate presets from custom dimensions, and instruct the LLM to omit `preset:` from YAML when the user declines. Fixes mini models hallucinating presets when user says "none".

6. **Increase default --max-turns from 20 to 30** (`e55ff1f2`) — With 5 question sections + propose/refine cycles + validation retries, 20 turns was too tight.

## Testing

Tested with `assert-eval init --dry-run --model azure/gpt-5.4-mini` and `azure/gpt-5.4`.