### PR TITLE
viewer: add ExpandableText for truncated description cards

### DIFF
--- a/viewer/src/lib/ExpandableText.svelte
+++ b/viewer/src/lib/ExpandableText.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+	import { untrack } from 'svelte';
+
+	interface Props {
+		text: string;
+		clampLines?: number;
+		/**
+		 * Cap on the paragraph height when expanded. Long descriptions scroll
+		 * inside the paragraph past this point so they don't push the rest of
+		 * the page around when toggled. Accepts any CSS length (e.g. "12em",
+		 * "200px", "40vh"). Defaults to "10em".
+		 */
+		expandedMaxHeight?: string;
+		class?: string;
+	}
+
+	let {
+		text,
+		clampLines = 2,
+		expandedMaxHeight = '10em',
+		class: className = ''
+	}: Props = $props();
+
+	let el: HTMLParagraphElement | undefined = $state();
+	let expanded = $state(false);
+	let overflows = $state(false);
+
+	function measure() {
+		if (!el) return;
+		overflows = el.scrollHeight > el.clientHeight + 1;
+	}
+
+	$effect(() => {
+		// Track props so the effect re-runs when this component instance is reused
+		// for a different seed/dimension inside an {#each} block.
+		void text;
+		void clampLines;
+		if (!el) return;
+		untrack(() => {
+			expanded = false;
+		});
+		measure();
+		const ro = new ResizeObserver(() => {
+			if (!expanded) measure();
+		});
+		ro.observe(el);
+		return () => ro.disconnect();
+	});
+
+	function toggle(e: MouseEvent) {
+		e.stopPropagation();
+		expanded = !expanded;
+		if (!expanded) queueMicrotask(measure);
+	}
+</script>
+
+<p
+	bind:this={el}
+	class={className}
+	class:clamped={!expanded}
+	class:expanded
+	style="--clamp-lines: {clampLines}; --expanded-max-height: {expandedMaxHeight};"
+>{text}</p>
+{#if overflows || expanded}
+	<button
+		type="button"
+		class="mt-1 text-[11px] font-medium text-interactive hover:underline focus:outline-none focus-visible:ring-1 focus-visible:ring-interactive"
+		aria-expanded={expanded}
+		onclick={toggle}
+	>{expanded ? 'Show less' : 'Show more'}</button>
+{/if}
+
+<style>
+	.clamped {
+		display: -webkit-box;
+		-webkit-line-clamp: var(--clamp-lines);
+		-webkit-box-orient: vertical;
+		line-clamp: var(--clamp-lines);
+		overflow: hidden;
+	}
+	.expanded {
+		max-height: var(--expanded-max-height);
+		overflow-y: auto;
+		overscroll-behavior: contain;
+	}
+</style>

--- a/viewer/src/lib/ResultDrawer.svelte
+++ b/viewer/src/lib/ResultDrawer.svelte
@@ -755,7 +755,8 @@
 <div class="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm transition-opacity" onclick={onClose}></div>
 
 <div class="fixed inset-4 z-50 mx-auto flex max-w-7xl flex-col overflow-hidden rounded-xl border border-border bg-bg shadow-2xl">
-	<div class="flex items-center gap-3 border-b border-border px-6 py-3 flex-shrink-0">
+	<div class="flex flex-col gap-2 border-b border-border px-6 py-3 flex-shrink-0">
+		<div class="flex items-center gap-3">
 		<button
 			aria-label="Close details"
 			class="flex h-8 w-8 items-center justify-center rounded-lg text-text-muted transition-colors hover:bg-surface hover:text-text"
@@ -789,18 +790,9 @@
 				{:else if judgeStatus(item) === 'unjudged'}
 					<span class="rounded px-1.5 py-0.5 text-[10px] font-medium bg-surface-2 text-text-muted">unjudged</span>
 				{/if}
-				{#if item.dimensions}
-					<span class="flex flex-wrap items-center gap-1.5">
-						{#each Object.entries(item.dimensions) as [name, value]}
-							<span class="inline-flex items-center rounded-full bg-zinc-700 px-2 py-0.5 text-[10px] font-medium text-zinc-200">
-								{formatFactorLabel(name)}: {value}
-							</span>
-						{/each}
-					</span>
-				{/if}
 			</div>
 		</div>
-		<div class="flex items-center gap-1.5">
+		<div class="flex flex-wrap items-center justify-end gap-1.5">
 			{#each metricNames as m}
 				{@const v = getRecordFlag(item, m)}
 				{#if v !== null}
@@ -819,6 +811,16 @@
 				</div>
 			{/if}
 		</div>
+		</div>
+		{#if item.dimensions && Object.keys(item.dimensions).length > 0}
+			<div class="flex flex-wrap items-center gap-1.5">
+				{#each Object.entries(item.dimensions) as [name, value]}
+					<span class="inline-flex items-center whitespace-nowrap rounded-full bg-zinc-700 px-2 py-0.5 text-[10px] font-medium text-zinc-200">
+						{formatFactorLabel(name)}: {value}
+					</span>
+				{/each}
+			</div>
+		{/if}
 	</div>
 
 	<div class="flex flex-1 min-h-0">

--- a/viewer/src/lib/ResultDrawer.svelte
+++ b/viewer/src/lib/ResultDrawer.svelte
@@ -757,53 +757,43 @@
 <div class="fixed inset-4 z-50 mx-auto flex max-w-7xl flex-col overflow-hidden rounded-xl border border-border bg-bg shadow-2xl">
 	<div class="flex flex-col gap-2 border-b border-border px-6 py-3 flex-shrink-0">
 		<div class="flex items-center gap-3">
-		<button
-			aria-label="Close details"
-			class="flex h-8 w-8 items-center justify-center rounded-lg text-text-muted transition-colors hover:bg-surface hover:text-text"
-			onclick={onClose}
-		>
-			<svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M6 18L18 6M6 6l12 12"/></svg>
-		</button>
-		<div class="flex items-center gap-0.5">
-			<button class="flex h-7 w-7 items-center justify-center rounded-md text-text-muted transition-colors hover:bg-surface hover:text-text disabled:opacity-25 disabled:pointer-events-none" disabled={navIdx <= 0} onclick={onPrev} title="Previous (←)">
-				<svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M15 19l-7-7 7-7"/></svg>
+			<button
+				aria-label="Close details"
+				class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-text-muted transition-colors hover:bg-surface hover:text-text"
+				onclick={onClose}
+			>
+				<svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M6 18L18 6M6 6l12 12"/></svg>
 			</button>
-			<span class="min-w-[3rem] text-center text-[10px] tabular-nums text-text-muted">{navIdx + 1} / {navTotal}</span>
-			<button class="flex h-7 w-7 items-center justify-center rounded-md text-text-muted transition-colors hover:bg-surface hover:text-text disabled:opacity-25 disabled:pointer-events-none" disabled={navIdx >= navTotal - 1} onclick={onNext} title="Next (→)">
-				<svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M9 5l7 7-7 7"/></svg>
-			</button>
-		</div>
-		<div class="flex-1 min-w-0">
-			<h2 class="truncate text-sm font-medium text-text" title={item.header_title}>{item.header_title}</h2>
-			<div class="mt-0.5 flex flex-wrap items-center gap-2">
-				{#if item.kind === 'scenario'}
-					<span class="text-xs text-text-muted">{conversationTurnCount(item.messages)} turns</span>
-					<span class="text-xs text-text-muted">·</span>
-				{/if}
-				{#if item.kind === 'scenario' && item.context.stop_reason}
-					<span class="rounded bg-surface-2 px-1.5 py-0.5 text-[10px] text-text-muted">{item.context.stop_reason}</span>
-					<span class="text-xs text-text-muted">·</span>
-				{/if}
-
-				{#if judgeStatus(item) === 'judge_failed'}
-					<span class="rounded px-1.5 py-0.5 text-[10px] font-medium bg-amber-500/10 text-amber-400">judge failed</span>
-				{:else if judgeStatus(item) === 'unjudged'}
-					<span class="rounded px-1.5 py-0.5 text-[10px] font-medium bg-surface-2 text-text-muted">unjudged</span>
-				{/if}
+			<div class="flex shrink-0 items-center gap-0.5">
+				<button class="flex h-7 w-7 items-center justify-center rounded-md text-text-muted transition-colors hover:bg-surface hover:text-text disabled:opacity-25 disabled:pointer-events-none" disabled={navIdx <= 0} onclick={onPrev} title="Previous (←)">
+					<svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M15 19l-7-7 7-7"/></svg>
+				</button>
+				<span class="min-w-[3rem] text-center text-[10px] tabular-nums text-text-muted">{navIdx + 1} / {navTotal}</span>
+				<button class="flex h-7 w-7 items-center justify-center rounded-md text-text-muted transition-colors hover:bg-surface hover:text-text disabled:opacity-25 disabled:pointer-events-none" disabled={navIdx >= navTotal - 1} onclick={onNext} title="Next (→)">
+					<svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M9 5l7 7-7 7"/></svg>
+				</button>
 			</div>
-		</div>
-		<div class="flex flex-wrap items-center justify-end gap-1.5">
-			{#each metricNames as m}
-				{@const v = getRecordFlag(item, m)}
-				{#if v !== null}
-					<span class="inline-flex items-center gap-1 rounded bg-surface-2 px-2 py-1 text-xs">
-						<span class="text-text-muted">{metricLabel(m)}</span>
-						<span class="font-semibold tabular-nums {metricOutcomeClass(v)}">{metricOutcomeText(v)}</span>
-					</span>
-				{/if}
-			{/each}
+			<div class="flex-1 min-w-0">
+				<h2 class="truncate text-sm font-medium text-text" title={item.header_title}>{item.header_title}</h2>
+				<div class="mt-0.5 flex flex-wrap items-center gap-2">
+					{#if item.kind === 'scenario'}
+						<span class="text-xs text-text-muted">{conversationTurnCount(item.messages)} turns</span>
+						<span class="text-xs text-text-muted">·</span>
+					{/if}
+					{#if item.kind === 'scenario' && item.context.stop_reason}
+						<span class="rounded bg-surface-2 px-1.5 py-0.5 text-[10px] text-text-muted">{item.context.stop_reason}</span>
+						<span class="text-xs text-text-muted">·</span>
+					{/if}
+
+					{#if judgeStatus(item) === 'judge_failed'}
+						<span class="rounded px-1.5 py-0.5 text-[10px] font-medium bg-amber-500/10 text-amber-400">judge failed</span>
+					{:else if judgeStatus(item) === 'unjudged'}
+						<span class="rounded px-1.5 py-0.5 text-[10px] font-medium bg-surface-2 text-text-muted">unjudged</span>
+					{/if}
+				</div>
+			</div>
 			{#if item.multi_judge}
-				<div class="flex items-center gap-0.5 ml-1">
+				<div class="flex shrink-0 items-center gap-0.5">
 					{#each item.multi_judge.votes?.[primaryMetric] ?? [] as vote}
 						{@const agreed = vote === getRecordFlag(item, primaryMetric)}
 						<span class="inline-block size-[7px] rounded-full" style={agreed ? `background: ${metricDotColor(vote)}` : `background: transparent; box-shadow: inset 0 0 0 1.5px ${metricDotColor(vote)}`}></span>
@@ -811,7 +801,19 @@
 				</div>
 			{/if}
 		</div>
-		</div>
+		{#if metricNames.some((m) => getRecordFlag(item, m) !== null)}
+			<div class="flex flex-wrap items-center gap-1.5">
+				{#each metricNames as m}
+					{@const v = getRecordFlag(item, m)}
+					{#if v !== null}
+						<span class="inline-flex items-center gap-1 whitespace-nowrap rounded bg-surface-2 px-2 py-1 text-xs">
+							<span class="text-text-muted">{metricLabel(m)}</span>
+							<span class="font-semibold tabular-nums {metricOutcomeClass(v)}">{metricOutcomeText(v)}</span>
+						</span>
+					{/if}
+				{/each}
+			</div>
+		{/if}
 		{#if item.dimensions && Object.keys(item.dimensions).length > 0}
 			<div class="flex flex-wrap items-center gap-1.5">
 				{#each Object.entries(item.dimensions) as [name, value]}

--- a/viewer/src/routes/suite/[suite_id]/+page.svelte
+++ b/viewer/src/routes/suite/[suite_id]/+page.svelte
@@ -5,6 +5,7 @@
 	import ResultDrawer from '$lib/ResultDrawer.svelte';
 	import PrimerDropdown from '$lib/PrimerDropdown.svelte';
 	import InfoTooltip from '$lib/components/InfoTooltip.svelte';
+	import ExpandableText from '$lib/ExpandableText.svelte';
 	import { getRecordFlag, getRequiredBaseMetricNames } from '$lib/judgment.js';
 	import { renderMarkdown } from '$lib/markdown.js';
 	import { mergeRunLists, normalizePromptSeeds, normalizeScenarioSeeds, type CombinedRunEntry } from '$lib/suite-view.js';
@@ -731,7 +732,7 @@
 									{#each selectedBehaviorPrompts as seed}
 										<div class="rounded-lg border border-border bg-bg p-3">
 											<div class="mb-1 text-sm font-medium text-text">{seed.title}</div>
-											{#if seed.description}<p class="line-clamp-2 text-xs leading-relaxed text-text-muted">{seed.description}</p>{/if}
+											{#if seed.description}<ExpandableText text={seed.description} class="text-xs leading-relaxed text-text-muted" />{/if}
 										</div>
 									{/each}
 								</div>
@@ -749,7 +750,7 @@
 									{#each selectedBehaviorScenarios as seed}
 										<div class="rounded-lg border border-border bg-bg p-3">
 											<div class="mb-1 text-sm font-medium text-text">{seed.title}</div>
-											{#if seed.description}<p class="line-clamp-2 text-xs leading-relaxed text-text-muted">{seed.description}</p>{/if}
+											{#if seed.description}<ExpandableText text={seed.description} class="text-xs leading-relaxed text-text-muted" />{/if}
 										</div>
 									{/each}
 								</div>

--- a/viewer/src/routes/suite/[suite_id]/[run_id]/+page.svelte
+++ b/viewer/src/routes/suite/[suite_id]/[run_id]/+page.svelte
@@ -15,6 +15,7 @@
 	import ResultDrawer from '$lib/ResultDrawer.svelte';
 	import PrimerDropdown from '$lib/PrimerDropdown.svelte';
 	import InfoTooltip from '$lib/components/InfoTooltip.svelte';
+	import ExpandableText from '$lib/ExpandableText.svelte';
 	import { normalizePromptResult } from '$lib/result-view.js';
 	import {
 		getRecordFlag,
@@ -892,7 +893,7 @@
 						<span class="shrink-0 text-[12px] text-text-muted tabular-nums">{total} prompts</span>
 					</div>
 					{#if m.description}
-					<p class="mt-0.5 !text-[11px] leading-snug text-text-muted line-clamp-2">{m.description}</p>
+					<ExpandableText text={m.description} class="mt-0.5 !text-[11px] leading-snug text-text-muted" />
 					{/if}
 					<div class="mt-3 flex items-baseline gap-1.5">
 						<span class="text-3xl font-bold tabular-nums text-text">{metricRateText(m.summary?.rate ?? 0)}</span>
@@ -1197,7 +1198,7 @@
 						<span class="shrink-0 text-[12px] text-text-muted tabular-nums">{total} scenarios</span>
 					</div>
 					{#if m.description}
-					<p class="mt-0.5 !text-[11px] leading-snug text-text-muted line-clamp-2">{m.description}</p>
+					<ExpandableText text={m.description} class="mt-0.5 !text-[11px] leading-snug text-text-muted" />
 					{/if}
 					<div class="mt-3 flex items-baseline gap-1.5">
 						<span class="text-3xl font-bold tabular-nums text-text">{metricRateText(m.summary?.rate ?? 0)}</span>


### PR DESCRIPTION
Several places in the viewer clamped descriptions to two lines with no way to see the rest:

- Behavior categories side panel on the suite overview page (Prompts and Scenarios seed descriptions)
- Judge dimension summary cards on the run details page (both the prompts and audit/scenarios grids)

Add a reusable ExpandableText.svelte that:

- Renders the text clamped (default 2 lines) and only shows a 'Show more' button when the content actually overflows
- Re-measures overflow with a ResizeObserver so the button appears/disappears correctly when the container is resized
- Resets to collapsed when its text prop changes, so component instances reused across {#each} iterations don't carry stale state
- Expands inline (the same box grows) but caps the expanded height at 10em with overflow-y: auto + overscroll-behavior: contain, so very long descriptions scroll inside the box instead of pushing the rest of the page around
- Exposes clampLines and expandedMaxHeight props for per-call-site tuning
- Uses aria-expanded on the toggle button

Wired into the four card sites above. Skipped table rows (already open a detail modal), short hardcoded hints, and headings that already have title= tooltips.