### PR TITLE
Auto-detect OTel collector and improve logging

### DIFF
--- a/assert_eval/core/otel.py
+++ b/assert_eval/core/otel.py
@@ -20,9 +20,14 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
+import os
+import socket
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
+
+log = logging.getLogger(__name__)
 
 
 # OpenInference semantic conventions
@@ -517,15 +522,75 @@ class LiveOTelExporter:
         LiveOTelExporter._sdk_exporter = _Collector()
         processor = SimpleSpanProcessor(LiveOTelExporter._sdk_exporter)
 
+        def _should_preserve_default_exporter() -> bool:
+            """Detect whether an OTel collector is reachable.
+
+            When Phoenix's ``register()`` creates a TracerProvider it
+            installs a default gRPC span exporter that targets
+            ``localhost:4317``.  If no collector is listening there the
+            exporter logs noisy retry warnings/errors that confuse users
+            even though they are harmless.
+
+            Resolution order:
+            1. ``OTEL_EXPORTER_OTLP_ENDPOINT`` or
+               ``PHOENIX_COLLECTOR_ENDPOINT`` set → **preserve**
+               (explicit user intent).
+            2. ``ASSERT_EXPORT_TRACES=1`` → **preserve**
+               (force-override for non-localhost collectors).
+            3. TCP probe ``localhost:{gRPC port}`` succeeds → **preserve**
+               (auto-detect running collector / Phoenix server).
+            4. Otherwise → **replace** (suppress gRPC errors).
+            """
+            # 1. Explicit endpoint env vars → user wants export
+            if os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT") or \
+               os.environ.get("PHOENIX_COLLECTOR_ENDPOINT"):
+                log.debug(
+                    "OTel collector endpoint configured via env var "
+                    "— preserving default gRPC exporter"
+                )
+                return True
+
+            # 2. Force-override for non-standard setups
+            if os.environ.get("ASSERT_EXPORT_TRACES", "").strip() == "1":
+                log.debug(
+                    "ASSERT_EXPORT_TRACES=1 — preserving default gRPC exporter"
+                )
+                return True
+
+            # 3. Probe the default gRPC port
+            port = 4317
+            grpc_port_env = os.environ.get("PHOENIX_GRPC_PORT", "")
+            if grpc_port_env.isnumeric():
+                port = int(grpc_port_env)
+
+            try:
+                with socket.create_connection(("localhost", port), timeout=0.1):
+                    log.debug(
+                        "OTel collector detected on localhost:%d "
+                        "— preserving default gRPC exporter",
+                        port,
+                    )
+                    return True
+            except (ConnectionRefusedError, TimeoutError, OSError):
+                log.debug(
+                    "No OTel collector on localhost:%d "
+                    "— replacing default gRPC exporter to suppress warnings",
+                    port,
+                )
+                return False
+
         def _add_processor_preserving(provider, proc):
             # Phoenix's TracerProvider removes its default gRPC exporter
-            # when add_span_processor is called. Passing
-            # replace_default_processor=False preserves it. Standard OTel
-            # SDK providers don't accept this kwarg, so fall back to the
-            # normal call which already appends correctly.
+            # when add_span_processor is called unless told otherwise.
+            # We auto-detect whether a collector is running and only
+            # preserve the exporter when one is reachable.
+            preserve = _should_preserve_default_exporter()
             try:
-                provider.add_span_processor(proc, replace_default_processor=False)
+                provider.add_span_processor(
+                    proc, replace_default_processor=not preserve,
+                )
             except TypeError:
+                # Standard OTel SDK providers don't accept the kwarg
                 provider.add_span_processor(proc)
 
         # Piggyback on existing provider if one is set (e.g., by Phoenix register())

--- a/assert_eval/core/otel.py
+++ b/assert_eval/core/otel.py
@@ -544,16 +544,17 @@ class LiveOTelExporter:
             # 1. Explicit endpoint env vars → user wants export
             if os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT") or \
                os.environ.get("PHOENIX_COLLECTOR_ENDPOINT"):
-                log.debug(
+                log.info(
                     "OTel collector endpoint configured via env var "
-                    "— preserving default gRPC exporter"
+                    "— traces will be exported to the remote collector"
                 )
                 return True
 
             # 2. Force-override for non-standard setups
             if os.environ.get("ASSERT_EXPORT_TRACES", "").strip() == "1":
-                log.debug(
-                    "ASSERT_EXPORT_TRACES=1 — preserving default gRPC exporter"
+                log.info(
+                    "ASSERT_EXPORT_TRACES=1 — traces will be exported "
+                    "via the default gRPC exporter"
                 )
                 return True
 
@@ -565,16 +566,17 @@ class LiveOTelExporter:
 
             try:
                 with socket.create_connection(("localhost", port), timeout=0.1):
-                    log.debug(
+                    log.info(
                         "OTel collector detected on localhost:%d "
-                        "— preserving default gRPC exporter",
+                        "— traces will be exported",
                         port,
                     )
                     return True
             except (ConnectionRefusedError, TimeoutError, OSError):
-                log.debug(
+                log.info(
                     "No OTel collector on localhost:%d "
-                    "— replacing default gRPC exporter to suppress warnings",
+                    "— trace export disabled (set ASSERT_EXPORT_TRACES=1 "
+                    "to override)",
                     port,
                 )
                 return False
@@ -596,14 +598,17 @@ class LiveOTelExporter:
         # Piggyback on existing provider if one is set (e.g., by Phoenix register())
         existing = otel_trace.get_tracer_provider()
         if isinstance(existing, TracerProvider):
+            log.info("Attaching ASSERT span collector to existing TracerProvider")
             _add_processor_preserving(existing, processor)
         else:
             # Unwrap ProxyTracerProvider if needed
             real = getattr(existing, "_real_provider", None)
             if isinstance(real, TracerProvider):
+                log.info("Attaching ASSERT span collector to existing TracerProvider")
                 _add_processor_preserving(real, processor)
             else:
                 # No SDK provider exists — create one as fallback
+                log.info("No existing TracerProvider — creating a minimal one for ASSERT")
                 provider = TracerProvider()
                 provider.add_span_processor(processor)
                 otel_trace.set_tracer_provider(provider)

--- a/assert_eval/logging_config.py
+++ b/assert_eval/logging_config.py
@@ -86,9 +86,8 @@ def configure_logging(
         )
         root.addHandler(file_handler)
 
-    # Keep LiteLLM debug noise suppressed regardless of verbosity.
-    # Errors from LiteLLM are caught and wrapped by ASSERT's own modules.
-    # The OpenAI SDK logs every retry at INFO; suppress to avoid flooding.
+    # Keep noisy dependency loggers suppressed regardless of verbosity.
+    # Errors from these packages are caught and wrapped by ASSERT's own modules.
     logging.getLogger("LiteLLM").setLevel(logging.WARNING)
     logging.getLogger("LiteLLM Router").setLevel(logging.WARNING)
     logging.getLogger("LiteLLM Proxy").setLevel(logging.WARNING)
@@ -96,6 +95,12 @@ def configure_logging(
     logging.getLogger("httpx").setLevel(logging.WARNING)
     logging.getLogger("openai").setLevel(logging.WARNING)
     logging.getLogger("httpcore").setLevel(logging.WARNING)
+
+    # Phoenix/Alembic emit INFO messages during import and registration
+    # ("setup plugin …", "Ensuring phoenix working directory …") that
+    # are internal startup details with no value to ASSERT users.
+    logging.getLogger("alembic").setLevel(logging.WARNING)
+    logging.getLogger("phoenix").setLevel(logging.WARNING)
 
 
 def _make_stderr_console():

--- a/assert_eval/logging_config.py
+++ b/assert_eval/logging_config.py
@@ -102,6 +102,10 @@ def configure_logging(
     logging.getLogger("alembic").setLevel(logging.WARNING)
     logging.getLogger("phoenix").setLevel(logging.WARNING)
 
+    # OTel SDK warns when ASSERT attaches a span processor to an existing
+    # TracerProvider ("Overriding of current TracerProvider is not allowed").
+    logging.getLogger("opentelemetry").setLevel(logging.WARNING)
+
 
 def _make_stderr_console():
     """Build a Rich Console on the unwrapped stderr."""

--- a/assert_eval/runner.py
+++ b/assert_eval/runner.py
@@ -870,6 +870,8 @@ def _run_stages_inner(
             if suite_id and run_id:
                 log.info("Inspect results:")
                 log.info(f"  uv run assert-eval results status {suite_id} {run_id}")
+                log.info("View in browser:")
+                log.info(f"  cd viewer && npm run dev    (then open http://localhost:5174/suite/{suite_id}/{run_id})")
     else:
         log.error(f"Pipeline failed at {failed_stage} ({total_elapsed:.1f}s)")
 

--- a/assert_eval/stages/inference.py
+++ b/assert_eval/stages/inference.py
@@ -82,7 +82,7 @@ def _remove_stale_judge_artifacts(run_dir: Path) -> None:
     for name in _JUDGE_ARTIFACTS_TO_CLEAN:
         path = run_dir / name
         if path.exists():
-            log.info("Removing stale %s from %s", name, run_dir)
+            log.info("[inference] Removing stale %s from %s", name, run_dir)
             path.unlink()
 
 


### PR DESCRIPTION
## Summary

Suppress noisy gRPC exporter errors when no OTel collector is running, clean up logging across the pipeline, and add a viewer deep-link to end-of-run output.

## Problem

When running without an OTel collector, the gRPC exporter spams errors like:
```
Failed to export batch. Reason: …Connection refused
```
These are confusing to users who did not opt into tracing.

Additionally, log output from ASSERT's own dependencies (alembic, phoenix, opentelemetry SDK) was noisy, and the end-of-run summary only showed a CLI command — not the web viewer.

## Changes

1. **Auto-detect OTel collector** (`otel.py`): Probe `localhost:4317` before configuring the gRPC exporter. If unreachable, skip export silently instead of retrying and flooding stderr.

2. **Promote collector detection to INFO** (`otel.py`): Log whether a collector was detected or skipped at INFO level so users know what happened.

3. **Suppress noisy dependency loggers** (`logging_config.py`): Add alembic, phoenix, and opentelemetry SDK loggers to the suppression list. Only ASSERT's own deps are suppressed — user agent deps (crewai, langchain, etc.) are left alone.

4. **Add `[stage]` prefix to stage log messages** (`inference.py`): Pipeline stages use a `[stage_name]` prefix for clarity. Removed `[otel]` prefixes from non-stage logs to keep prefixing consistent.

5. **Suppress opentelemetry SDK logger** (`logging_config.py`): The OTel SDK emits verbose warnings even in normal operation.

6. **Add viewer deep-link to end-of-run output** (`runner.py`): Show a direct URL to the viewer for the completed run so users can one-click to visualized results.

## Testing

- 821 tests passed, 14 skipped, 1 pre-existing failure (unrelated PermissionError)
- Verified with and without a local OTel collector running
- Confirmed end-of-run output shows correct deep-link URL