### PR TITLE
docs: refresh README ASSERT branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,16 @@
-<p align="center">
-  <img src="logo.jpg" alt="Adaptive Eval" width="60%">
-</p>
+# ASSERT
 
-# Adaptive Eval
+**ASSERT** stands for **Adaptive Spec-driven Scoring for Evaluation and Regression Testing**.
 
-**Spec-driven evaluation for any agent or multi-agent system - local-first, framework-agnostic, and trace-aware.**
+ASSERT is a local-first, framework-agnostic, trace-aware evaluation harness for agents and multi-agent systems.
 
-> **Customer preview.** Adaptive Eval is a preview / POC distribution for design partners. The core workflow is stable: write an eval spec, generate targeted test cases, execute them against your agent, and judge the results against your rubric. Some YAML field names are still evolving; the docs bridge current names to the intended developer-facing terminology.
+> **Customer preview.** ASSERT is a preview / POC distribution for design partners. The core workflow is stable: write an eval spec, generate targeted test cases, execute them against your agent, and judge the results against your rubric. Some YAML field names are still evolving; the docs bridge current names to the intended developer-facing terminology.
 
-## Why Adaptive Eval
+## Why ASSERT
 
 Most eval tools start with a fixed benchmark. Real agents fail in product-specific ways: they call the wrong tool, ignore a constraint, fabricate a price, skip a safety check, or agree with a risky plan.
 
-Adaptive Eval flips the workflow. **You write a short spec describing what your agent should and should not do.** The pipeline derives behavior categories, generates single-turn and multi-turn test cases, executes them against your target, and uses an LLM judge to score each conversation against your spec. **Any agent or multi-agent system** that runs in Python plugs in through `target.callable`. The recommended integration captures the agent's OpenTelemetry spans (Phoenix/OpenInference auto-instruments 33+ frameworks in two lines, or you can emit your own with the OTel SDK) so the judge can inspect tool calls, arguments, routing, latency, and intermediate decisions — not just the final response.
+ASSERT flips the workflow. **You write a short spec describing what your agent should and should not do.** The pipeline derives behavior categories, generates single-turn and multi-turn test cases, executes them against your target, and uses an LLM judge to score each conversation against your spec. **Any agent or multi-agent system** that runs in Python plugs in through `target.callable`. The recommended integration captures the agent's OpenTelemetry spans (Phoenix/OpenInference auto-instruments 33+ frameworks in two lines, or you can emit your own with the OTel SDK) so the judge can inspect tool calls, arguments, routing, latency, and intermediate decisions — not just the final response.
 
 You get:
 
@@ -48,7 +46,7 @@ assert-eval results status travel-planner-langgraph-v1 demo-1
 
 Codespaces / VS Code Dev Containers:
 
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/microsoft/adaptive-eval)
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/microsoft/ASSERT)
 
 The repo includes a minimal dev container for the LangGraph quickstart. It installs `.[otel,langgraph,dev]`, copies `.env.example` to `.env` if needed, and forwards Phoenix on port `6006`. After the container finishes setup, add your provider credentials to `.env` and run the same `assert-eval run` command above.
 
@@ -171,7 +169,7 @@ Browse them with the CLI, the local viewer, or any JSONL tool. Nothing leaves yo
 
 ## Status
 
-Adaptive Eval is a customer preview / POC, not a GA service.
+ASSERT is a customer preview / POC, not a GA service.
 
 Stable enough to try:
 
@@ -207,7 +205,7 @@ This project may contain trademarks or logos for projects, products, or services
 
 ## Important: Risks and limitations
 
-Adaptive Evaluation is designed to generate and run scenario-based evaluations for AI systems, including adversarial and edge-case tests. These scenarios are intended to help surface potential weaknesses, unsafe behaviors, and other undesirable outcomes. They do not guarantee that a system has failed, nor are they guarantees that a system is safe.
+ASSERT is designed to generate and run scenario-based evaluations for AI systems, including adversarial and edge-case tests. These scenarios are intended to help surface potential weaknesses, unsafe behaviors, and other undesirable outcomes. They do not guarantee that a system has failed, nor are they guarantees that a system is safe.
 
 Because generated scenarios can meaningfully affect system behavior, using this product without adequate sandboxing or environment controls can cause real-world side effects. Depending on the target system, evaluations may trigger unwanted actions such as data modification or deletion, information disclosure, code or configuration changes, external messages, or other operational impacts.
 
@@ -220,7 +218,7 @@ You are responsible for ensuring that evaluations run only in environments that 
 
 You should review generated adversarial or stress-test prompts before use and confirm that your environment can safely handle them. Some generated scenarios may involve jailbreak-style behavior, prompt injection, tool misuse, over-broad requests, or other forms of adversarial interaction.
 
-Adaptive Evaluation is not a compliance or certification tool. You and your users remain responsible for ensuring that evaluated systems comply with applicable laws, regulations, contractual obligations, internal policies, and industry standards.
+ASSERT is not a compliance or certification tool. You and your users remain responsible for ensuring that evaluated systems comply with applicable laws, regulations, contractual obligations, internal policies, and industry standards.
 
 Use of this system may also result in meaningful compute and inference costs. You should monitor usage, model calls, tool execution, and resource consumption during evaluations.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # ASSERT
 
-**ASSERT** stands for **Adaptive Spec-driven Scoring for Evaluation and Regression Testing**.
-
-ASSERT is a local-first, framework-agnostic, trace-aware evaluation harness for agents and multi-agent systems.
+**ASSERT** (**Adaptive Spec-driven Scoring for Evaluation and Regression Testing**) is a local-first, framework-agnostic, trace-aware evaluation harness for agents and multi-agent systems.
 
 > **Customer preview.** ASSERT is a preview / POC distribution for design partners. The core workflow is stable: write an eval spec, generate targeted test cases, execute them against your agent, and judge the results against your rubric. Some YAML field names are still evolving; the docs bridge current names to the intended developer-facing terminology.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ASSERT
 
-**ASSERT** (**Adaptive Spec-driven Scoring for Evaluation and Regression Testing**) is a local-first, framework-agnostic, trace-aware evaluation harness for agents and multi-agent systems.
+**ASSERT** (**A**daptive **S**pec-driven **S**coring for **E**valuation and **R**egression **T**esting) is a local-first, framework-agnostic, trace-aware evaluation harness for agents and multi-agent systems.
 
 > **Customer preview.** ASSERT is a preview / POC distribution for design partners. The core workflow is stable: write an eval spec, generate targeted test cases, execute them against your agent, and judge the results against your rubric. Some YAML field names are still evolving; the docs bridge current names to the intended developer-facing terminology.
 


### PR DESCRIPTION
## Summary
- updates the README title and top-level preview wording from Adaptive Eval to ASSERT
- defines the ASSERT acronym at the top of the README
- updates the Codespaces link to microsoft/ASSERT
- removes remaining Adaptive Eval / adaptive-eval references from README.md

## Validation
- scanned README.md for stale Adaptive Eval, Adaptive Evaluation, adaptive-eval, microsoft/adaptive-eval, and logo.jpg references
- checked local README markdown links resolve
