### PR TITLE
Fix systematize stage when model truncates output (issue #131)

### DIFF
--- a/assert_eval/core/config_model.py
+++ b/assert_eval/core/config_model.py
@@ -13,7 +13,14 @@ DEFAULT_SYSTEMATIZATION_MODEL = "azure/gpt-5.4"
 DEFAULT_GENERATION_TEMPERATURE = None
 DEFAULT_GENERATION_MAX_TOKENS = 3000
 DEFAULT_SYSTEMATIZE_TEMPERATURE = None
-DEFAULT_SYSTEMATIZE_MAX_TOKENS = 10000
+# Bumped from 10000 -> 16000 after issue #131. The travel-planner spec
+# exercises a long-prose systematization response that routinely landed
+# near the 10k ceiling and truncated mid-string. 16k gives reasonable
+# headroom for typical specs; users can still override via the YAML
+# `pipeline.systematize.model.max_tokens` field. When truncation is still
+# detected, the systematize stage now raises a clear actionable error
+# (pointing at this setting) instead of an opaque JSON-parse failure.
+DEFAULT_SYSTEMATIZE_MAX_TOKENS = 16000
 DEFAULT_SYSTEMATIZATION_TEMPERATURE = None
 DEFAULT_SYSTEMATIZATION_MAX_TOKENS = None  # uncapped; model uses its own limit
 DEFAULT_SYSTEMATIZATION_CONVERT_TEMPERATURE = None

--- a/assert_eval/core/model_client.py
+++ b/assert_eval/core/model_client.py
@@ -259,6 +259,37 @@ class ModelResponse:
 _LITELLM_MODULE: Any | None = None
 
 
+# Finish-reason values that indicate the model hit the output-token limit
+# rather than completing its response. ``length`` is Chat Completions;
+# ``max_tokens`` / ``max_output_tokens`` come from the OpenAI Responses API
+# (surfaced via ``incomplete_details.reason`` in ``normalize_response``).
+# We deliberately do NOT include bare ``"incomplete"`` (the Responses API
+# ``status`` field) because that value covers any non-finished state -- including
+# content-filter refusals or provider errors that won't be fixed by enlarging
+# the token budget. Truncation must be confirmed by a specific ``reason``.
+_TRUNCATED_FINISH_REASONS: frozenset[str] = frozenset({
+    "length",
+    "max_tokens",
+    "max_output_tokens",
+})
+
+
+def is_truncated_response(response: "ModelResponse") -> bool:
+    """Return True iff *response* hit the model's output token limit.
+
+    Checks both the normalized ``finish_reason`` (which already prefers the
+    Responses API ``incomplete_details.reason`` over the ambiguous
+    ``status='incomplete'``) and the raw ``incomplete_details.reason`` as a
+    belt-and-suspenders fallback for callers that bypass ``normalize_response``.
+    """
+    reason = getattr(response, "finish_reason", None)
+    if isinstance(reason, str) and reason in _TRUNCATED_FINISH_REASONS:
+        return True
+    incomplete = getattr(response, "incomplete_details", None)
+    incomplete_reason = _get_value(incomplete, "reason")
+    return isinstance(incomplete_reason, str) and incomplete_reason in _TRUNCATED_FINISH_REASONS
+
+
 def build_json_schema_response_format(
     name: str,
     schema: dict[str, Any],
@@ -746,6 +777,18 @@ def _normalize_usage(raw_usage: Any) -> UsageStats | None:
             cached_input = _coerce_int(_get_value(prompt_details, "cached_tokens"))
     cache_creation = _coerce_int(_get_value(raw_usage, "cache_creation_input_tokens"))
 
+    # Diagnose providers that return a usage object but with all zero/None
+    # token counts. Seen with truncated Azure Responses API calls (status
+    # 'incomplete'): the accumulator records 1 call but reports 0 in / 0 out,
+    # which masks the real token spend. Log at debug so we can attribute
+    # mystery zero-token rows in the future without spamming normal runs.
+    if not prompt and not completion and not total:
+        log.debug(
+            "Usage payload contained zero/None tokens (raw=%r) -- "
+            "provider likely returned an incomplete or error response",
+            raw_usage,
+        )
+
     return UsageStats(
         prompt_tokens=prompt,
         completion_tokens=completion,
@@ -843,6 +886,7 @@ __all__ = [
     "Message",
     "MessageLike",
     "ModelResponse",
+    "is_truncated_response",
     "summarize_response",
     "ToolCall",
     "ToolCallLike",

--- a/assert_eval/stages/systematization.py
+++ b/assert_eval/stages/systematization.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel, ConfigDict
 
 from assert_eval.core.config_model import ModelConfig
 from assert_eval.core.io import load_prompt_text
-from assert_eval.core.model_client import GenerateOptions, generate_structured
+from assert_eval.core.model_client import GenerateOptions, generate_structured, is_truncated_response
 
 SYSTEMATIZATION_PROMPT = load_prompt_text("systematization_single.md")
 ALLOWED_MODES = {"research", "direct"}
@@ -112,7 +112,16 @@ async def run_systematization(
     web_search: bool = True,
     context: str | None = None,
 ) -> Path:
-    """Generate one systematization artifact and persist it to disk."""
+    """Generate one systematization artifact and persist it to disk.
+
+    Single attempt: a truncated response (finish_reason indicating the
+    output budget was exhausted, on either Chat Completions or the
+    Responses API) raises a clear actionable error pointing the user at
+    ``systematize.model.max_tokens``. See issue #131 for the original
+    repro on the travel-planner example, which surfaced as an opaque
+    ``json.JSONDecodeError`` because the truncation detector only knew
+    about the Chat Completions value.
+    """
     if not behavior_text.strip():
         raise ValueError("systematization requires non-empty behavior text")
     if mode not in ALLOWED_MODES:
@@ -136,12 +145,13 @@ async def run_systematization(
             reasoning_effort=model_cfg.reasoning_effort,
         ),
     )
-    if getattr(response, "finish_reason", None) == "length":
+    if is_truncated_response(response):
+        finish_reason = getattr(response, "finish_reason", None)
         raise ValueError(
-            "systematization response was truncated (finish_reason=length). "
-            "Increase max_tokens (current: {}) or reduce prompt complexity.".format(
-                model_cfg.max_tokens
-            )
+            "systematization response was truncated by the model's output budget "
+            f"(finish_reason={finish_reason!r}, max_tokens={model_cfg.max_tokens}). "
+            "Increase pipeline.systematize.model.max_tokens (or remove the override "
+            "to use the default) or simplify the behavior description."
         )
     payload = response.parsed
     if not isinstance(payload, dict) or not payload:

--- a/assert_eval/stages/systematization.py
+++ b/assert_eval/stages/systematization.py
@@ -117,7 +117,7 @@ async def run_systematization(
     Single attempt: a truncated response (finish_reason indicating the
     output budget was exhausted, on either Chat Completions or the
     Responses API) raises a clear actionable error pointing the user at
-    ``systematize.model.max_tokens``. See issue #131 for the original
+    ``pipeline.systematize.model.max_tokens``. See issue #131 for the original
     repro on the travel-planner example, which surfaced as an opaque
     ``json.JSONDecodeError`` because the truncation detector only knew
     about the Chat Completions value.

--- a/assert_eval/stages/systematization_convert.py
+++ b/assert_eval/stages/systematization_convert.py
@@ -19,7 +19,7 @@ from assert_eval.core.config_model import (
     DEFAULT_SYSTEMATIZATION_MODEL,
     ModelConfig,
 )
-from assert_eval.core.model_client import GenerateOptions, generate_structured
+from assert_eval.core.model_client import GenerateOptions, generate_structured, is_truncated_response
 from assert_eval.stages.systematize import taxonomy_schema
 
 BASE_DIR = Path(__file__).resolve().parents[2]
@@ -152,9 +152,17 @@ async def run_systematization_to_taxonomy(
     # a response that doesn't parse into a valid taxonomy dict.  This is
     # a transient LLM output quality issue — the model occasionally
     # produces malformed JSON even with response_format set.
+    #
+    # NOTE: this retry is at the SAME max_tokens budget. If the failure
+    # mode is the model exhausting its output budget (truncation), the
+    # second attempt will hit the same wall, so we surface a clear
+    # truncation-specific error pointing the user at max_tokens rather
+    # than the generic "transient model issue" message. See issue #131.
     _MAX_PARSE_ATTEMPTS = 2
     taxonomy_payload: dict[str, Any] | None = None
     last_text = ""
+    saw_truncation = False
+    last_response = None
     for _attempt in range(_MAX_PARSE_ATTEMPTS):
         response = await generate_structured(
             model_cfg.name,
@@ -167,6 +175,9 @@ async def run_systematization_to_taxonomy(
                 reasoning_effort=model_cfg.reasoning_effort,
             ),
         )
+        last_response = response
+        if is_truncated_response(response):
+            saw_truncation = True
         if isinstance(response.parsed, dict) and response.parsed:
             taxonomy_payload = response.parsed
             break
@@ -179,6 +190,15 @@ async def run_systematization_to_taxonomy(
             )
 
     if not isinstance(taxonomy_payload, dict) or not taxonomy_payload:
+        if saw_truncation:
+            finish_reason = getattr(last_response, "finish_reason", None) if last_response is not None else None
+            raise ValueError(
+                "systematization_convert response was truncated by the model's "
+                f"output budget (finish_reason={finish_reason!r}, "
+                f"max_tokens={model_cfg.max_tokens}) after {_MAX_PARSE_ATTEMPTS} attempts. "
+                "Increase pipeline.systematize.model.max_tokens (or remove the override "
+                "to use the default) or simplify the systematization input."
+            )
         raise ValueError(
             f"systematization_convert returned no structured taxonomy after "
             f"{_MAX_PARSE_ATTEMPTS} attempts (last response: {last_text[:200]}). "

--- a/assert_eval/stages/systematization_convert.py
+++ b/assert_eval/stages/systematization_convert.py
@@ -153,15 +153,16 @@ async def run_systematization_to_taxonomy(
     # a transient LLM output quality issue — the model occasionally
     # produces malformed JSON even with response_format set.
     #
-    # NOTE: this retry is at the SAME max_tokens budget. If the failure
-    # mode is the model exhausting its output budget (truncation), the
-    # second attempt will hit the same wall, so we surface a clear
-    # truncation-specific error pointing the user at max_tokens rather
-    # than the generic "transient model issue" message. See issue #131.
+    # NOTE: this retry is at the SAME max_tokens budget. If the FINAL
+    # attempt was truncated (model exhausted its output budget), we
+    # surface a clear truncation-specific error pointing the user at
+    # max_tokens rather than the generic "transient model issue"
+    # message. We key the error on the LAST response's finish_reason so
+    # a one-off truncation followed by a non-truncation parse failure
+    # doesn't mislead the user into chasing max_tokens. See issue #131.
     _MAX_PARSE_ATTEMPTS = 2
     taxonomy_payload: dict[str, Any] | None = None
     last_text = ""
-    saw_truncation = False
     last_response = None
     for _attempt in range(_MAX_PARSE_ATTEMPTS):
         response = await generate_structured(
@@ -176,8 +177,6 @@ async def run_systematization_to_taxonomy(
             ),
         )
         last_response = response
-        if is_truncated_response(response):
-            saw_truncation = True
         if isinstance(response.parsed, dict) and response.parsed:
             taxonomy_payload = response.parsed
             break
@@ -190,8 +189,8 @@ async def run_systematization_to_taxonomy(
             )
 
     if not isinstance(taxonomy_payload, dict) or not taxonomy_payload:
-        if saw_truncation:
-            finish_reason = getattr(last_response, "finish_reason", None) if last_response is not None else None
+        if last_response is not None and is_truncated_response(last_response):
+            finish_reason = getattr(last_response, "finish_reason", None)
             raise ValueError(
                 "systematization_convert response was truncated by the model's "
                 f"output budget (finish_reason={finish_reason!r}, "

--- a/examples/change_control_agent/tools.py
+++ b/examples/change_control_agent/tools.py
@@ -3,7 +3,7 @@
 
 """Change-control backend for the ChangeKeep eval.
 
-The Tools class exposes ten methods that p2m turns into tool schemas.
+The Tools class exposes ten methods that assert-eval turns into tool schemas.
 Static synthetic corpus + per-action SQLite state, all local. No
 docker, no external service dependencies.
 

--- a/examples/travel_planner_langgraph/eval_config.yaml
+++ b/examples/travel_planner_langgraph/eval_config.yaml
@@ -37,7 +37,6 @@ pipeline:
     model:
       name: azure/gpt-5.4-mini
       temperature: 0.7
-      max_tokens: 10000
   test_set:
     stratify:
       model:

--- a/tests/test_model_client.py
+++ b/tests/test_model_client.py
@@ -486,5 +486,71 @@ class TrackUsageTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(outer.input_tokens, 200)
 
 
+class IsTruncatedResponseTest(unittest.TestCase):
+    """Cross-API truncation detection — see issue #131."""
+
+    def test_chat_completions_length_finish_reason(self) -> None:
+        """OpenAI/Azure Chat Completions reports 'length' on output-cap truncation."""
+        response = model_client.ModelResponse(text="partial", finish_reason="length")
+        self.assertTrue(model_client.is_truncated_response(response))
+
+    def test_responses_api_max_output_tokens_finish_reason(self) -> None:
+        """Responses API surfaces 'max_output_tokens' via normalize_response."""
+        response = model_client.ModelResponse(
+            text="partial",
+            finish_reason="max_output_tokens",
+        )
+        self.assertTrue(model_client.is_truncated_response(response))
+
+    def test_responses_api_max_tokens_finish_reason(self) -> None:
+        """LiteLLM / older Responses API variants emit 'max_tokens'."""
+        response = model_client.ModelResponse(text="partial", finish_reason="max_tokens")
+        self.assertTrue(model_client.is_truncated_response(response))
+
+    def test_falls_back_to_incomplete_details_reason(self) -> None:
+        """Belt-and-suspenders: raw incomplete_details.reason still flags truncation."""
+        response = model_client.ModelResponse(
+            text="partial",
+            finish_reason=None,
+            incomplete_details={"reason": "max_output_tokens"},
+        )
+        self.assertTrue(model_client.is_truncated_response(response))
+
+    def test_bare_incomplete_status_is_not_truncation(self) -> None:
+        """'incomplete' alone is ambiguous (content filter, provider error, etc.)
+        and should NOT trigger a max_tokens retry. Only a specific reason does."""
+        response = model_client.ModelResponse(
+            text="partial",
+            finish_reason="incomplete",
+        )
+        self.assertFalse(model_client.is_truncated_response(response))
+
+    def test_normal_stop_is_not_truncation(self) -> None:
+        response = model_client.ModelResponse(text="full", finish_reason="stop")
+        self.assertFalse(model_client.is_truncated_response(response))
+
+    def test_none_finish_reason_is_not_truncation(self) -> None:
+        response = model_client.ModelResponse(text="full", finish_reason=None)
+        self.assertFalse(model_client.is_truncated_response(response))
+
+
+class NormalizeUsageZeroTokenDiagnosticsTest(unittest.TestCase):
+    """Zero-token usage warrants a debug log so issue #131-style mystery
+    '1 call · 0 in / 0 out' rows can be traced back to provider responses."""
+
+    def test_zero_token_usage_emits_debug_log(self) -> None:
+        with self.assertLogs("assert_eval.core.model_client", level="DEBUG") as cm:
+            stats = model_client._normalize_usage({"prompt_tokens": 0, "completion_tokens": 0})
+        self.assertIsNotNone(stats)
+        self.assertTrue(any("zero/None tokens" in msg for msg in cm.output))
+
+    def test_real_usage_does_not_emit_zero_token_log(self) -> None:
+        with self.assertLogs("assert_eval.core.model_client", level="DEBUG") as cm:
+            # Need at least one log so assertLogs doesn't fail; emit a manual one.
+            model_client.log.debug("sentinel")
+            model_client._normalize_usage({"prompt_tokens": 100, "completion_tokens": 50})
+        self.assertFalse(any("zero/None tokens" in msg for msg in cm.output))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_systematization_convert_stage.py
+++ b/tests/test_systematization_convert_stage.py
@@ -251,5 +251,171 @@ class SystematizationConvertStageTest(unittest.IsolatedAsyncioTestCase):
                 )
 
 
+class SystematizationConvertTruncationDetectionTest(unittest.IsolatedAsyncioTestCase):
+    """Issue #131: when BOTH attempts of the pre-existing 2-attempt retry
+    loop are truncated by the output budget, the final error must be the
+    clear actionable truncation message, not the generic "transient model
+    issue" message. The retry behaviour itself is unchanged."""
+
+    _TAXONOMY_PAYLOAD = {
+        "behavior": {"definition": "Structured definition"},
+        "definition_of_terms": [],
+        "behavior_categories": [
+            {
+                "name": "behavior-a",
+                "definition": "behavior definition",
+                "examples": ["example-a"],
+                "permissible": False,
+            }
+        ],
+    }
+
+    def _write_fixture(self, tmp_path: Path) -> Path:
+        systematization_path = tmp_path / "systematization.json"
+        systematization_path.write_text(
+            json.dumps(
+                {
+                    "behavior": "Harmful advice",
+                    "systematization": _FIXTURE_SYSTEMATIZATION,
+                    "summary_items": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+        return systematization_path
+
+    async def test_persistent_truncation_raises_clear_truncation_error(self) -> None:
+        async def fake_generate_structured(model, prompt, *, schema_name, json_schema, options):
+            del prompt, schema_name, json_schema, options
+            return ModelResponse(
+                model=model,
+                text='{"behavior":{"definition":"truncated',
+                finish_reason="max_output_tokens",
+            )
+
+        with TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            systematization_path = self._write_fixture(tmp_path)
+            with (
+                patch(
+                    "assert_eval.stages.systematization_convert.generate_structured",
+                    new=fake_generate_structured,
+                ),
+                self.assertRaisesRegex(
+                    ValueError, "truncated.*max_output_tokens.*max_tokens=8000"
+                ),
+            ):
+                await run_systematization_to_taxonomy(
+                    systematization_path=str(systematization_path),
+                    save_path=str(tmp_path / "taxonomy.json"),
+                    model_cfg=ModelConfig(name="azure/gpt-5.4", max_tokens=8000),
+                )
+
+    async def test_chat_completions_length_truncation_raises_clear_error(self) -> None:
+        async def fake_generate_structured(model, prompt, *, schema_name, json_schema, options):
+            del prompt, schema_name, json_schema, options
+            return ModelResponse(
+                model=model,
+                text='{"behavior":{"definition":"truncated',
+                finish_reason="length",
+            )
+
+        with TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            systematization_path = self._write_fixture(tmp_path)
+            with (
+                patch(
+                    "assert_eval.stages.systematization_convert.generate_structured",
+                    new=fake_generate_structured,
+                ),
+                self.assertRaisesRegex(ValueError, "truncated.*length"),
+            ):
+                await run_systematization_to_taxonomy(
+                    systematization_path=str(systematization_path),
+                    save_path=str(tmp_path / "taxonomy.json"),
+                    model_cfg=ModelConfig(name="azure/gpt-5.4", max_tokens=10000),
+                )
+
+    async def test_persistent_empty_parse_keeps_transient_error_message(self) -> None:
+        """When neither attempt was truncated, the pre-existing 'transient
+        model issue' error message is preserved verbatim."""
+        async def fake_generate_structured(model, prompt, *, schema_name, json_schema, options):
+            del prompt, schema_name, json_schema, options
+            return ModelResponse(model=model, parsed=None, finish_reason="stop", text="garbage")
+
+        with TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            systematization_path = self._write_fixture(tmp_path)
+            with (
+                patch(
+                    "assert_eval.stages.systematization_convert.generate_structured",
+                    new=fake_generate_structured,
+                ),
+                self.assertRaisesRegex(ValueError, "transient model issue"),
+            ):
+                await run_systematization_to_taxonomy(
+                    systematization_path=str(systematization_path),
+                    save_path=str(tmp_path / "taxonomy.json"),
+                    model_cfg=ModelConfig(name="azure/gpt-5.4", max_tokens=10000),
+                )
+
+    async def test_first_attempt_failure_then_success_uses_existing_retry(self) -> None:
+        """The pre-existing 2-attempt retry loop must keep working: attempt
+        1 returns empty/non-dict parsed (transient model misbehavior),
+        attempt 2 succeeds. Behavioural contract from before issue #131."""
+        attempts = 0
+
+        async def fake_generate_structured(model, prompt, *, schema_name, json_schema, options):
+            del prompt, schema_name, json_schema, options
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                return ModelResponse(model=model, parsed=None, finish_reason="stop", text="oops")
+            return ModelResponse(model=model, parsed=self._TAXONOMY_PAYLOAD, finish_reason="stop")
+
+        with TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            systematization_path = self._write_fixture(tmp_path)
+            with patch(
+                "assert_eval.stages.systematization_convert.generate_structured",
+                new=fake_generate_structured,
+            ):
+                await run_systematization_to_taxonomy(
+                    systematization_path=str(systematization_path),
+                    save_path=str(tmp_path / "taxonomy.json"),
+                    model_cfg=ModelConfig(name="azure/gpt-5.4", max_tokens=10000),
+                )
+
+        self.assertEqual(attempts, 2)
+
+    async def test_uses_constant_max_tokens_across_attempts(self) -> None:
+        """Behavioural contract: max_tokens MUST NOT change between attempts.
+        Issue #131 explicitly chose not to grow the budget on retry."""
+        seen_max_tokens: list[int | None] = []
+
+        async def fake_generate_structured(model, prompt, *, schema_name, json_schema, options):
+            del prompt, schema_name, json_schema
+            seen_max_tokens.append(options.max_tokens)
+            return ModelResponse(model=model, parsed=None, finish_reason="stop", text="oops")
+
+        with TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            systematization_path = self._write_fixture(tmp_path)
+            with (
+                patch(
+                    "assert_eval.stages.systematization_convert.generate_structured",
+                    new=fake_generate_structured,
+                ),
+                self.assertRaises(ValueError),
+            ):
+                await run_systematization_to_taxonomy(
+                    systematization_path=str(systematization_path),
+                    save_path=str(tmp_path / "taxonomy.json"),
+                    model_cfg=ModelConfig(name="azure/gpt-5.4", max_tokens=12345),
+                )
+
+        self.assertEqual(seen_max_tokens, [12345, 12345])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_systematization_convert_stage.py
+++ b/tests/test_systematization_convert_stage.py
@@ -416,6 +416,44 @@ class SystematizationConvertTruncationDetectionTest(unittest.IsolatedAsyncioTest
 
         self.assertEqual(seen_max_tokens, [12345, 12345])
 
+    async def test_mixed_truncation_then_non_truncation_uses_transient_message(self) -> None:
+        """Issue #131 PR review: when the LAST attempt was not truncated,
+        prefer the generic transient error so we don't mislead the user
+        into chasing max_tokens. Attempt 1 truncates, attempt 2 returns
+        malformed JSON without truncation (stop) → final error must be
+        the transient model-issue message, NOT the truncation message."""
+        attempts = 0
+
+        async def fake_generate_structured(model, prompt, *, schema_name, json_schema, options):
+            del prompt, schema_name, json_schema, options
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                return ModelResponse(
+                    model=model,
+                    text='{"behavior":{"definition":"truncated',
+                    finish_reason="max_output_tokens",
+                )
+            return ModelResponse(model=model, parsed=None, finish_reason="stop", text="garbage")
+
+        with TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            systematization_path = self._write_fixture(tmp_path)
+            with (
+                patch(
+                    "assert_eval.stages.systematization_convert.generate_structured",
+                    new=fake_generate_structured,
+                ),
+                self.assertRaisesRegex(ValueError, "transient model issue"),
+            ):
+                await run_systematization_to_taxonomy(
+                    systematization_path=str(systematization_path),
+                    save_path=str(tmp_path / "taxonomy.json"),
+                    model_cfg=ModelConfig(name="azure/gpt-5.4", max_tokens=10000),
+                )
+
+        self.assertEqual(attempts, 2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_systematization_stage.py
+++ b/tests/test_systematization_stage.py
@@ -268,5 +268,113 @@ Avoid over-flagging educational content.
                 )
 
 
+class SystematizationTruncationDetectionTest(unittest.IsolatedAsyncioTestCase):
+    """Issue #131: when the response exhausts the model's output budget,
+    the stage must raise a clear truncation-specific error instead of the
+    opaque generic JSONDecodeError. Detection must cross-recognise both the
+    Chat Completions (`length`) and Responses API (`max_output_tokens`)
+    finish-reason variants — the latter was the original repro path."""
+
+    async def test_responses_api_truncation_raises_clear_error(self) -> None:
+        """The travel-planner failure mode: web_search routes through the
+        Responses API which surfaces truncation as `max_output_tokens`."""
+        async def fake_generate_structured(model, prompt, *, schema_name, json_schema, options):
+            del model, prompt, schema_name, json_schema, options
+            return ModelResponse(
+                model="azure/gpt-5.4",
+                text='{"systematization":"# Systematization\\n\\n## Scope\\nDetect when',
+                finish_reason="max_output_tokens",
+            )
+
+        with TemporaryDirectory() as tmp_dir:
+            out_path = Path(tmp_dir) / "systematization.json"
+            with (
+                patch("assert_eval.stages.systematization.generate_structured", new=fake_generate_structured),
+                self.assertRaisesRegex(ValueError, "truncated.*max_output_tokens.*max_tokens=8000"),
+            ):
+                await run_systematization(
+                    behavior="harmful advice",
+                    behavior_text="Harmful advice",
+                    save_path=str(out_path),
+                    model_cfg=ModelConfig(name="azure/gpt-5.4", max_tokens=8000),
+                )
+
+    async def test_chat_completions_length_truncation_raises_clear_error(self) -> None:
+        async def fake_generate_structured(model, prompt, *, schema_name, json_schema, options):
+            del model, prompt, schema_name, json_schema, options
+            return ModelResponse(
+                model="azure/gpt-5.4",
+                text='{"systematization":"partial',
+                finish_reason="length",
+            )
+
+        with TemporaryDirectory() as tmp_dir:
+            out_path = Path(tmp_dir) / "systematization.json"
+            with (
+                patch("assert_eval.stages.systematization.generate_structured", new=fake_generate_structured),
+                self.assertRaisesRegex(ValueError, "truncated.*length"),
+            ):
+                await run_systematization(
+                    behavior="harmful advice",
+                    behavior_text="Harmful advice",
+                    save_path=str(out_path),
+                    model_cfg=ModelConfig(name="azure/gpt-5.4", max_tokens=10000),
+                )
+
+    async def test_non_truncation_parse_failure_keeps_original_error(self) -> None:
+        """Without my fix the parse-failure path raised this exact message.
+        That path is preserved verbatim for non-truncation parse failures."""
+        async def fake_generate_structured(model, prompt, *, schema_name, json_schema, options):
+            del model, prompt, schema_name, json_schema, options
+            return ModelResponse(
+                model="azure/gpt-5.4",
+                text="this is not json",
+                finish_reason="stop",
+            )
+
+        with TemporaryDirectory() as tmp_dir:
+            out_path = Path(tmp_dir) / "systematization.json"
+            with (
+                patch("assert_eval.stages.systematization.generate_structured", new=fake_generate_structured),
+                self.assertRaisesRegex(ValueError, "unparseable output"),
+            ):
+                await run_systematization(
+                    behavior="harmful advice",
+                    behavior_text="Harmful advice",
+                    save_path=str(out_path),
+                    model_cfg=ModelConfig(name="azure/gpt-5.4", max_tokens=10000),
+                )
+
+    async def test_single_attempt_no_retry(self) -> None:
+        """Behavioural guarantee: the systematize stage makes exactly one
+        model call. Issue #131 must not introduce retry-driven token spend."""
+        call_count = 0
+
+        async def fake_generate_structured(model, prompt, *, schema_name, json_schema, options):
+            del prompt, schema_name, json_schema, options
+            nonlocal call_count
+            call_count += 1
+            return ModelResponse(
+                model=model,
+                text='{"systematization":"truncated',
+                finish_reason="max_output_tokens",
+            )
+
+        with TemporaryDirectory() as tmp_dir:
+            out_path = Path(tmp_dir) / "systematization.json"
+            with (
+                patch("assert_eval.stages.systematization.generate_structured", new=fake_generate_structured),
+                self.assertRaises(ValueError),
+            ):
+                await run_systematization(
+                    behavior="harmful advice",
+                    behavior_text="Harmful advice",
+                    save_path=str(out_path),
+                    model_cfg=ModelConfig(name="azure/gpt-5.4", max_tokens=8000),
+                )
+
+        self.assertEqual(call_count, 1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_systematization_stage.py
+++ b/tests/test_systematization_stage.py
@@ -322,8 +322,8 @@ class SystematizationTruncationDetectionTest(unittest.IsolatedAsyncioTestCase):
                 )
 
     async def test_non_truncation_parse_failure_keeps_original_error(self) -> None:
-        """Without my fix the parse-failure path raised this exact message.
-        That path is preserved verbatim for non-truncation parse failures."""
+        """Prior to issue #131, the parse-failure path raised this exact message.
+        That behavior is preserved verbatim for non-truncation parse failures."""
         async def fake_generate_structured(model, prompt, *, schema_name, json_schema, options):
             del model, prompt, schema_name, json_schema, options
             return ModelResponse(


### PR DESCRIPTION
Fixes #131.
 
 The systematize stage crashed with an opaque `JSONDecodeError` when the model truncated mid-string. Hit reliably on `travel_planner_langgraph` because `web_search: true` routes through the **Responses API**, where truncation surfaces as `finish_reason == "max_output_tokens"` — but the detector only matched the Chat Completions value `"length"`. The default 10k `max_tokens` was also tight for prose-heavy specs.
 
 ## Fix (minimal, "healthy error" — no auto-grow)
 
 - `model_client`: new `is_truncated_response()` covers `length`, `max_output_tokens`, `max_tokens`. Excludes the bare `incomplete` status (also covers content-filter / provider errors). Plus a debug log when usage is present but all token fields are 0/None.
 - `stages/systematization`: single attempt; truncation → clear `ValueError` naming the finish reason, current `max_tokens`, and the YAML key to bump.
 - `stages/systematization_convert`: pre-existing 2-attempt same-budget retry preserved; swaps in the truncation error only when the **last** attempt was truncated.
 - `config_model`: `DEFAULT_SYSTEMATIZE_MAX_TOKENS` 10000 → 16000.
 - `examples/travel_planner_langgraph`: drop explicit `max_tokens: 10000` override.
 
 **Explicitly does NOT** auto-grow `max_tokens` on retry or add new retry loops — users set the budget consciously, the error tells them exactly which key to change.
 
 **Tests:** +19 (7 truncation-detection + 2 zero-token-log + 4 systematize-stage + 6 convert-stage incl. mixed-truncation case from PR review). Full suite: 928 passed locally; Tier 1 + Tier 4 green.