### PR TITLE
chore: clean up new example hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,9 @@ p2m_policy.*
 
 # Code Security Assessment artifacts
 .security-assessment/
+
+# Example-local caches and state
+examples/science_research_agent/.tool_cache.json
+examples/change_control_agent/.state.db
+examples/change_control_agent/.state.db-wal
+examples/change_control_agent/.state.db-shm

--- a/examples/change_control_agent/__init__.py
+++ b/examples/change_control_agent/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ examples = [
   "openai-agents>=0.14.5",
   "pydantic-ai>=0.8.1",
   "smolagents>=1.22.0",
+  "tavily-python>=0.7.0",
   # Framework-specific OpenInference instrumentors used by the
   # examples/phoenix_auto_trace/* demos. `phoenix.otel.register(auto_instrument=True)`
   # auto-loads every installed `openinference-instrumentation-*` package and a


### PR DESCRIPTION
## Summary
- ignores the science research example's local `.tool_cache.json`
- ignores the change-control example's local SQLite state sidecars
- adds the Tavily client to the `examples` extra used by the science research README
- adds the standard copyright/license header to `examples/change_control_agent/__init__.py`

## Validation
- `python3 -m py_compile examples/science_research_agent/agent.py examples/science_research_agent/tools.py examples/change_control_agent/agent.py examples/change_control_agent/tools.py examples/change_control_agent/__init__.py`
- parsed `pyproject.toml` and both new example eval YAML files
- verified `git check-ignore` catches `.tool_cache.json`, `.state.db`, `.state.db-wal`, and `.state.db-shm`
- `git diff --check`

Stacked on PR #123 because GitHub still shows #123 open/not yet on `main`, but these are the follow-up hygiene fixes from review.
