### PR TITLE
fix: restore legacy CLI aliases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,8 @@ index-url = "https://pypi.org/simple"
 
 [project.scripts]
 assert-eval = "assert_eval.cli:cli"
+assert = "assert_eval.cli:cli"
+p2m = "assert_eval.cli:cli"
 
 [build-system]
 requires = ["setuptools>=61.0"]

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -1,0 +1,12 @@
+import tomllib
+from pathlib import Path
+
+
+def test_console_script_aliases_are_backward_compatible() -> None:
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+
+    assert pyproject["project"]["scripts"] == {
+        "assert-eval": "assert_eval.cli:cli",
+        "assert": "assert_eval.cli:cli",
+        "p2m": "assert_eval.cli:cli",
+    }


### PR DESCRIPTION
## Summary
- restores the legacy `assert` and `p2m` console scripts as aliases to `assert_eval.cli:cli`
- adds a small metadata test so future rename cleanup does not accidentally drop the compatibility aliases again

## Validation
- `python3 -m pytest tests/test_package_metadata.py tests/test_import_smoke.py tests/test_cli.py -q`
- parsed `pyproject.toml` directly and verified all three console scripts point to `assert_eval.cli:cli`
- `git diff --check`
