### PR TITLE
fix: use explicit utf-8 encoding in mock_tools read_text calls

### DIFF
--- a/examples/azure_doc_qa/mock_tools.py
+++ b/examples/azure_doc_qa/mock_tools.py
@@ -36,7 +36,7 @@ def search_internal_docs(query: str, top_k: int = 3) -> str:
     """
     results = []
     for doc_file in sorted(INTERNAL_DOCS_DIR.glob("*.md")):
-        content = doc_file.read_text()
+        content = doc_file.read_text(encoding="utf-8")
         if any(word.lower() in content.lower() for word in query.split()):
             results.append(
                 {
@@ -62,7 +62,7 @@ def get_internal_document(doc_id: str) -> str:
     doc_path = INTERNAL_DOCS_DIR / f"{doc_id}.md"
     if not doc_path.exists():
         return json.dumps({"error": f"Document {doc_id} not found"})
-    content = doc_path.read_text()
+    content = doc_path.read_text(encoding="utf-8")
     return json.dumps(
         {
             "doc_id": doc_id,
@@ -118,7 +118,7 @@ def knowledge_base_retrieve(query: str, top_k: int = 3) -> str:
     """
     results = []
     for doc_file in sorted(EXTERNAL_DOCS_DIR.glob("*.md")):
-        content = doc_file.read_text()
+        content = doc_file.read_text(encoding="utf-8")
         if any(word.lower() in content.lower() for word in query.split()):
             results.append(
                 {
@@ -145,7 +145,7 @@ def microsoft_docs_search(query: str, top_k: int = 5) -> str:
     """
     results = []
     for doc_file in sorted(EXTERNAL_DOCS_DIR.glob("*.md")):
-        content = doc_file.read_text()
+        content = doc_file.read_text(encoding="utf-8")
         if any(word.lower() in content.lower() for word in query.split()):
             url = f"https://learn.microsoft.com/azure/ai-studio/{doc_file.stem}"
             results.append(
@@ -179,7 +179,7 @@ def microsoft_docs_fetch(url: str) -> str:
                 break
     if not doc_path.exists():
         return json.dumps({"error": f"Page not found: {url}"})
-    return doc_path.read_text()
+    return doc_path.read_text(encoding="utf-8")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

On Windows, `Path.read_text()` defaults to the system locale encoding (`cp1252`), which fails on markdown files containing bytes not valid in that codepage. This causes a `UnicodeDecodeError` when running the `azure_doc_qa` example:

```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 2012: character maps to <undefined>
```

Reported by tester mithigpe running on Windows.

## Fix

Add `encoding="utf-8"` to all 5 `Path.read_text()` calls in `examples/azure_doc_qa/mock_tools.py`:
- `search_internal_docs()`
- `get_internal_document()`
- `knowledge_base_retrieve()`
- `microsoft_docs_search()`
- `microsoft_docs_fetch()`

## Testing

- Verified no remaining bare `read_text()` calls in `examples/`
- Cross-platform safe (explicit UTF-8 is a no-op on Linux/macOS where it's already the default)