### PR TITLE
ci: add Component Governance scan pipeline

### DIFF
--- a/.azure-pipelines/component-governance.yml
+++ b/.azure-pipelines/component-governance.yml
@@ -1,0 +1,12 @@
+trigger: none
+pr: none
+
+pool:
+  vmImage: ubuntu-latest
+
+steps:
+  - checkout: self
+    fetchDepth: 1
+
+  - task: ComponentGovernanceComponentDetection@0
+    displayName: Component Detection


### PR DESCRIPTION
## Summary
- adds a manual Azure Pipelines YAML file for the ASSERT Component Governance / ComponentCheck release gate
- keeps `trigger` and `pr` disabled so it only runs when invoked manually from ADO
- runs the Component Detection task against the checked-out repo

## Validation
- YAML is intentionally minimal so Azure DevOps can select it from the governed pipeline wizard
- next validation is running this from the ADO pipeline wizard and checking Compliance > Component Governance > Components/Alerts
