### PR TITLE
Fix temperature values for azure/gpt-5.4-mini in examples configs

### DIFF
--- a/examples/benchmark/eval_config.yaml
+++ b/examples/benchmark/eval_config.yaml
@@ -68,7 +68,7 @@ pipeline:
   systematize:
     model:
       name: azure/gpt-5.4-mini
-      temperature: 0.7
+      temperature: 1.0
       max_tokens: 10000
     behavior_category_count: 6
   test_set:
@@ -84,11 +84,11 @@ pipeline:
           '
       model:
         name: azure/gpt-5.4-mini
-        temperature: 0.7
+        temperature: 1.0
     scenario:
       model:
         name: azure/gpt-5.4-mini
-        temperature: 0.2
+        temperature: 0.0
       sample_size: 10
   inference:
     concurrency: 10

--- a/examples/phoenix_auto_trace/eval_config.yaml
+++ b/examples/phoenix_auto_trace/eval_config.yaml
@@ -45,7 +45,7 @@ pipeline:
     scenario:
       model:
         name: azure/gpt-5.4-mini
-        temperature: 0.2
+        temperature: 0.0
       sample_size: 5
   inference:
     concurrency: 5

--- a/examples/phoenix_auto_trace/eval_crewai.yaml
+++ b/examples/phoenix_auto_trace/eval_crewai.yaml
@@ -35,19 +35,19 @@ pipeline:
   systematize:
     model:
       name: azure/gpt-5.4-mini
-      temperature: 0.7
+      temperature: 1.0
       max_tokens: 10000
     behavior_category_count: 6
   test_set:
     prompt:
       model:
         name: azure/gpt-5.4-mini
-        temperature: 0.7
+        temperature: 1.0
       sample_size: 5
     scenario:
       model:
         name: azure/gpt-5.4-mini
-        temperature: 0.2
+        temperature: 0.0
       sample_size: 5
   inference:
     concurrency: 1

--- a/examples/phoenix_auto_trace/eval_dspy.yaml
+++ b/examples/phoenix_auto_trace/eval_dspy.yaml
@@ -35,19 +35,19 @@ pipeline:
   systematize:
     model:
       name: azure/gpt-5.4-mini
-      temperature: 0.7
+      temperature: 1.0
       max_tokens: 10000
     behavior_category_count: 6
   test_set:
     prompt:
       model:
         name: azure/gpt-5.4-mini
-        temperature: 0.7
+        temperature: 1.0
       sample_size: 5
     scenario:
       model:
         name: azure/gpt-5.4-mini
-        temperature: 0.2
+        temperature: 0.0
       sample_size: 5
   inference:
     concurrency: 1

--- a/examples/phoenix_auto_trace/eval_framework_template.yaml
+++ b/examples/phoenix_auto_trace/eval_framework_template.yaml
@@ -35,19 +35,19 @@ pipeline:
   systematize:
     model:
       name: azure/gpt-5.4-mini
-      temperature: 0.7
+      temperature: 1.0
       max_tokens: 10000
     behavior_category_count: 6
   test_set:
     prompt:
       model:
         name: azure/gpt-5.4-mini
-        temperature: 0.7
+        temperature: 1.0
       sample_size: 5
     scenario:
       model:
         name: azure/gpt-5.4-mini
-        temperature: 0.2
+        temperature: 0.0
       sample_size: 5
   inference:
     concurrency: 1

--- a/examples/phoenix_auto_trace/eval_langchain.yaml
+++ b/examples/phoenix_auto_trace/eval_langchain.yaml
@@ -35,19 +35,19 @@ pipeline:
   systematize:
     model:
       name: azure/gpt-5.4-mini
-      temperature: 0.7
+      temperature: 1.0
       max_tokens: 10000
     behavior_category_count: 6
   test_set:
     prompt:
       model:
         name: azure/gpt-5.4-mini
-        temperature: 0.7
+        temperature: 1.0
       sample_size: 5
     scenario:
       model:
         name: azure/gpt-5.4-mini
-        temperature: 0.2
+        temperature: 0.0
       sample_size: 5
   inference:
     concurrency: 1

--- a/examples/phoenix_auto_trace/eval_litellm.yaml
+++ b/examples/phoenix_auto_trace/eval_litellm.yaml
@@ -35,19 +35,19 @@ pipeline:
   systematize:
     model:
       name: azure/gpt-5.4-mini
-      temperature: 0.7
+      temperature: 1.0
       max_tokens: 10000
     behavior_category_count: 6
   test_set:
     prompt:
       model:
         name: azure/gpt-5.4-mini
-        temperature: 0.7
+        temperature: 1.0
       sample_size: 5
     scenario:
       model:
         name: azure/gpt-5.4-mini
-        temperature: 0.2
+        temperature: 0.0
       sample_size: 5
   inference:
     concurrency: 1

--- a/examples/phoenix_auto_trace/eval_openai.yaml
+++ b/examples/phoenix_auto_trace/eval_openai.yaml
@@ -35,19 +35,19 @@ pipeline:
   systematize:
     model:
       name: azure/gpt-5.4-mini
-      temperature: 0.7
+      temperature: 1.0
       max_tokens: 10000
     behavior_category_count: 6
   test_set:
     prompt:
       model:
         name: azure/gpt-5.4-mini
-        temperature: 0.7
+        temperature: 1.0
       sample_size: 5
     scenario:
       model:
         name: azure/gpt-5.4-mini
-        temperature: 0.2
+        temperature: 0.0
       sample_size: 5
   inference:
     concurrency: 1

--- a/examples/pipes/health_assistant_external.yaml
+++ b/examples/pipes/health_assistant_external.yaml
@@ -33,7 +33,7 @@ pipeline:
     scenario:
       model:
         name: azure/gpt-5.4-mini
-        temperature: 0.2
+        temperature: 0.0
         max_tokens: 4000
       sample_size: 5
   inference:

--- a/examples/pipes/health_assistant_generated_tools.yaml
+++ b/examples/pipes/health_assistant_generated_tools.yaml
@@ -34,7 +34,7 @@ pipeline:
     scenario:
       model:
         name: azure/gpt-5.4-mini
-        temperature: 0.2
+        temperature: 0.0
         max_tokens: 4000
       sample_size: 5
   inference:

--- a/examples/pipes/health_assistant_sandbox.yaml
+++ b/examples/pipes/health_assistant_sandbox.yaml
@@ -33,7 +33,7 @@ pipeline:
     scenario:
       model:
         name: azure/gpt-5.4-mini
-        temperature: 0.2
+        temperature: 0.0
         max_tokens: 4000
       sample_size: 5
   inference:

--- a/examples/pipes/health_assistant_simulated_tools.yaml
+++ b/examples/pipes/health_assistant_simulated_tools.yaml
@@ -32,7 +32,7 @@ pipeline:
     scenario:
       model:
         name: azure/gpt-5.4-mini
-        temperature: 0.2
+        temperature: 0.0
         max_tokens: 4000
       sample_size: 5
   inference:

--- a/examples/travel_planner_langgraph/eval_config.yaml
+++ b/examples/travel_planner_langgraph/eval_config.yaml
@@ -36,13 +36,13 @@ pipeline:
     web_search: true
     model:
       name: azure/gpt-5.4-mini
-      temperature: 0.7
+      temperature: 1.0
       max_tokens: 10000
   test_set:
     stratify:
       model:
         name: azure/gpt-5.4-mini
-        temperature: 0.7
+        temperature: 1.0
       dimensions:
         - name: traveler_type
           description: The type of traveler using the travel planner, such as solo backpacker, family with young children, elderly couple, business traveler, or traveler with disability.
@@ -52,12 +52,12 @@ pipeline:
       sample_size: 5
       model:
         name: azure/gpt-5.4-mini
-        temperature: 0.7
+        temperature: 1.0
     scenario:
       sample_size: 5
       model:
         name: azure/gpt-5.4-mini
-        temperature: 0.2
+        temperature: 0.0
   inference:
     concurrency: 1
     target:

--- a/examples/travel_planner_neurosan/eval_config.yaml
+++ b/examples/travel_planner_neurosan/eval_config.yaml
@@ -33,7 +33,7 @@ pipeline:
   systematize:
     model:
       name: azure/gpt-5.4-mini
-      temperature: 0.7
+      temperature: 1.0
       max_tokens: 10000
     behavior_category_count: 6
   test_set:
@@ -49,16 +49,16 @@ pipeline:
           '
       model:
         name: azure/gpt-5.4-mini
-        temperature: 0.7
+        temperature: 1.0
     prompt:
       model:
         name: azure/gpt-5.4-mini
-        temperature: 0.7
+        temperature: 1.0
       sample_size: 5
     scenario:
       model:
         name: azure/gpt-5.4-mini
-        temperature: 0.2
+        temperature: 0.0
       sample_size: 5
   inference:
     concurrency: 1


### PR DESCRIPTION
## Summary

`azure/gpt-5.4-mini` (and other reasoning-tier GPT-5 models) only accepts `temperature: 0.0` or `1.0` — any fractional value returns `400 Unsupported value`. The example configs under `examples/` were using legacy GPT-4-style temperatures (`0.7` for sampling, `0.2` for deterministic stages) on `azure/gpt-5.4-mini` blocks, causing these examples to fail out of the box.

This PR fixes the `examples/` configs only.

## Changes

Applied the following mapping to every `azure/gpt-5.4-mini` block in `examples/`:

| Stage                              | Old   | New   |
| ---------------------------------- | ----- | ----- |
| Sampling (systematize / prompt / inference) | `0.7` | `1.0` |
| Deterministic (scenario / judge / tester)   | `0.2` | `0.0` |

Values already at `0.0` or `1.0` were left untouched. Non-mini variants (e.g. `azure/gpt-5.4`) were already compliant and not modified.

## Files touched (14)

- `examples/benchmark/eval_config.yaml`
- `examples/phoenix_auto_trace/eval_config.yaml`
- `examples/phoenix_auto_trace/eval_{crewai,dspy,framework_template,langchain,litellm,openai}.yaml`
- `examples/pipes/health_assistant_{external,generated_tools,sandbox,simulated_tools}.yaml`
- `examples/travel_planner_langgraph/eval_config.yaml`
- `examples/travel_planner_neurosan/eval_config.yaml`

Total: 34 temperature value adjustments.

## Verification

Swept `examples/` post-fix — zero remaining fractional temperatures on any `azure/gpt-5.4-mini` block.
