### PR TITLE
fix(viewer): truncate long callable target labels in compare view

### DIFF
--- a/viewer/src/routes/suite/[suite_id]/compare/+page.svelte
+++ b/viewer/src/routes/suite/[suite_id]/compare/+page.svelte
@@ -36,6 +36,16 @@ function metricLabel(m: string): string {
 	return m.replace(/_/g, ' ');
 }
 
+// Short label for a run's target. Callable targets ("module.path:function_name")
+// reduce to "function_name"; provider/model strings ("provider/model-name")
+// reduce to "model-name". Avoids overflowing column headers and per-run cards.
+function runLabel(model: string | null | undefined): string {
+	const m = model ?? '';
+	if (m.includes(':')) return m.split(':').pop() || m;
+	if (m.includes('/')) return m.split('/').pop() || m;
+	return m;
+}
+
 // Re-sort comparisons by active metric's delta
 let sortedComparisons = $derived.by(() => {
 	return [...data.comparisons].sort((a, b) =>
@@ -208,7 +218,7 @@ function capitalize(s: string): string {
 					</div>
 
 					<!-- Model name -->
-					<div class="mt-1 font-mono text-xs text-text-muted truncate">{run.model}</div>
+					<div class="mt-1 font-mono text-xs text-text-muted truncate" title={run.model}>{runLabel(run.model)}</div>
 
 					<!-- Big number -->
 					<div class="mt-3 flex items-baseline gap-1.5">
@@ -298,7 +308,7 @@ function capitalize(s: string): string {
 					style="grid-template-columns: {comparisonGridTemplate(data.runs.length)};">
 					<span>Behavior</span>
 					{#each data.runs as run, i}
-						<span class="text-center font-mono font-medium" style="color: {RUN_COLORS[i]}">{run.model.split('/').pop()}</span>
+						<span class="text-center font-mono font-medium truncate" title={run.model} style="color: {RUN_COLORS[i]}">{runLabel(run.model)}</span>
 					{/each}
 				</div>
 
@@ -373,7 +383,7 @@ function capitalize(s: string): string {
 														<div class="flex items-center justify-between">
 															<div class="flex items-center gap-1.5 min-w-0">
 																<span class="h-1.5 w-1.5 rounded-full flex-shrink-0" style="background: {RUN_COLORS[i]}"></span>
-																<span class="text-xs font-mono truncate" style="color: {RUN_COLORS[i]}">{run.model.split('/').pop()}</span>
+																<span class="text-xs font-mono truncate" title={run.model} style="color: {RUN_COLORS[i]}">{runLabel(run.model)}</span>
 															</div>
 															{#if sample}
 																{@const sampleScore = getRecordFlag(sample, activeMetric)}


### PR DESCRIPTION
## What

When a run's `target` is a Python callable like `examples.bank_manager_demo.agent:chat_unguarded`, the compare view's `run.model.split('/').pop()` returned the entire dotted path (no `/` in callable strings → `pop` is a no-op). Two adjacent column headers in the "By behavior category" table visibly crashed into each other; the per-run card model line wrapped or overflowed.

## Fix

Adds a `runLabel(model)` helper near the existing `metricLabel`:
- if the string contains `:` (callable target) → return everything after the last `:`
- else if it contains `/` (provider/model path) → return everything after the last `/`
- else return as-is

Three render sites updated (compare-page run card body line 211, behavior-category header line 301, expanded sample row line 376). All three now wrap the short label in a `truncate + title` tooltip so the full dotted path is still discoverable on hover.

## Repro (before)

Open the local viewer at any `compare` URL whose runs use a callable target. Example with the new `examples/bank_manager_demo/` snapshot from PR #88:

`http://localhost:5174/suite/bank-manager-demo/compare?baseline=variant-a-unguarded-n100&runs=variant-d-guarded-v3-n100`

Without this fix, the column header for variant-d overflows into variant-a's space.

## Scope and relationship to PR #78

PR #78 was the original attempt. It bundled this label fix with a separate "3-way compare URL plumbing" change and has been CONFLICTING since the late-May docs/viewer churn. I'm splitting off **only the label fix** here as a single-purpose 13-line patch — easier to review and unblocks PR #88's bank-manager demo viewer rendering immediately. The 3-way URL piece can come back in a separate PR if anyone needs it.

## Validation

- `npx svelte-check` — 0 new errors. The 3 pre-existing svelte-check errors on `main` are in `PrimerPagination.svelte` and `routes/+page.svelte` (unrelated).
- Manual smoke at `http://localhost:5174` against the `bank-manager-demo` suite from PR #88: the "By behavior category" column headers now show `chat_unguarded` / `chat_guarded_v3` instead of overlapping full dotted paths.

## Co-author

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>