### PR TITLE
docs: replace stale microsoft/adaptive-eval URLs with responsibleai/ASSERT

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,7 +140,7 @@ Do not reintroduce internal-only planning docs into this customer-preview distri
 End users can paste the following block into their AI assistant to get the same orientation this file gives you:
 
 ```text
-You are helping me with the Adaptive Eval repo (https://github.com/microsoft/adaptive-eval).
+You are helping me with the ASSERT repo (https://github.com/responsibleai/ASSERT).
 
 Adaptive Eval is a local-first, spec-driven evaluation pipeline for AI agents. The mental model:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,8 +14,8 @@ Thank you for your interest in contributing to Adaptive Eval. This project is in
 Adaptive Eval requires Python 3.11 or later. Node.js is needed only for viewer work and tests that exercise viewer assets.
 
 ```bash
-git clone https://github.com/microsoft/adaptive-eval.git
-cd adaptive-eval
+git clone https://github.com/responsibleai/ASSERT.git
+cd ASSERT
 python -m venv .venv
 source .venv/bin/activate
 python -m pip install --upgrade pip
@@ -26,8 +26,8 @@ cp .env.example .env
 Windows PowerShell equivalent:
 
 ```powershell
-git clone https://github.com/microsoft/adaptive-eval.git
-cd adaptive-eval
+git clone https://github.com/responsibleai/ASSERT.git
+cd ASSERT
 python -m venv .venv
 .\.venv\Scripts\Activate.ps1
 python -m pip install --upgrade pip


### PR DESCRIPTION
## What

Two customer-facing docs still pointed at the dead `microsoft/adaptive-eval` slug (returns 404 after the rename to ASSERT). This PR points both at the canonical `responsibleai/ASSERT` URL.

| file | before | after |
|---|---|---|
| `CONTRIBUTING.md:17,29` | `git clone https://github.com/microsoft/adaptive-eval.git` | `git clone https://github.com/responsibleai/ASSERT.git` |
| `CONTRIBUTING.md:18,30` | `cd adaptive-eval` | `cd ASSERT` |
| `AGENTS.md:143` | `https://github.com/microsoft/adaptive-eval` | `https://github.com/responsibleai/ASSERT` |

## Why this matters

`CONTRIBUTING.md` is the first thing a contributor reads when setting up locally — a dead clone URL is a hard stop. `AGENTS.md:143` lives inside the paste-in prompt block that downstream LLMs hand back to users, so the 404 URL was being amplified one hop further.

## Scope

5 insertions, 5 deletions across 2 files. No code touched. Both fixes verified with ``Select-String -Pattern 'microsoft/adaptive-eval'`` returning zero hits across customer-facing markdown post-edit.
