### PR TITLE
viewer/compare: pin baseline left + show only populated dim columns

### DIFF
--- a/viewer/src/lib/PrimerDropdown.svelte
+++ b/viewer/src/lib/PrimerDropdown.svelte
@@ -7,6 +7,13 @@
   interface DropdownOption {
     value: string;
     label: string;
+    // When true, the option is rendered with reduced opacity and an optional
+    // inline `secondaryLabel` hint. Click handlers still fire so callers can
+    // implement swap-style behavior (discoverability over prevention).
+    disabled?: boolean;
+    // Optional muted, smaller-font hint shown next to the main label. Useful
+    // for explaining why an option is in a disabled visual state.
+    secondaryLabel?: string;
   }
 
   interface Props {
@@ -144,16 +151,16 @@
       tabindex={-1}
     >
       {#each options as option, idx}
-        <li class="ActionList-item" role="option" aria-selected={selected === option.value}>
+        <li class="ActionList-item" role="option" aria-selected={selected === option.value} aria-disabled={option.disabled || undefined}>
           <button
             type="button"
-            class="ActionList-content w-full text-left {selected === option.value ? 'ActionList-content--selected' : ''} {highlightedIndex === idx ? 'ActionList-content--highlighted' : ''}"
+            class="ActionList-content w-full text-left {selected === option.value ? 'ActionList-content--selected' : ''} {highlightedIndex === idx ? 'ActionList-content--highlighted' : ''} {option.disabled ? 'ActionList-content--disabled' : ''}"
             onclick={() => handleSelect(option.value)}
             onmouseenter={() => (highlightedIndex = idx)}
             onmouseleave={() => (highlightedIndex = -1)}
           >
             <span class="ActionList-content-text">
-              {option.label}
+              {option.label}{#if option.secondaryLabel}<span class="ActionList-content-secondary">{option.secondaryLabel}</span>{/if}
             </span>
           </button>
         </li>
@@ -295,6 +302,17 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  :global(.ActionList-content--disabled) {
+    opacity: 0.5;
+  }
+
+  :global(.ActionList-content-secondary) {
+    margin-left: 0.5rem;
+    color: var(--fgColor-muted, #59636e);
+    font-size: 0.75rem;
+    font-weight: 400;
   }
 
   :global(html[data-color-mode="dark"] .ActionMenu-button) {

--- a/viewer/src/lib/compare-view.ts
+++ b/viewer/src/lib/compare-view.ts
@@ -14,23 +14,31 @@ export function buildMatchedSampleRows(
 	runIds: string[],
 	metric: string,
 	disagreementsOnly: boolean,
-	baselineRunId?: string
+	baselineRunId?: string,
+	// Optional: customize the key used to match samples across runs. Defaults to
+	// matching by `sample.prompt`, which is appropriate for single-turn prompts
+	// comparisons. Scenario comparisons pass `(s) => s.test_case_id ?? s.prompt`
+	// so multi-turn conversations are paired by the shared test_case_id even
+	// though the assistant responses diverge after the seed turn.
+	keyFn?: (sample: JudgedSample) => string
 ): MatchedSampleRow[] {
-	const promptMap = new Map<string, Record<string, JudgedSample | null>>();
+	const keyOf = keyFn ?? ((sample: JudgedSample) => sample.prompt);
+	const grouped = new Map<string, { prompt: string; samples: Record<string, JudgedSample | null> }>();
 
 	for (const runId of runIds) {
 		for (const sample of samplesByRunId[runId] ?? []) {
-			if (!promptMap.has(sample.prompt)) {
-				promptMap.set(
-					sample.prompt,
-					Object.fromEntries(runIds.map((id) => [id, null])) as Record<string, JudgedSample | null>
-				);
+			const key = keyOf(sample);
+			if (!grouped.has(key)) {
+				grouped.set(key, {
+					prompt: sample.prompt,
+					samples: Object.fromEntries(runIds.map((id) => [id, null])) as Record<string, JudgedSample | null>
+				});
 			}
-			promptMap.get(sample.prompt)![runId] = sample;
+			grouped.get(key)!.samples[runId] = sample;
 		}
 	}
 
-	let rows = Array.from(promptMap.entries()).map(([prompt, samples]) => ({ prompt, samples }));
+	let rows = Array.from(grouped.values());
 	if (disagreementsOnly) {
 		rows = rows.filter((row) => {
 			const scores = Object.values(row.samples)

--- a/viewer/src/lib/compare-view.ts
+++ b/viewer/src/lib/compare-view.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { getRecordFlag, getVerdictFlag, scoreSortValue } from '$lib/judgment.js';
+import { getRecordFlag, getVerdictFlag } from '$lib/judgment.js';
 import type { JudgedSample } from '$lib/types.js';
 
 export interface MatchedSampleRow {
@@ -13,7 +13,8 @@ export function buildMatchedSampleRows(
 	samplesByRunId: Record<string, JudgedSample[]>,
 	runIds: string[],
 	metric: string,
-	disagreementsOnly: boolean
+	disagreementsOnly: boolean,
+	baselineRunId?: string
 ): MatchedSampleRow[] {
 	const promptMap = new Map<string, Record<string, JudgedSample | null>>();
 
@@ -39,22 +40,52 @@ export function buildMatchedSampleRows(
 		});
 	}
 
-	rows.sort((left, right) => {
-		const leftScores = Object.values(left.samples)
+	// Three-key sort to lead with the regression-fix narrative without hiding regressions:
+	//   1. baseline-flagged DESC (baseline-fail rows first — the "wins" demo case)
+	//   2. has-disagreement DESC (mixed-outcome rows next)
+	//   3. |delta| on the active metric DESC (largest spread first)
+	//   tiebreak: prompt for stable, reproducible ordering across reloads
+	const flagOf = (row: MatchedSampleRow, runId: string | undefined): boolean | null => {
+		if (!runId) return null;
+		const sample = row.samples[runId];
+		return sample ? getRecordFlag(sample, metric) : null;
+	};
+	const absDelta = (row: MatchedSampleRow): number => {
+		const scores: number[] = [];
+		for (const sample of Object.values(row.samples)) {
+			if (!sample) continue;
+			const flag = getRecordFlag(sample, metric);
+			if (flag === true) scores.push(1);
+			else if (flag === false) scores.push(0);
+		}
+		if (scores.length < 2) return 0;
+		return Math.max(...scores) - Math.min(...scores);
+	};
+	const disagrees = (row: MatchedSampleRow): boolean => {
+		const scores = Object.values(row.samples)
 			.filter(Boolean)
 			.map((sample) => getRecordFlag(sample!, metric))
-			.filter((score): score is boolean => score !== null);
-		const rightScores = Object.values(right.samples)
-			.filter(Boolean)
-			.map((sample) => getRecordFlag(sample!, metric))
-			.filter((score): score is boolean => score !== null);
-		const leftDisagrees = new Set(leftScores).size > 1 ? 0 : 1;
-		const rightDisagrees = new Set(rightScores).size > 1 ? 0 : 1;
-		if (leftDisagrees !== rightDisagrees) return leftDisagrees - rightDisagrees;
+			.filter((s): s is boolean => s !== null);
+		return new Set(scores).size > 1;
+	};
 
-		const leftFirst = Object.values(left.samples).find(Boolean);
-		const rightFirst = Object.values(right.samples).find(Boolean);
-		return scoreSortValue(leftFirst ?? {}, metric) - scoreSortValue(rightFirst ?? {}, metric);
+	rows.sort((left, right) => {
+		// Key 1: baseline-flagged (only when baselineRunId provided)
+		if (baselineRunId) {
+			const lFlagged = flagOf(left, baselineRunId) === true ? 1 : 0;
+			const rFlagged = flagOf(right, baselineRunId) === true ? 1 : 0;
+			if (lFlagged !== rFlagged) return rFlagged - lFlagged;
+		}
+		// Key 2: disagreement
+		const lDisagrees = disagrees(left) ? 1 : 0;
+		const rDisagrees = disagrees(right) ? 1 : 0;
+		if (lDisagrees !== rDisagrees) return rDisagrees - lDisagrees;
+		// Key 3: |delta|
+		const lDelta = absDelta(left);
+		const rDelta = absDelta(right);
+		if (lDelta !== rDelta) return rDelta - lDelta;
+		// Tiebreak: prompt for reproducibility
+		return left.prompt.localeCompare(right.prompt);
 	});
 
 	return rows;

--- a/viewer/src/lib/server/data.ts
+++ b/viewer/src/lib/server/data.ts
@@ -1490,16 +1490,23 @@ export async function loadScenarioDrawerItem(suiteId: string, runId: string, see
 	);
 }
 
-export function loadComparePageData(suiteId: string, runIds: string[]) {
+export function loadComparePageData(
+	suiteId: string,
+	runIds: string[],
+	kind: 'prompts' | 'scenarios' = 'prompts'
+) {
 	const suiteSnapshot = loadSuiteSnapshot(suiteId);
 	const taxonomy = normalizePolicy(suiteSnapshot?.taxonomy);
 
 	const runSummaries: CompareRunSummary[] = [];
 	const metricNames = new Set<string>();
 
+	const buildSamples =
+		kind === 'scenarios' ? buildJudgedScenariosFromSnapshot : buildJudgedPromptsFromSnapshot;
+
 	for (const runId of runIds) {
 		const runSnapshot = loadRunSnapshot(suiteId, runId, suiteSnapshot?.seedRows);
-		const samples = buildJudgedPromptsFromSnapshot(runSnapshot);
+		const samples = buildSamples(runSnapshot);
 		if (samples.length === 0) return null;
 
 		const summary = buildCompareRunSummary(runId, runSnapshot.manifest, samples);
@@ -1512,6 +1519,7 @@ export function loadComparePageData(suiteId: string, runIds: string[]) {
 
 	return {
 		suite_id: suiteId,
+		kind,
 		taxonomy,
 		runs: runSummaries.map(({ samples, ...summary }) => summary),
 		comparisons,

--- a/viewer/src/routes/suite/[suite_id]/+page.svelte
+++ b/viewer/src/routes/suite/[suite_id]/+page.svelte
@@ -68,6 +68,16 @@
 	);
 	let metricNames = $derived(Object.keys((data.dimensionDefs ?? {}) as Record<string, DimensionDef>));
 	let primaryMetric = $derived(metricNames[0] ?? 'policy_violation');
+	let dimNames = $derived(Object.keys((data.dimensionDefs ?? {}) as Record<string, DimensionDef>));
+	function dimColumnLabel(name: string): string {
+		const spaced = name.replace(/_/g, ' ');
+		return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+	}
+	let visibleDimNames = $derived(
+		dimNames.filter((name) =>
+			allRuns.some((r) => aggregateRunDimensionRate(r, name) !== null)
+		)
+	);
 	let sortedBehaviors = $derived(data.taxonomy?.behavior_categories ?? []);
 	let promptSeedItems = $derived(normalizePromptSeeds(data.promptSeeds));
 	let scenarioSeedItems = $derived(normalizeScenarioSeeds(data.scenarioSeeds));
@@ -452,9 +462,9 @@
 						</th>
 						<th class="px-3 py-2 text-xs font-medium text-text-muted">Run date</th>
 						<th class="px-3 py-2 text-xs font-medium text-text-muted">Run status</th>
-						<th class="w-32 px-3 py-2 text-left text-xs font-medium text-text-muted whitespace-nowrap truncate">Policy violation</th>
-						<th class="w-32 px-3 py-2 text-left text-xs font-medium text-text-muted whitespace-nowrap truncate">Overrefusal</th>
-						<th class="w-32 px-3 py-2 text-left text-xs font-medium text-text-muted whitespace-nowrap truncate">Harm actionability</th>
+						{#each visibleDimNames as dimName (dimName)}
+							<th class="w-32 px-3 py-2 text-left text-xs font-medium text-text-muted whitespace-nowrap truncate">{dimColumnLabel(dimName)}</th>
+						{/each}
 						<th class="px-3 py-2 text-left text-xs font-medium text-text-muted">Total</th>
 					</tr>
 				</thead>
@@ -466,9 +476,6 @@
 						{@const isCompareSelected = Boolean(run.compare_run_id && selectedCompareRuns.has(run.compare_run_id))}
 						{@const isCompareDisabled = !run.compare_run_id || (!isCompareSelected && selectedCompareRuns.size >= MAX_COMPARE_RUNS)}
 						{@const isExpanded = expandedRunIds.has(run.run_id)}
-						{@const violationRate = aggregateRunViolationRate(run)}
-						{@const overrefusalRate = aggregateRunOverrefusalRate(run)}
-						{@const harmRate = aggregateRunDimensionRate(run, 'harm_actionability')}
 						{@const runStartedAt = qRun?.manifest?.started_at ?? aRun?.manifest?.started_at ?? null}
 						{@const runStatus = qRun?.manifest?.status ?? aRun?.manifest?.status ?? null}
 						{@const runStatusLabel = runStatus === 'completed' ? 'complete' : runStatus === 'failed' ? 'failed' : runStatus === 'running' ? 'running' : 'incomplete'}
@@ -505,27 +512,16 @@
 							<td class="px-3 py-2">
 								<span class="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium {runStatusClass}">{runStatusLabel}</span>
 							</td>
-							<td class="px-3 py-2 text-left">
-								{#if violationRate !== null}
-									<span class="text-xs font-semibold">{(violationRate * 100).toFixed(0)}%</span>
-								{:else}
-									<span class="text-xs text-text-muted">—</span>
-								{/if}
-							</td>
-							<td class="px-3 py-2 text-left">
-								{#if overrefusalRate !== null}
-									<span class="text-xs font-semibold">{(overrefusalRate * 100).toFixed(0)}%</span>
-								{:else}
-									<span class="text-xs text-text-muted">—</span>
-								{/if}
-							</td>
-							<td class="px-3 py-2 text-left">
-								{#if harmRate !== null}
-									<span class="text-xs font-semibold">{(harmRate * 100).toFixed(0)}%</span>
-								{:else}
-									<span class="text-xs text-text-muted">—</span>
-								{/if}
-							</td>
+							{#each visibleDimNames as dimName (dimName)}
+								{@const dimRate = aggregateRunDimensionRate(run, dimName)}
+								<td class="px-3 py-2 text-left">
+									{#if dimRate !== null}
+										<span class="text-xs font-semibold">{(dimRate * 100).toFixed(0)}%</span>
+									{:else}
+										<span class="text-xs text-text-muted">—</span>
+									{/if}
+								</td>
+							{/each}
 							<td class="px-3 py-2 text-left text-xs text-text-muted">{runTotal(run) || '—'}</td>
 						</tr>
 						{#if hasChildren && isExpanded && qRun}
@@ -536,9 +532,10 @@
 								<td class="px-3 py-2 font-mono text-xs text-text-muted">{qRun.metrics?.target ?? '—'}</td>
 								<td class="px-3 py-2"></td>
 								<td class="px-3 py-2"></td>
-								<td class="px-3 py-2 text-left">{#if qRun.metrics}<span class="text-xs font-semibold">{(qRun.metrics.policy_violation_rate * 100).toFixed(0)}%</span>{:else}<span class="text-xs text-text-muted">—</span>{/if}</td>
-								<td class="px-3 py-2 text-left">{#if qRun.metrics}<span class="text-xs font-semibold">{(qRun.metrics.overrefusal_rate * 100).toFixed(0)}%</span>{:else}<span class="text-xs text-text-muted">—</span>{/if}</td>
-								<td class="px-3 py-2 text-left">{#if qRun.metrics?.dimensions?.harm_actionability}<span class="text-xs font-semibold">{(qRun.metrics.dimensions.harm_actionability.rate * 100).toFixed(0)}%</span>{:else}<span class="text-xs text-text-muted">—</span>{/if}</td>
+								{#each visibleDimNames as dimName (dimName)}
+									{@const childDimRate = qRun.metrics?.dimensions?.[dimName]?.rate ?? null}
+									<td class="px-3 py-2 text-left">{#if childDimRate !== null && childDimRate !== undefined}<span class="text-xs font-semibold">{(childDimRate * 100).toFixed(0)}%</span>{:else}<span class="text-xs text-text-muted">—</span>{/if}</td>
+								{/each}
 								<td class="px-3 py-2 text-left text-xs text-text-muted">{qRun.metrics?.total ?? '—'}</td>
 							</tr>
 						{/if}
@@ -550,9 +547,10 @@
 								<td class="px-3 py-2 font-mono text-xs text-text-muted">{aRun.metrics?.target ?? '—'}</td>
 								<td class="px-3 py-2"></td>
 								<td class="px-3 py-2"></td>
-								<td class="px-3 py-2 text-left">{#if aRun.metrics}<span class="text-xs font-semibold">{(aRun.metrics.policy_violation_rate * 100).toFixed(0)}%</span>{:else}<span class="text-xs text-text-muted">—</span>{/if}</td>
-								<td class="px-3 py-2 text-left">{#if aRun.metrics}<span class="text-xs font-semibold">{(aRun.metrics.overrefusal_rate * 100).toFixed(0)}%</span>{:else}<span class="text-xs text-text-muted">—</span>{/if}</td>
-								<td class="px-3 py-2 text-left">{#if aRun.metrics?.dimensions?.harm_actionability}<span class="text-xs font-semibold">{(aRun.metrics.dimensions.harm_actionability.rate * 100).toFixed(0)}%</span>{:else}<span class="text-xs text-text-muted">—</span>{/if}</td>
+								{#each visibleDimNames as dimName (dimName)}
+									{@const childDimRate = aRun.metrics?.dimensions?.[dimName]?.rate ?? null}
+									<td class="px-3 py-2 text-left">{#if childDimRate !== null && childDimRate !== undefined}<span class="text-xs font-semibold">{(childDimRate * 100).toFixed(0)}%</span>{:else}<span class="text-xs text-text-muted">—</span>{/if}</td>
+								{/each}
 								<td class="px-3 py-2 text-left text-xs text-text-muted">{aRun.metrics?.total ?? '—'}</td>
 							</tr>
 						{/if}

--- a/viewer/src/routes/suite/[suite_id]/+page.svelte
+++ b/viewer/src/routes/suite/[suite_id]/+page.svelte
@@ -66,9 +66,25 @@
 	let requiredBaseMetrics = $derived(
 		getRequiredBaseMetricNames((data.dimensionDefs ?? {}) as Record<string, DimensionDef>)
 	);
-	let metricNames = $derived(Object.keys((data.dimensionDefs ?? {}) as Record<string, DimensionDef>));
+	// Union of (a) globally-declared dim defs and (b) dim names actually present in run metrics.
+	// (b) covers custom per-suite dims declared inline in eval.yaml judge.dimensions which never
+	// reach loadDimensions() (that only reads BUILT_IN_DIMENSIONS + the global
+	// examples/eval-definitions/judge_dimensions.yaml file). Mirrors the compare view's
+	// loadComparePageData which derives data.allMetrics from Object.keys(summary.dimensions).
+	let allDimNames = $derived.by(() => {
+		const names = new Set<string>();
+		for (const name of Object.keys((data.dimensionDefs ?? {}) as Record<string, DimensionDef>)) {
+			names.add(name);
+		}
+		for (const r of allRuns) {
+			for (const name of Object.keys(r.prompt?.metrics?.dimensions ?? {})) names.add(name);
+			for (const name of Object.keys(r.audit?.metrics?.dimensions ?? {})) names.add(name);
+		}
+		return Array.from(names);
+	});
+	let metricNames = $derived(allDimNames);
 	let primaryMetric = $derived(metricNames[0] ?? 'policy_violation');
-	let dimNames = $derived(Object.keys((data.dimensionDefs ?? {}) as Record<string, DimensionDef>));
+	let dimNames = $derived(allDimNames);
 	function dimColumnLabel(name: string): string {
 		const spaced = name.replace(/_/g, ' ');
 		return spaced.charAt(0).toUpperCase() + spaced.slice(1);

--- a/viewer/src/routes/suite/[suite_id]/+page.svelte
+++ b/viewer/src/routes/suite/[suite_id]/+page.svelte
@@ -471,11 +471,6 @@
 								<InfoTooltip direction="se" label="Direct prompts are single-turn requests. Multi-turn scenarios simulate longer user conversations against the target." />
 							</span>
 						</th>
-						<th class="px-3 py-2 text-xs font-medium text-text-muted">
-							<span class="inline-flex items-center gap-1">Target
-								<InfoTooltip direction="se" label="The model or agent under evaluation — typically the deployment or model name that produced the responses for this run." />
-							</span>
-						</th>
 						<th class="px-3 py-2 text-xs font-medium text-text-muted">Run date</th>
 						<th class="px-3 py-2 text-xs font-medium text-text-muted">Run status</th>
 						{#each visibleDimNames as dimName (dimName)}
@@ -511,19 +506,21 @@
 								</button>
 							</td>
 							<td class="px-3 py-2">
-								<div class="flex items-center gap-1.5">
+								<div class="flex items-start gap-1.5">
 									{#if hasChildren}
-										<button class="flex h-4 w-4 items-center justify-center rounded text-text-muted transition-colors hover:text-text" onclick={() => toggleRunExpanded(run.run_id)} aria-expanded={isExpanded} aria-label={isExpanded ? 'Collapse run details' : 'Expand run details'}>
+										<button class="mt-0.5 flex h-4 w-4 items-center justify-center rounded text-text-muted transition-colors hover:text-text" onclick={() => toggleRunExpanded(run.run_id)} aria-expanded={isExpanded} aria-label={isExpanded ? 'Collapse run details' : 'Expand run details'}>
 											<svg class="h-3 w-3 transition-transform duration-150 {isExpanded ? 'rotate-90' : ''}" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M9 5l7 7-7 7"/></svg>
 										</button>
 									{/if}
-									<a href="/suite/{data.suite_id}/{run.prompt_run_id ?? run.audit_run_id ?? run.run_id}" class="text-sm font-medium text-interactive hover:underline">{run.run_id}</a>
+									<div class="min-w-0 flex flex-col">
+										<a href="/suite/{data.suite_id}/{run.prompt_run_id ?? run.audit_run_id ?? run.run_id}" class="text-sm font-medium text-interactive hover:underline">{run.run_id}</a>
+										<span class="font-mono text-[10px] text-text-muted truncate" title={runTarget(run)}>{runTarget(run)}</span>
+									</div>
 								</div>
 							</td>
 							<td class="px-3 py-2 text-xs text-text-muted">
 								{#if !hasChildren}{qRun ? 'Single-turn prompts' : 'Multi-turn scenarios'}{:else}<span>{[qRun ? 'Prompts' : '', aRun ? 'Scenarios' : ''].filter(Boolean).join(' + ')}</span>{/if}
 							</td>
-							<td class="px-3 py-2 font-mono text-xs text-text-muted">{runTarget(run)}</td>
 							<td class="px-3 py-2 text-xs text-text-muted">{runStartedAt ? new Date(runStartedAt).toLocaleDateString('en-US', { month: '2-digit', day: '2-digit', year: 'numeric' }) : '—'}</td>
 							<td class="px-3 py-2">
 								<span class="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium {runStatusClass}">{runStatusLabel}</span>
@@ -545,7 +542,6 @@
 								<td class="px-3 py-2"></td>
 								<td class="px-3 py-2 pl-7"><a href="/suite/{data.suite_id}/{run.prompt_run_id ?? run.run_id}?tab=prompts" class="text-xs text-text-secondary hover:text-interactive hover:underline">Prompts</a></td>
 								<td class="px-3 py-2 text-xs text-text-muted">Single-turn prompts</td>
-								<td class="px-3 py-2 font-mono text-xs text-text-muted">{qRun.metrics?.target ?? '—'}</td>
 								<td class="px-3 py-2"></td>
 								<td class="px-3 py-2"></td>
 								{#each visibleDimNames as dimName (dimName)}
@@ -560,7 +556,6 @@
 								<td class="px-3 py-2"></td>
 								<td class="px-3 py-2 pl-7"><a href="/suite/{data.suite_id}/{run.audit_run_id ?? run.run_id}?tab=audit" class="text-xs text-text-secondary hover:text-interactive hover:underline">Scenarios</a></td>
 								<td class="px-3 py-2 text-xs text-text-muted">Multi-turn scenarios</td>
-								<td class="px-3 py-2 font-mono text-xs text-text-muted">{aRun.metrics?.target ?? '—'}</td>
 								<td class="px-3 py-2"></td>
 								<td class="px-3 py-2"></td>
 								{#each visibleDimNames as dimName (dimName)}

--- a/viewer/src/routes/suite/[suite_id]/+page.svelte
+++ b/viewer/src/routes/suite/[suite_id]/+page.svelte
@@ -12,6 +12,8 @@
 	import type { DimensionDef, JudgedSample, ViewerResultItem } from '$lib/types.js';
 	import type { SuiteHeavyData } from '$lib/server/data.js';
 	import { fade } from 'svelte/transition';
+	import { page } from '$app/state';
+	import { goto } from '$app/navigation';
 
 	type BehaviorEvalEntry = { kind: 'prompt' | 'scenario'; sample: JudgedSample };
 
@@ -94,6 +96,54 @@
 			allRuns.some((r) => aggregateRunDimensionRate(r, name) !== null)
 		)
 	);
+
+	// Per-column dim selection for the evaluation-results table. Each of the
+	// MAX_METRIC_COLS slots holds either a dim name (must currently be populated)
+	// or null when the user hasn't picked a dim for that slot. State is sourced
+	// from the URL search param ``metrics`` so links are shareable and reloads
+	// preserve the user's column choice. Default = first MAX_METRIC_COLS entries
+	// of visibleDimNames, preserving the existing ordering.
+	const MAX_METRIC_COLS = 3;
+	let selectedMetricCols = $derived.by<(string | null)[]>(() => {
+		const populated = visibleDimNames;
+		const numCols = Math.min(MAX_METRIC_COLS, populated.length);
+		if (numCols === 0) return [];
+		const raw = page.url.searchParams.get('metrics');
+		const result: (string | null)[] = new Array(numCols).fill(null);
+		const used = new Set<string>();
+		if (raw) {
+			const parts = raw.split(',').map((s) => s.trim());
+			for (let i = 0; i < numCols && i < parts.length; i++) {
+				const name = parts[i];
+				if (name && populated.includes(name) && !used.has(name)) {
+					result[i] = name;
+					used.add(name);
+				}
+			}
+		}
+		// Fill empty slots with the first unused populated dim (preserves default ordering).
+		for (let i = 0; i < numCols; i++) {
+			if (result[i] !== null) continue;
+			const fallback = populated.find((n) => !used.has(n));
+			if (!fallback) break;
+			result[i] = fallback;
+			used.add(fallback);
+		}
+		return result;
+	});
+
+	function setMetricCol(colIdx: number, dimName: string) {
+		const next = [...selectedMetricCols];
+		if (colIdx < 0 || colIdx >= next.length) return;
+		// If the chosen dim is already used in another slot, swap them so we never
+		// end up with the same dim in two columns.
+		const existingIdx = next.findIndex((n, i) => n === dimName && i !== colIdx);
+		if (existingIdx >= 0) next[existingIdx] = next[colIdx];
+		next[colIdx] = dimName;
+		const url = new URL(page.url);
+		url.searchParams.set('metrics', next.filter((n): n is string => Boolean(n)).join(','));
+		goto(url.toString(), { replaceState: true, noScroll: true, keepFocus: true });
+	}
 	let sortedBehaviors = $derived(data.taxonomy?.behavior_categories ?? []);
 	let promptSeedItems = $derived(normalizePromptSeeds(data.promptSeeds));
 	let scenarioSeedItems = $derived(normalizeScenarioSeeds(data.scenarioSeeds));
@@ -473,8 +523,24 @@
 						</th>
 						<th class="px-3 py-2 text-xs font-medium text-text-muted">Run date</th>
 						<th class="px-3 py-2 text-xs font-medium text-text-muted">Run status</th>
-						{#each visibleDimNames as dimName (dimName)}
-							<th class="w-32 px-3 py-2 text-left text-xs font-medium text-text-muted whitespace-nowrap truncate">{dimColumnLabel(dimName)}</th>
+						{#each selectedMetricCols as colDim, colIdx (colIdx)}
+							<th class="w-32 px-3 py-2 text-left text-xs font-medium text-text-muted whitespace-nowrap">
+								<label class="sr-only" for="metric-col-{colIdx}">Metric column {colIdx + 1}</label>
+								<select
+									id="metric-col-{colIdx}"
+									class="w-full bg-transparent text-xs font-medium text-text-muted hover:text-text focus:outline-none focus:ring-1 focus:ring-interactive/40 rounded px-1 py-0.5 cursor-pointer truncate"
+									value={colDim ?? ''}
+									onchange={(e) => setMetricCol(colIdx, (e.currentTarget as HTMLSelectElement).value)}
+									title={colDim ? dimColumnLabel(colDim) : ''}
+								>
+									{#each visibleDimNames as optDim (optDim)}
+										<option
+											value={optDim}
+											disabled={selectedMetricCols.some((n, i) => n === optDim && i !== colIdx)}
+										>{dimColumnLabel(optDim)}</option>
+									{/each}
+								</select>
+							</th>
 						{/each}
 						<th class="px-3 py-2 text-left text-xs font-medium text-text-muted">Total</th>
 					</tr>
@@ -525,8 +591,8 @@
 							<td class="px-3 py-2">
 								<span class="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium {runStatusClass}">{runStatusLabel}</span>
 							</td>
-							{#each visibleDimNames as dimName (dimName)}
-								{@const dimRate = aggregateRunDimensionRate(run, dimName)}
+							{#each selectedMetricCols as colDim, colIdx (colIdx)}
+								{@const dimRate = colDim ? aggregateRunDimensionRate(run, colDim) : null}
 								<td class="px-3 py-2 text-left">
 									{#if dimRate !== null}
 										<span class="text-xs font-semibold">{(dimRate * 100).toFixed(0)}%</span>
@@ -544,8 +610,8 @@
 								<td class="px-3 py-2 text-xs text-text-muted">Single-turn prompts</td>
 								<td class="px-3 py-2"></td>
 								<td class="px-3 py-2"></td>
-								{#each visibleDimNames as dimName (dimName)}
-									{@const childDimRate = qRun.metrics?.dimensions?.[dimName]?.rate ?? null}
+								{#each selectedMetricCols as colDim, colIdx (colIdx)}
+									{@const childDimRate = colDim ? (qRun.metrics?.dimensions?.[colDim]?.rate ?? null) : null}
 									<td class="px-3 py-2 text-left">{#if childDimRate !== null && childDimRate !== undefined}<span class="text-xs font-semibold">{(childDimRate * 100).toFixed(0)}%</span>{:else}<span class="text-xs text-text-muted">—</span>{/if}</td>
 								{/each}
 								<td class="px-3 py-2 text-left text-xs text-text-muted">{qRun.metrics?.total ?? '—'}</td>
@@ -558,8 +624,8 @@
 								<td class="px-3 py-2 text-xs text-text-muted">Multi-turn scenarios</td>
 								<td class="px-3 py-2"></td>
 								<td class="px-3 py-2"></td>
-								{#each visibleDimNames as dimName (dimName)}
-									{@const childDimRate = aRun.metrics?.dimensions?.[dimName]?.rate ?? null}
+								{#each selectedMetricCols as colDim, colIdx (colIdx)}
+									{@const childDimRate = colDim ? (aRun.metrics?.dimensions?.[colDim]?.rate ?? null) : null}
 									<td class="px-3 py-2 text-left">{#if childDimRate !== null && childDimRate !== undefined}<span class="text-xs font-semibold">{(childDimRate * 100).toFixed(0)}%</span>{:else}<span class="text-xs text-text-muted">—</span>{/if}</td>
 								{/each}
 								<td class="px-3 py-2 text-left text-xs text-text-muted">{aRun.metrics?.total ?? '—'}</td>

--- a/viewer/src/routes/suite/[suite_id]/+page.svelte
+++ b/viewer/src/routes/suite/[suite_id]/+page.svelte
@@ -525,21 +525,21 @@
 						<th class="px-3 py-2 text-xs font-medium text-text-muted">Run status</th>
 						{#each selectedMetricCols as colDim, colIdx (colIdx)}
 							<th class="w-32 px-3 py-2 text-left text-xs font-medium text-text-muted whitespace-nowrap">
-								<label class="sr-only" for="metric-col-{colIdx}">Metric column {colIdx + 1}</label>
-								<select
-									id="metric-col-{colIdx}"
-									class="w-full bg-transparent text-xs font-medium text-text-muted hover:text-text focus:outline-none focus:ring-1 focus:ring-interactive/40 rounded px-1 py-0.5 cursor-pointer truncate"
-									value={colDim ?? ''}
-									onchange={(e) => setMetricCol(colIdx, (e.currentTarget as HTMLSelectElement).value)}
-									title={colDim ? dimColumnLabel(colDim) : ''}
-								>
-									{#each visibleDimNames as optDim (optDim)}
-										<option
-											value={optDim}
-											disabled={selectedMetricCols.some((n, i) => n === optDim && i !== colIdx)}
-										>{dimColumnLabel(optDim)}</option>
-									{/each}
-								</select>
+								<PrimerDropdown
+									ariaLabel={`Metric column ${colIdx + 1}`}
+									selected={colDim ?? ''}
+									options={visibleDimNames.map((optDim) => {
+										const usedColIdx = selectedMetricCols.findIndex((n, i) => n === optDim && i !== colIdx);
+										const isUsedElsewhere = usedColIdx >= 0;
+										return {
+											value: optDim,
+											label: dimColumnLabel(optDim),
+											disabled: isUsedElsewhere,
+											secondaryLabel: isUsedElsewhere ? `in column ${usedColIdx + 1}` : undefined
+										};
+									})}
+									onSelect={(value) => setMetricCol(colIdx, value)}
+								/>
 							</th>
 						{/each}
 						<th class="px-3 py-2 text-left text-xs font-medium text-text-muted">Total</th>

--- a/viewer/src/routes/suite/[suite_id]/compare/+page.server.ts
+++ b/viewer/src/routes/suite/[suite_id]/compare/+page.server.ts
@@ -4,6 +4,7 @@
 import { loadComparePageData } from '$lib/server/data.js';
 import { isSafeArtifactId } from '$lib/server/artifacts.js';
 import { error } from '@sveltejs/kit';
+import type { JudgedSample } from '$lib/types.js';
 import type { PageServerLoad } from './$types.js';
 
 export const load: PageServerLoad = async ({ params, url }) => {
@@ -22,7 +23,29 @@ export const load: PageServerLoad = async ({ params, url }) => {
 		if (!isSafeArtifactId(runId)) throw error(400, `Invalid run ID: ${runId}`);
 	}
 
-	const payload = loadComparePageData(suite_id, runIds);
-	if (!payload) throw error(404, 'One or more runs had no judged samples');
-	return payload;
+	const kind: 'prompts' | 'scenarios' =
+		url.searchParams.get('kind') === 'scenarios' ? 'scenarios' : 'prompts';
+
+	const payload = loadComparePageData(suite_id, runIds, kind);
+	if (payload) return payload;
+
+	// Scenarios-mode empty state: when one or more runs have no scenario
+	// samples, we still want to render the toggle so the user can switch back
+	// to Prompts. Reuse the prompts payload for the shared metadata (runs,
+	// taxonomy, dimensionDefs) and blank out the comparison data so the page
+	// can show a "No scenarios in these runs" message.
+	if (kind === 'scenarios') {
+		const promptsPayload = loadComparePageData(suite_id, runIds, 'prompts');
+		if (!promptsPayload) throw error(404, 'One or more runs had no judged samples');
+		return {
+			...promptsPayload,
+			kind: 'scenarios' as const,
+			emptyKind: true,
+			comparisons: [] as typeof promptsPayload.comparisons,
+			samplesByBehavior: {} as Record<string, Record<string, JudgedSample[]>>,
+			allMetrics: [] as string[]
+		};
+	}
+
+	throw error(404, 'One or more runs had no judged samples');
 };

--- a/viewer/src/routes/suite/[suite_id]/compare/+page.svelte
+++ b/viewer/src/routes/suite/[suite_id]/compare/+page.svelte
@@ -7,7 +7,9 @@
 	import PrimerDropdown from '$lib/PrimerDropdown.svelte';
 	import { slide } from 'svelte/transition';
 	import { quintOut } from 'svelte/easing';
-	import type { BinaryCounts, DimensionDef } from '$lib/types.js';
+	import { page } from '$app/state';
+	import { goto } from '$app/navigation';
+	import type { BinaryCounts, DimensionDef, InteractionMessage, JudgedSample } from '$lib/types.js';
 
 	let { data } = $props();
 	let requiredBaseMetrics = $derived(
@@ -22,6 +24,26 @@ const RUN_COLORS = ['#a78bfa', '#60a5fa', '#2dd4bf', '#fbbf24'];
 
 // Baseline is always the first run
 let baselineIdx = $state(0);
+
+// Result type toggle: prompts (single-turn, default) vs scenarios (multi-turn).
+// URL contract is `?kind=prompts|scenarios` — note the new compare-page param
+// name intentionally diverges from the legacy run-page `?tab=prompts|audit`
+// so the public URL surface matches the user-visible "Scenarios" label here
+// without breaking existing run-page bookmarks.
+let activeKind = $derived(
+	((data as { kind?: string }).kind === 'scenarios' ? 'scenarios' : 'prompts') as
+		| 'prompts'
+		| 'scenarios'
+);
+let emptyKind = $derived(Boolean((data as { emptyKind?: boolean }).emptyKind));
+
+function setActiveKind(kind: 'prompts' | 'scenarios') {
+	if (kind === activeKind) return;
+	const url = new URL(page.url);
+	if (kind === 'scenarios') url.searchParams.set('kind', 'scenarios');
+	else url.searchParams.delete('kind');
+	goto(url.toString(), { replaceState: true, noScroll: true, keepFocus: true });
+}
 
 // Expanded behavior rows
 let expandedRows = $state<Set<string>>(new Set());
@@ -116,8 +138,40 @@ function getMatchedSamples(behavior: string) {
 		runIds,
 		activeMetric,
 		disagreementsOnly,
-		data.runs[baselineIdx]?.run_id
+		data.runs[baselineIdx]?.run_id,
+		// In scenarios mode, pair multi-turn conversations by the shared
+		// test_case_id. The opening prompt (first user turn) is identical
+		// across runs because both replays seed from the same test_set.jsonl,
+		// but assistant responses diverge after turn 1 as the adaptive tester
+		// drives each variant differently. Fall back to prompt text when a
+		// row is missing test_case_id (legacy artifacts) so pairing is still
+		// best-effort instead of dropping the row entirely.
+		activeKind === 'scenarios' ? (s: JudgedSample) => s.test_case_id ?? s.prompt : undefined
 	);
+}
+
+// Conversation messages minus system prompts. Used by scenarios mode to
+// render each run's full multi-turn transcript below the shared seed turn.
+function conversationMessages(sample: JudgedSample | null): InteractionMessage[] {
+	if (!sample?.messages) return [];
+	return sample.messages.filter((m) => m.role !== 'system');
+}
+
+// Opening user turn for a scenario row. Per `buildJudgedSampleRow` in
+// server/data.ts, JudgedSample.prompt already holds the first user message,
+// which is the same across runs in scenarios mode (the seed).
+function openingPrompt(samples: Record<string, JudgedSample | null>): string {
+	for (const sample of Object.values(samples)) {
+		if (sample?.prompt) return sample.prompt;
+	}
+	return '';
+}
+
+function turnRoleLabel(role: InteractionMessage['role']): string {
+	if (role === 'user') return 'User';
+	if (role === 'assistant') return 'Assistant';
+	if (role === 'tool') return 'Tool';
+	return role;
 }
 
 function pctBar(counts: BinaryCounts): { clear: number; flagged: number } {
@@ -174,22 +228,64 @@ function capitalize(s: string): string {
 			Comparing {data.runs.length} runs on {data.taxonomy?.behavior?.name ?? data.suite_id}
 		</h1>
 
-		<div class="mt-4">
+		<div class="mt-4 flex flex-wrap items-end gap-4">
 			<!-- Baseline dropdown -->
-			<label for="baseline-select" class="block text-xs font-medium text-text-muted mb-1.5">Baseline</label>
-			<PrimerDropdown
-				ariaLabel="Select baseline run"
-				selected={String(baselineIdx)}
-				options={data.runs.map((run, i) => ({
-					value: String(i),
-					label: `${run.display_name} · ${run.date}`
-				}))}
-				onSelect={(value) => { baselineIdx = Number(value); }}
-			/>
+			<div>
+				<label for="baseline-select" class="block text-xs font-medium text-text-muted mb-1.5">Baseline</label>
+				<PrimerDropdown
+					ariaLabel="Select baseline run"
+					selected={String(baselineIdx)}
+					options={data.runs.map((run, i) => ({
+						value: String(i),
+						label: `${run.display_name} · ${run.date}`
+					}))}
+					onSelect={(value) => { baselineIdx = Number(value); }}
+				/>
+			</div>
+
+			<!-- Result type toggle (same design language as the single-run view) -->
+			<div>
+				<span class="block text-xs font-medium text-text-muted mb-1.5">Result type</span>
+				<div class="SegmentedControl" role="tablist" aria-label="Result type">
+					<button
+						type="button"
+						role="tab"
+						aria-selected={activeKind === 'prompts'}
+						class="SegmentedControl-item"
+						class:SegmentedControl-item--selected={activeKind === 'prompts'}
+						onclick={() => setActiveKind('prompts')}
+					>
+						<span class="SegmentedControl-content">
+							<span>Prompts</span>
+						</span>
+					</button>
+					<button
+						type="button"
+						role="tab"
+						aria-selected={activeKind === 'scenarios'}
+						class="SegmentedControl-item"
+						class:SegmentedControl-item--selected={activeKind === 'scenarios'}
+						onclick={() => setActiveKind('scenarios')}
+					>
+						<span class="SegmentedControl-content">
+							<span>Scenarios</span>
+						</span>
+					</button>
+				</div>
+			</div>
 		</div>
 	</div>
 </div>
 
+{#if emptyKind}
+	<div class="rounded-lg border border-border bg-surface px-6 py-12 text-center">
+		<svg class="mx-auto mb-4 h-10 w-10 text-text-muted opacity-40" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+			<path d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"/>
+		</svg>
+		<p class="text-sm text-text-secondary">No scenario evaluations recorded for these runs.</p>
+		<p class="mt-2 text-xs text-text-muted">Switch back to Prompts to view this comparison.</p>
+	</div>
+{:else}
 <div class="space-y-8">
 	<!-- ═══ SECTION 2: Metric Picker + Summary Cards ═══ -->
 	<section class="space-y-4">
@@ -378,8 +474,86 @@ function capitalize(s: string): string {
 											{disagreementsOnly ? 'No disagreements for this behavior' : 'No samples'}
 										</div>
 									{:else}
-										{#each displaySamples as pair, pairIdx (pair.prompt)}
+										{#each displaySamples as pair, pairIdx (pair.prompt + ':' + pairIdx)}
 											<div class="rounded-lg border border-border bg-surface overflow-hidden">
+												{#if activeKind === 'scenarios'}
+													<!-- Opening (seed) turn — identical across runs; conversations
+													     diverge from turn 2 onward as each variant is driven by the
+													     adaptive tester. -->
+													<div class="px-4 py-2.5 bg-surface-2 border-b border-border">
+														<div class="text-[12px] font-medium text-text-muted mb-0.5">Opening prompt</div>
+														<div class="text-sm text-text leading-relaxed">{(() => { const op = openingPrompt(pair.samples); return op.length > 200 ? op.slice(0, 200) + '…' : op; })()}</div>
+													</div>
+
+													<!-- Per-run multi-turn transcripts side by side -->
+													<div class="overflow-x-auto">
+														<div
+															class="grid divide-x divide-border"
+															style="grid-template-columns: {sampleGridTemplate(data.runs.length)}; min-width: {sampleGridMinWidth(data.runs.length)};"
+														>
+															{#each orderedRuns as run (run.run_id)}
+																{@const sample = pair.samples[run.run_id]}
+																{@const convo = conversationMessages(sample)}
+																<div class="p-3 space-y-2">
+																	<!-- Model + score -->
+																	<div class="flex items-center justify-between">
+																		<div class="flex items-center gap-1.5 min-w-0">
+																			<span class="h-1.5 w-1.5 rounded-full flex-shrink-0" style="background: {runColor[run.run_id]}"></span>
+																			<span class="text-xs font-mono truncate" title={run.model} style="color: {runColor[run.run_id]}">{runLabel(run.model)}</span>
+																		</div>
+																		{#if sample}
+																			{@const sampleScore = getRecordFlag(sample, activeMetric)}
+																			{#if sampleScore !== null}
+																				<span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold {scoreBadgeClass(sampleScore)}">
+																					{sampleScore ? 'Flagged' : 'Clear'}
+																				</span>
+																			{:else if judgeStatus(sample) === 'judge_failed'}
+																				<span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-amber-500/10 text-amber-500">
+																					Judge failed
+																				</span>
+																			{/if}
+																		{/if}
+																	</div>
+
+																	{#if sample}
+																		<div class="text-[10px] uppercase tracking-wide text-text-muted">
+																			{convo.length} turn{convo.length === 1 ? '' : 's'}
+																		</div>
+																		<!-- Scrollable conversation; capped height so cards
+																		     stay aligned and long transcripts don't blow up
+																		     the page. -->
+																		<div class="max-h-80 overflow-y-auto rounded border border-border bg-surface-2/40 p-2 space-y-2">
+																			{#each convo as msg, msgIdx (msgIdx)}
+																				{@const isUser = msg.role === 'user'}
+																				{@const isAssistant = msg.role === 'assistant'}
+																				<div class="text-xs leading-relaxed">
+																					<div class="mb-0.5 font-semibold {isUser ? 'text-interactive' : isAssistant ? 'text-text' : 'text-text-muted'}">
+																						{turnRoleLabel(msg.role)}
+																					</div>
+																					<div class="whitespace-pre-wrap text-text-secondary">{msg.content.length > 600 ? msg.content.slice(0, 600) + '…' : msg.content}</div>
+																				</div>
+																			{/each}
+																			{#if convo.length === 0}
+																				<p class="text-xs text-text-muted italic">No transcript captured</p>
+																			{/if}
+																		</div>
+																		{#if typeof sample.verdict?.justification === 'string'}
+																			<p class="text-xs text-text-muted italic leading-relaxed border-t border-border pt-2 mt-2">
+																				{sample.verdict.justification.length > 200 ? sample.verdict.justification.slice(0, 200) + '…' : sample.verdict.justification}
+																			</p>
+																		{:else if judgeStatus(sample) === 'judge_failed'}
+																			<p class="text-xs text-amber-500 italic leading-relaxed border-t border-border pt-2 mt-2">
+																				Judge failed{getJudgeError(sample) ? `: ${getJudgeError(sample)}` : ''}
+																			</p>
+																		{/if}
+																	{:else}
+																		<p class="text-xs text-text-muted italic">No scenario for this run</p>
+																	{/if}
+																</div>
+															{/each}
+														</div>
+													</div>
+												{:else}
 												<!-- Prompt -->
 												<div class="px-4 py-2.5 bg-surface-2 border-b border-border">
 													<div class="text-[12px] font-medium text-text-muted mb-0.5">Test prompt</div>
@@ -436,6 +610,7 @@ function capitalize(s: string): string {
 														{/each}
 													</div>
 												</div>
+												{/if}
 											</div>
 										{/each}
 
@@ -465,3 +640,4 @@ function capitalize(s: string): string {
 		</div>
 	</section>
 </div>
+{/if}

--- a/viewer/src/routes/suite/[suite_id]/compare/+page.svelte
+++ b/viewer/src/routes/suite/[suite_id]/compare/+page.svelte
@@ -95,12 +95,28 @@ function deltaArrow(d: number): string {
 
 let runIds = $derived(data.runs.map((run) => run.run_id));
 
+// Issue 1: baseline-first display order + run-id-keyed colors so a run keeps its color across pages
+let orderedRuns = $derived([
+	data.runs[baselineIdx],
+	...data.runs.filter((_, i) => i !== baselineIdx)
+]);
+let runColor = $derived(
+	Object.fromEntries(data.runs.map((r, i) => [r.run_id, RUN_COLORS[i]])) as Record<string, string>
+);
+function baselineDeltaFor(run: { run_id: string; policyViolationRate: number; dimensions: Record<string, { rate: number }> }) {
+	const baseline = data.runs[baselineIdx];
+	const avg = activeMetric === 'policy_violation' ? run.policyViolationRate : (run.dimensions[activeMetric]?.rate ?? 0);
+	const baselineAvg = activeMetric === 'policy_violation' ? baseline.policyViolationRate : (baseline.dimensions[activeMetric]?.rate ?? 0);
+	return { avg, baselineAvg, delta: run.run_id === baseline.run_id ? 0 : avg - baselineAvg };
+}
+
 function getMatchedSamples(behavior: string) {
 	return buildMatchedSampleRows(
 		data.samplesByBehavior[behavior] ?? {},
 		runIds,
 		activeMetric,
-		disagreementsOnly
+		disagreementsOnly,
+		data.runs[baselineIdx]?.run_id
 	);
 }
 
@@ -196,11 +212,11 @@ function capitalize(s: string): string {
 		</div>
 
 		<div class="grid gap-4" style="grid-template-columns: {summaryGridTemplate()};">
-			{#each data.runs as run, i}
-				{@const baseline = data.runs[baselineIdx]}
-				{@const avg = activeMetric === 'policy_violation' ? run.policyViolationRate : (run.dimensions[activeMetric]?.rate ?? 0)}
-				{@const baselineAvg = activeMetric === 'policy_violation' ? baseline.policyViolationRate : (baseline.dimensions[activeMetric]?.rate ?? 0)}
-				{@const delta = i !== baselineIdx ? avg - baselineAvg : 0}
+			{#each orderedRuns as run (run.run_id)}
+				{@const isBaseline = run.run_id === data.runs[baselineIdx].run_id}
+				{@const dInfo = baselineDeltaFor(run)}
+				{@const avg = dInfo.avg}
+				{@const delta = dInfo.delta}
 				{@const runScores = activeMetric === 'policy_violation' ? run.counts : (run.dimensions[activeMetric]?.counts ?? { 0: 0, 1: 0 })}
 				{@const pct = pctBar(runScores)}
 				{@const totalSamples = runScores[0] + runScores[1]}
@@ -208,9 +224,9 @@ function capitalize(s: string): string {
 					<!-- Header: run name + sample count -->
 					<div class="flex items-start justify-between gap-3">
 						<div class="flex items-center gap-2 min-w-0">
-							<span class="h-2 w-2 rounded-full flex-shrink-0" style="background: {RUN_COLORS[i]}"></span>
+							<span class="h-2 w-2 rounded-full flex-shrink-0" style="background: {runColor[run.run_id]}"></span>
 							<span class="text-sm font-medium text-text truncate">{run.display_name}</span>
-							{#if i === baselineIdx}
+							{#if isBaseline}
 								<span class="inline-flex items-center rounded-full bg-interactive/15 px-2 py-0.5 text-[10px] font-semibold text-interactive ring-1 ring-interactive/40">Baseline</span>
 							{/if}
 						</div>
@@ -224,7 +240,7 @@ function capitalize(s: string): string {
 					<div class="mt-3 flex items-baseline gap-1.5">
 						<span class="text-3xl font-bold tabular-nums text-text">{(avg * 100).toFixed(0)}%</span>
 						<span class="text-sm text-text-muted">Flagged</span>
-						{#if i !== baselineIdx && Math.abs(delta) >= 0.005}
+						{#if !isBaseline && Math.abs(delta) >= 0.005}
 							<span class="ml-1 text-sm font-semibold tabular-nums {deltaClass(delta)}">
 								{deltaText(delta)} {deltaArrow(delta)}
 							</span>
@@ -307,8 +323,8 @@ function capitalize(s: string): string {
 				<div class="grid items-center gap-2 px-4 py-2.5 bg-surface text-xs font-semibold text-text-muted border-b border-border"
 					style="grid-template-columns: {comparisonGridTemplate(data.runs.length)};">
 					<span>Behavior</span>
-					{#each data.runs as run, i}
-						<span class="text-center font-mono font-medium truncate" title={run.model} style="color: {RUN_COLORS[i]}">{runLabel(run.model)}</span>
+					{#each orderedRuns as run (run.run_id)}
+						<span class="text-center font-mono font-medium truncate" title={run.model} style="color: {runColor[run.run_id]}">{runLabel(run.model)}</span>
 					{/each}
 				</div>
 
@@ -336,7 +352,7 @@ function capitalize(s: string): string {
 						</div>
 
 						<!-- Score cells -->
-						{#each data.runs as run, i}
+						{#each orderedRuns as run (run.run_id)}
 							{@const cell = row.metrics[activeMetric]?.[run.run_id]}
 							{@const hasFlagged = cell && cell.counts[1] > 0}
 							{@const cellColor = hasFlagged ? 'var(--color-score-fail, #cf222e)' : 'var(--color-score-pass, #1a7f37)'}
@@ -376,14 +392,14 @@ function capitalize(s: string): string {
 														class="grid divide-x divide-border"
 														style="grid-template-columns: {sampleGridTemplate(data.runs.length)}; min-width: {sampleGridMinWidth(data.runs.length)};"
 													>
-														{#each data.runs as run, i}
+														{#each orderedRuns as run (run.run_id)}
 															{@const sample = pair.samples[run.run_id]}
 															<div class="p-3 space-y-2">
 														<!-- Model + score -->
 														<div class="flex items-center justify-between">
 															<div class="flex items-center gap-1.5 min-w-0">
-																<span class="h-1.5 w-1.5 rounded-full flex-shrink-0" style="background: {RUN_COLORS[i]}"></span>
-																<span class="text-xs font-mono truncate" title={run.model} style="color: {RUN_COLORS[i]}">{runLabel(run.model)}</span>
+																<span class="h-1.5 w-1.5 rounded-full flex-shrink-0" style="background: {runColor[run.run_id]}"></span>
+																<span class="text-xs font-mono truncate" title={run.model} style="color: {runColor[run.run_id]}">{runLabel(run.model)}</span>
 															</div>
 															{#if sample}
 																{@const sampleScore = getRecordFlag(sample, activeMetric)}


### PR DESCRIPTION
# viewer/compare: pin baseline left + show only populated dim columns

## TL;DR

Three independent UX/correctness fixes on the compare and suite-landing views, in three commits:

1. **`viewer/suite`** — render columns from the eval's actual `dimensionDefs` instead of three hardcoded headers (`Policy violation`, `Overrefusal`, `Harm actionability`). For evals with custom dimension names (e.g. `safety_violation`, `unjustified_refusal`), the previous UI silently relabeled the customer's metric and showed a dead `—` column for the unsupported `harm_actionability`. Headers now come from `Object.keys(data.dimensionDefs)`, per-row values from `metrics.dimensions[name].rate`, and any column where every visible row is null is hidden. No cap — the table scrolls horizontally like the by-behavior heatmap.

2. **`viewer/compare`** — pin the baseline run to the leftmost column across summary cards, the by-behavior heatmap header, and per-prompt sample columns. Tagging a card `Baseline` while leaving it on the right inverted the diff-tool convention (baseline left, change right) every reader expects; `-18%` deltas read as "left is better than right" on first glance when they actually mean "left is better than baseline on the right." Colors are now keyed by `run_id` via a `runColor` map so a run keeps its color regardless of column position. `?runs=` URL order is preserved as the canonical user-selection order.

3. **`viewer/compare`** — sort the per-prompt sample panels with a three-key comparator: (baseline-flagged DESC, has-disagreement DESC, |Δ| DESC), tiebreak on `prompt`. Lead with the regression-fix story (baseline-fail / variant-clear at top) without hiding regressions (baseline-clear / variant-fail next). The previous sort was disagreement-first then `scoreSortValue` on whichever sample happened to be first non-null, which made screenshot order subtly non-deterministic when the baseline was missing a prompt.

## Decisions worth flagging

- **No column cap on the suite-landing dim table.** The spec floated capping at 5; dropped because the by-behavior heatmap already overflows horizontally and a cap forces an overflow UI we don't need. If a customer has >7 dims we'd rather they scroll than introduce a kebab-menu column picker now.
- **Sort key 1 is `baseline-flagged` = `getRecordFlag(sample, metric) === true`.** I treated judge-failure rows as not-flagged so they fall to the bottom (rather than being treated as agreement-on-clear). Matches the per-spec acceptance criterion.
- **Aggregate helpers `aggregateRunViolationRate` / `aggregateRunOverrefusalRate` are left in place** even though the table no longer calls them — they're tiny and may have downstream callers. Will sweep in a follow-up if confirmed dead.

## How to verify

Existing bank-manager ACS demo artifacts in `artifacts/results/bank-manager-agent-shield/` exercise all three changes:

- Open the suite landing page → the table should show columns for `safety_violation` and `unjustified_refusal` (the eval's actual dims) rather than the old hardcoded three. No empty `Harm actionability` column.
- Click Compare → pick a baseline → it should render leftmost across the cards, the heatmap header, and inside any expanded behavior row's sample panel.
- Expand a behavior with mixed outcomes → baseline-flagged-variant-clear prompts (the "wins") should be at the top; regressions next; agreement at the bottom.

## CI / typecheck

`npm run check` in `viewer/` reports the same 3 pre-existing errors (`PrimerPagination.svelte` `rel` prop, `routes/+page.svelte` `sortBy` typing) on `main` as on this branch. Zero new errors introduced.

## Out of scope

- Issue 3 (Prompt | Scenario segmented control + paired-transcript view) is M effort and needs the divergent-transcript view to ship honestly; deferred to a separate PR.
- Run-detail page (`/suite/[id]/[run_id]`) has its own column conventions — a follow-up audit can align landing and detail.
