### PR TITLE
chore: add community-launch hygiene (issue/PR templates, CODEOWNERS, README badges)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,79 @@
+name: Bug report
+description: Report a bug or unexpected behavior in ASSERT
+title: "[Bug]: "
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report! Before submitting, please:
+        - Search existing issues to avoid duplicates.
+        - Redact any secrets, customer data, or other sensitive content from configs, logs, and traces.
+        - Include a minimal reproduction so we can investigate quickly.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear and concise description of the bug.
+      placeholder: When I run `assert-eval run ...`, the CLI crashes with ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+      description: A clear and concise description of the expected behavior.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps and minimal eval config
+      description: |
+        Step-by-step instructions to reproduce, plus the smallest eval config that triggers the issue.
+        Please redact secrets and customer data.
+      value: |
+        1.
+        2.
+        3.
+
+        ```yaml
+        # minimal eval_config.yaml
+        ```
+    validations:
+      required: true
+
+  - type: input
+    id: version-info
+    attributes:
+      label: Version info (assert_ai version, Python version, OS)
+      description: |
+        Run `pip show assert_ai | grep Version` (or `pip show assert_ai | Select-String Version` on Windows),
+        plus `python --version` and your OS (e.g., Windows 11, macOS 14.5, Ubuntu 22.04).
+      placeholder: "assert_ai 0.x.y, Python 3.12.3, Ubuntu 22.04"
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or traceback
+      description: Paste any console output, stack traces, or judge artifacts that help explain the issue.
+      render: shell
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Acknowledgements
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+        - label: I redacted secrets, credentials, and customer data from my report.
+          required: true
+        - label: I included a minimal reproduction.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: GitHub Discussions
+    url: https://github.com/responsibleai/ASSERT/discussions
+    about: Ask questions, share use cases, or discuss design ideas with the community.
+  - name: Documentation and setup help
+    url: https://github.com/responsibleai/ASSERT/blob/main/README.md
+    about: Start with the README and the docs/ directory for installation, quickstart, and CLI/config reference.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,54 @@
+name: Feature request
+description: Suggest a new feature or improvement for ASSERT
+title: "[Feature]: "
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please search existing issues and discussions before opening a new request.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem you're trying to solve
+      description: What problem or limitation are you running into today?
+      placeholder: When I evaluate a multi-agent system, I can't ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed solution or behavior
+      description: Describe the behavior you'd like to see. Sketches of YAML, CLI flags, or API shapes are welcome.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you've thought about and why they don't quite work.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Use case context
+      description: |
+        Which target type (callable, model, model+tools)? Which framework (LangGraph, CrewAI, OpenAI Agents SDK, custom, etc.)?
+        Production vs. prototyping? Any other relevant context.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Acknowledgements
+      options:
+        - label: I searched existing issues and discussions and did not find a duplicate.
+          required: true
+        - label: I'd be willing to contribute a PR for this (optional).
+          required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!-- Thanks for contributing to ASSERT! Please keep this template short and scannable. -->
+
+## Summary
+
+<!-- 1-2 lines describing what this PR does. -->
+
+## Motivation / linked issue
+
+<!-- Closes #..., relates to #..., or briefly explain the why. -->
+
+## Changes
+
+<!-- Bullet list of the key changes. -->
+-
+-
+
+## Testing
+
+<!-- How did you verify? E.g., `pytest`, `npm run check`, manual viewer testing, `assert-eval run --config ...`. -->
+
+## Checklist
+
+- [ ] Tests pass locally (`pytest` and/or viewer checks as applicable).
+- [ ] Docs updated if behavior or public API changed.
+- [ ] No secrets, credentials, or customer data committed.
+- [ ] No breaking change, or a `CHANGELOG.md` entry is included.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# CODEOWNERS — placeholder team handle. Chang to update @responsibleai/assert-maintainers
+# to the actual GitHub team handle for this repo's maintainers.
+
+* @responsibleai/assert-maintainers

--- a/README.md
+++ b/README.md
@@ -13,11 +13,14 @@
         <a href="examples/README.md">🧪 Examples</a>
 </p>
 <p align="center">
-        <a href="LICENSE">
-                <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License: MIT">
+        <a href="https://github.com/responsibleai/ASSERT/actions/workflows/build.yml">
+                <img src="https://github.com/responsibleai/ASSERT/actions/workflows/build.yml/badge.svg" alt="Build status">
         </a>
         <a href="https://www.python.org/downloads/" target="_blank">
-                <img src="https://img.shields.io/badge/python-3.11%2B-blue.svg" alt="Python 3.11+">
+                <img src="https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13-blue.svg" alt="Python 3.11 | 3.12 | 3.13">
+        </a>
+        <a href="LICENSE">
+                <img src="https://img.shields.io/github/license/responsibleai/ASSERT" alt="License">
         </a>
 </p>
 <p align="center">


### PR DESCRIPTION
Bundle D for public-preview readiness.

**Added**:
- .github/ISSUE_TEMPLATE/bug_report.yml — form-style template with required fields, version-info input, secret-redaction reminder
- .github/ISSUE_TEMPLATE/feature_request.yml — problem / proposed solution / alternatives / context
- .github/ISSUE_TEMPLATE/config.yml — disables blank issues, links to Discussions
- .github/PULL_REQUEST_TEMPLATE.md — summary, motivation, testing, checklist (~30 lines)
- CODEOWNERS — placeholder catch-all (@responsibleai/assert-maintainers — needs real team handle from Chang)
- README.md — three badges at the top: CI build status (uses PR #182's uild.yml), Python versions (3.11/3.12/3.13 matching the actual CI matrix), license. Replaced the prior hardcoded license/python badges in the same badge block.

**Not included** (owned by parallel PRs):
- CHANGELOG.md + README migration callout — see parallel changelog PR
- PyPI badge — package not yet published; add when available

**Action for Chang post-merge**: replace @responsibleai/assert-maintainers in CODEOWNERS with the real team handle (or expand to per-path owners).
