### PR TITLE
refactor(viewer): rename spawnAssertEvalRun / resolveAssertEvalCommand to AssertAi*

### DIFF
--- a/viewer/src/lib/server/run-spawn.ts
+++ b/viewer/src/lib/server/run-spawn.ts
@@ -21,7 +21,7 @@
  *     -> writes eval_config.yaml (single-YAML authoring; behavior description
  *        lives inline in behavior.description)
  *
- *   spawnAssertEvalRun(...)
+ *   spawnAssertAiRun(...)
  *     -> spawns `assert-ai run --config <eval_config.yaml>` detached
  *     -> waits for the OS spawn/error event before resolving so a missing
  *        binary surfaces as HTTP 500 (not 200 then a forever-pending monitor)
@@ -677,7 +677,7 @@ function candidateVenvDirs(): string[] {
 	return dirs;
 }
 
-function resolveAssertEvalCommand(configPath: string): ResolvedCommand {
+function resolveAssertAiCommand(configPath: string): ResolvedCommand {
 	const cliArgs = ['run', '--config', configPath];
 	// Module invocation is the reliable form: it works even when the `assert-ai`
 	// console script was never (re)generated for a venv — e.g. after the package
@@ -759,8 +759,8 @@ function commandExistsOnPath(command: string): boolean {
  * Only after we hear back do we resolve — that way a missing `assert-ai`
  * binary surfaces as a 500 instead of a 200 followed by a forever-pending monitor.
  */
-export function spawnAssertEvalRun(written: WrittenRun): Promise<SpawnedRun> {
-	const resolved = resolveAssertEvalCommand(written.configPath);
+export function spawnAssertAiRun(written: WrittenRun): Promise<SpawnedRun> {
+	const resolved = resolveAssertAiCommand(written.configPath);
 
 	let logFd: number;
 	try {

--- a/viewer/src/routes/api/runs/+server.ts
+++ b/viewer/src/routes/api/runs/+server.ts
@@ -6,7 +6,7 @@ import { getActiveRuns } from '$lib/server/runner.js';
 import {
 	normalizeWizardPayload,
 	writeRunConfigFiles,
-	spawnAssertEvalRun,
+	spawnAssertAiRun,
 	runDirExists,
 	WizardValidationError,
 	RunConflictError,
@@ -105,7 +105,7 @@ export const POST: RequestHandler = async ({ request }) => {
 
 	let spawned;
 	try {
-		spawned = await spawnAssertEvalRun(written);
+		spawned = await spawnAssertAiRun(written);
 	} catch (err) {
 		const message = err instanceof SpawnError ? err.message : (err as Error).message ?? String(err);
 		return json(


### PR DESCRIPTION
Small follow-up to PRs #177 and #182.

Yeming flagged on PR #182 that the viewer TypeScript function names `spawnAssertEvalRun` and `resolveAssertEvalCommand` still carried the old prefix even after the env-var values were updated. This PR finishes the rename:

- `spawnAssertEvalRun` -> `spawnAssertAiRun`
- `resolveAssertEvalCommand` -> `resolveAssertAiCommand`
- Updated the one external import site (`viewer/src/routes/api/runs/+server.ts`) and the module-header JSDoc reference.

Pure rename. No behavior change. `npm run check` clean: 3 errors / 6 warnings, identical to the pre-rename baseline (the same 3 pre-existing errors documented in PR #180). Zero new errors.