### PR TITLE
docs: clean-slate the public-facing surface — drop private-preview migration callouts

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -16,7 +16,7 @@ body:
     attributes:
       label: What happened?
       description: A clear and concise description of the bug.
-      placeholder: When I run `assert-eval run ...`, the CLI crashes with ...
+      placeholder: When I run `assert-ai run ...`, the CLI crashes with ...
     validations:
       required: true
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@
 
 ## Testing
 
-<!-- How did you verify? E.g., `pytest`, `npm run check`, manual viewer testing, `assert-eval run --config ...`. -->
+<!-- How did you verify? E.g., `pytest`, `npm run check`, manual viewer testing, `assert-ai run --config ...`. -->
 
 ## Checklist
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,30 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- **BREAKING:** Python package renamed `assert_eval` → `assert_ai`. CLI entrypoint
-  is now `assert-ai` (previously `assert-eval`). Update your imports and shell
-  commands.
-- **BREAKING:** Environment variables renamed `ASSERT_EVAL_*` → `ASSERT_AI_*`.
-  The pre-rename `P2M_*` aliases are also removed. Update your `.env` files,
-  CI secrets, and shell profiles. The viewer and runtime read only the
-  `ASSERT_AI_*` names.
-- Internal prompt templates moved from `internal-pipeline-prompts/` to
-  `assert_ai/internal_pipeline_prompts/` so the package is wheel-importable
-  via `importlib.resources`. No user-visible API change unless you were
-  reading these files directly.
-
-### Migration
-
-1. Replace `import assert_eval` with `import assert_ai`. Replace
-   `assert-eval` CLI invocations with `assert-ai`.
-2. Rename env vars: e.g., `ASSERT_EVAL_RUNS_ROOT=...` → `ASSERT_AI_RUNS_ROOT=...`.
-3. Reinstall: `pip install -e ".[otel]"` (or your usual extras).
-
 ### Added
 
-- PEP 517 wheel-build CI matrix on Linux/macOS/Windows × Python 3.10/3.11/3.12
-  to verify package importability across platforms.
+### Changed
+
+### Fixed
 
 [Unreleased]: https://github.com/responsibleai/ASSERT/commits/main

--- a/README.md
+++ b/README.md
@@ -27,13 +27,6 @@
         <img src="assets/assert-ai-framework-diagram.png" alt="Diagram of the ASSERT evaluation framework" width="100%">
 </p>
 
-> [!IMPORTANT]
-> **Migration note (May 2026):** The Python package was renamed `assert_eval` → `assert_ai`,
-> the CLI was renamed `assert-eval` → `assert-ai`, and environment variables were renamed
-> `ASSERT_EVAL_*` → `ASSERT_AI_*` (the pre-rename `P2M_*` aliases are also gone). If you
-> installed an earlier preview, update your imports, CLI invocations, and `.env` files. See
-> [CHANGELOG.md](./CHANGELOG.md) for details.
-
 ## Why ASSERT?
 
 Most AI systems start with a specification: product requirements, policies, system prompts, or launch criteria describing what the system should and should not do.
@@ -51,6 +44,7 @@ From the natural language specification, the ASSERT pipeline derives behavior ca
 - **Test any agent or multi-agent system** via integrations with [OpenInference](https://github.com/Arize-ai/openinference/). Evaluate a LangGraph agent, a CrewAI / OpenAI Agents SDK / DSPy / LlamaIndex / AutoGen system, custom multi-agent orchestration, a Python callable, or a hosted model — without rewriting the evaluation orchestration pipeline.
 - **Agent trace-grounded judgment** - the recommended integration captures OpenTelemetry spans (Phoenix/OpenInference auto-instruments 33+ frameworks in two lines, or you can emit your own with the OTel SDK) so the judge can cite tool calls, routing, model calls, and latency as evidence — not just the final response.
 - **Portable artifacts** - every stage writes JSON/JSONL files locally for inspection, CI, and sharing.
+- **Bundled local viewer** - browse runs side-by-side, pin a baseline, drill into per-behavior dimension breakdowns, and read judge justifications cited against the captured traces.
 
 ## Get started
 


### PR DESCRIPTION
Follow-up to PR #185.

Public docs should read like a clean v1 launch, not a project mid-migration. The private-preview-era transitions (`assert_eval` -> `assert_ai`, `ASSERT_EVAL_*` -> `ASSERT_AI_*`, prompts directory move) are noise in public docs — there were no public releases to break. Existing private-preview users will be notified out-of-band.

**Removed**
- `README.md` `[!IMPORTANT]` migration callout (from #185)
- `CHANGELOG.md` BREAKING-change history of the renames

**Replaced**
- `CHANGELOG.md` rewritten to empty `[Unreleased]` scaffold (Keep a Changelog 1.1.0), ready to populate when v0.1 ships
- README capability bullets gained a `Bundled local viewer` line for the side-by-side / baseline / dimension-breakdown UI

**Swept**
- `.github/ISSUE_TEMPLATE/bug_report.yml` and `.github/PULL_REQUEST_TEMPLATE.md`: stale `assert-eval` placeholders updated to `assert-ai` so contributor-facing examples match the current CLI
- Verified `docs/`, `examples/`, `AGENTS.md`, `CONTRIBUTING.md`, `viewer/README.md`, `scripts/` for residual `previously called` / `renamed from` / migration-note language — none remained after the above edits
- `examples/azure_doc_qa/**` contains `migration runbook` strings as **fixture data** for boundary-violation eval (the example agent is tested on NOT leaking internal migration docs) — left untouched, this is product data, not a customer-facing migration note
- `.github/PULL_REQUEST_TEMPLATE.md` line `- [ ] No breaking change, or a CHANGELOG.md entry is included.` is forward-looking contributor guidance — left untouched

No code change.