### PR TITLE
fix(tests): make test_runtime_safety subprocess inherit parent sys.path after assert_ai rename

### DIFF
--- a/tests/test_runtime_safety.py
+++ b/tests/test_runtime_safety.py
@@ -186,6 +186,7 @@ def test_run_stage_coro_does_not_block_subprocess_exit_when_worker_leaked(
     If the dual-detach is correct, the subprocess exits within the
     timeout. If not, ``subprocess.run`` raises ``TimeoutExpired``.
     """
+    import os
     import subprocess
     import sys
     import textwrap
@@ -218,12 +219,27 @@ def test_run_stage_coro_does_not_block_subprocess_exit_when_worker_leaked(
     script_path = tmp_path / "leaked_worker_subprocess_probe.py"
     script_path.write_text(script, encoding="utf-8")
 
+    # Propagate the parent interpreter's import paths to the subprocess.
+    # pytest's rootdir hook puts the repo root on sys.path of the test
+    # runner, but a fresh `sys.executable` subprocess only sees its own
+    # site-packages — so without ``pip install -e .``, ``import assert_ai``
+    # would ModuleNotFoundError even though sys.executable is correct.
+    # Merging sys.path into PYTHONPATH makes the test pass regardless of
+    # whether the package is editable-installed or discovered via pytest.
+    env = os.environ.copy()
+    extra_paths = [p for p in sys.path if p]
+    existing = env.get("PYTHONPATH", "")
+    if existing:
+        extra_paths.append(existing)
+    env["PYTHONPATH"] = os.pathsep.join(extra_paths)
+
     try:
         proc = subprocess.run(
             [sys.executable, str(script_path)],
             capture_output=True,
             text=True,
             timeout=15.0,
+            env=env,
         )
     except subprocess.TimeoutExpired as exc:
         stdout = exc.stdout if isinstance(exc.stdout, str) else (


### PR DESCRIPTION
Fixes a pre-existing failure in `tests/test_runtime_safety.py::test_run_stage_coro_does_not_block_subprocess_exit_when_worker_leaked` that triggers whenever the harness is run without first installing the package into the active interpreter.

## Root cause

The test spawns a fresh `sys.executable` subprocess to verify that interpreter shutdown does not block on a leaked worker thread. The subprocess script does `from assert_ai.core.runtime_safety import run_stage_coro`.

That import used to succeed in dev environments because pytest's rootdir hook puts the repo root on `sys.path` of the test runner — but a child interpreter started via `subprocess.run([sys.executable, ...])` does **not** inherit `sys.path`; it only sees its own `site-packages`. CI's `pip install -e ".[dev,otel]"` step masks this because it installs `assert_ai` into site-packages, but anyone running `pytest tests/` in a venv that hasn't been editable-installed (or had its install go stale across the `assert_eval` → `assert_ai` rename in #177) hits:

```
ModuleNotFoundError: No module named 'assert_ai'
```

…and the test fails before it can even exercise the leaked-worker shutdown path it's actually trying to cover.

## Fix

Build a `PYTHONPATH` from the parent interpreter's `sys.path` and pass it to `subprocess.run` via `env=`. This makes the test pass whether `assert_ai` is editable-installed in the active venv or only discovered through pytest's rootdir mechanism.

## Diff

+16 LOC in 1 file (`tests/test_runtime_safety.py`). No production code touched. No new dependencies. No skip / xfail markers.

## Verification

- Failing test now passes locally with `assert_ai` uninstalled from the venv (dev-without-install scenario, which is the bug)
- Failing test also passes with `assert_ai` editable-installed (CI scenario)
- Full `tests/test_runtime_safety.py` suite: 14/14 green
- Broader `pytest tests/ -q` smoke: 952 passed, 14 skipped, no regressions