### PR TITLE
ci: add release-triggered PyPI publish workflow (OIDC, reviewer-gated)

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,103 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Publish target'
+        type: choice
+        options: [testpypi, pypi]
+        default: testpypi
+      ref:
+        description: 'Git ref to publish (defaults to HEAD)'
+        type: string
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.ref || github.sha }}
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: python -m pip install --upgrade build twine
+      - run: python -m build
+      - run: python -m twine check --strict dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          retention-days: 30
+          if-no-files-found: error
+
+  attach-release-assets:
+    name: Attach wheel + sdist to release
+    needs: build
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    needs: build
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi')
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/assert-ai/
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: [build, publish-testpypi]
+    if: |
+      always() &&
+      needs.build.result == 'success' &&
+      (needs.publish-testpypi.result == 'success' || needs.publish-testpypi.result == 'skipped') &&
+      (
+        (github.event_name == 'release' && github.event.release.prerelease == false) ||
+        (github.event_name == 'workflow_dispatch' && inputs.target == 'pypi')
+      )
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/assert-ai/
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary

Adds `.github/workflows/publish-pypi.yml` — a release-triggered workflow that publishes `assert-ai` to TestPyPI and PyPI via PyPA [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC).

## Triggers

- `release: published` — primary path
- `workflow_dispatch` with a `target` choice (`testpypi` / `pypi`) for manual re-publish or retry

## Jobs

1. **build** — checks out the release tag, builds wheel + sdist, runs `twine check --strict`, uploads `dist/` as an artifact.
2. **attach-release-assets** — attaches the wheel + sdist to the GitHub Release as downloadable assets.
3. **publish-testpypi** — uses the `testpypi` environment. Runs on every release event (and on dispatch when `target=testpypi`). `skip-existing: true` so re-runs of the same version are no-ops.
4. **publish-pypi** — uses the `pypi` environment with a required reviewer. Runs only on non-prerelease releases (and on dispatch when `target=pypi`). The `prerelease == false` guard means an `rc` release uploads to TestPyPI only.

## Auth

Trusted Publishing only — no PyPI tokens, no secrets in this repo.

To activate, a maintainer needs to register the following pending publishers on pypi.org and test.pypi.org:

| Field        | pypi.org           | test.pypi.org      |
| ------------ | ------------------ | ------------------ |
| PyPI project | `assert-ai`        | `assert-ai`        |
| Owner        | `responsibleai`    | `responsibleai`    |
| Repository   | `ASSERT`           | `ASSERT`           |
| Workflow     | `publish-pypi.yml` | `publish-pypi.yml` |
| Environment  | `pypi`             | `testpypi`         |

And create matching GitHub environments under repo Settings → Environments:

- `testpypi` — no protection rules
- `pypi` — required reviewer (e.g. release manager)

## Safety

This workflow is **inert when merged**:

1. It only fires on a published GitHub Release, and no Release exists yet.
2. PyPI Trusted Publishing requires the pending publisher to be registered — until then the upload step fails closed.
3. The `pypi` environment requires reviewer approval before the upload step runs.

All three gates must be in place for a real publish to happen.

## Companion

Builds on top of the wheel build hardening from #182, which already exercises `python -m build` + `twine check` on every PR.
