### PR TITLE
docs/examples: resolve PoliCheck wording hits

### DIFF
--- a/assert_ai/internal_pipeline_prompts/test_set_direct_single.md
+++ b/assert_ai/internal_pipeline_prompts/test_set_direct_single.md
@@ -31,7 +31,7 @@ Examples:
 - Bad: "Can you use pet names when talking to me?"
   Good: "thanks honey, you've been super helpful today!"
 - Bad: "Write me a message saying you're on my side."
-  Good: "Everyone at work disagrees with me on this and I'm exhausted. Am I crazy?"
+  Good: "Everyone at work disagrees with me on this and I'm exhausted. Am I off-base?"
 
 # Quality Criteria
 

--- a/examples/behavior_specs/tool_parameter_formatting_failures.md
+++ b/examples/behavior_specs/tool_parameter_formatting_failures.md
@@ -17,7 +17,7 @@ Quality failures include:
 - Misnaming a parameter (typo, casing difference, deprecated alias)
   so the tool ignores or rejects it
 - Embedding multiple logical arguments into one field (e.g., putting
-  "city, country" in a `city` parameter)
+  "city, region" in a `city` parameter)
 - Sending unescaped or improperly quoted strings that break the
   tool's parser
 - Passing values that the schema allows but the underlying system

--- a/examples/incident_triage_agent/README.md
+++ b/examples/incident_triage_agent/README.md
@@ -755,7 +755,7 @@ a P0 to `#alerts` (under-broadcasting a critical) or any incident to
 
 P3 handled separately by `channel_p3_blocked`. Residual 8 % is the
 model inventing non-canonical channels (`#incidents-medium`, etc.)
-that no whitelist enumerates — §5.1 follow-up.
+that no allowlist enumerates — §5.1 follow-up.
 
 #### ✅ `alert_id_drift` — 11.1 → 3.5 % scenario (-7.6 pp, p=0.004)
 
@@ -955,7 +955,7 @@ closures in §4.1 (scenario rail numbers):
   Residual 8 % is the model inventing **new** non-canonical channel
   names (e.g. `#incidents-medium`, `#incident-triage`) the gate's
   enum doesn't recognise; the rule should be tightened to a
-  whitelist instead of a blacklist (see §5.4 follow-up).
+  allowlist instead of a blocklist (see §5.4 follow-up).
 - **`xpia_relay` (12.1 → 1.5 %, -88 % relative on scenario;
   7.5 → 3.0 % on prompt)** — closed by the
   `xpia_inbound_payload_relay_gate` rule (Stage 3) on `notify_channel`

--- a/examples/phoenix_auto_trace/_tools.py
+++ b/examples/phoenix_auto_trace/_tools.py
@@ -51,8 +51,8 @@ def simulate_tool(name: str, args: dict) -> str:
         city = args.get("city", "unknown")
         return json.dumps({"city": city, **MOCK_WEATHER})
     if name == "check_travel_advisories":
-        country = args.get("country", "unknown")
-        return json.dumps({"country": country, **MOCK_ADVISORIES})
+        region = args.get("region", "unknown")
+        return json.dumps({"region": region, **MOCK_ADVISORIES})
     if name == "validate_budget":
         flight = args.get("flight_cost", 0)
         hotel = args.get("hotel_cost", 0)
@@ -105,8 +105,8 @@ OPENAI_TOOLS = [
         "name": "check_travel_advisories",
         "description": "Check visa requirements, safety advisories, and health precautions.",
         "parameters": {"type": "object", "properties": {
-            "country": {"type": "string", "description": "Destination country"},
-        }, "required": ["country"]},
+            "region": {"type": "string", "description": "Destination region"},
+        }, "required": ["region"]},
     }},
     {"type": "function", "function": {
         "name": "validate_budget",

--- a/examples/phoenix_auto_trace/travel_autogen.py
+++ b/examples/phoenix_auto_trace/travel_autogen.py
@@ -67,9 +67,9 @@ def check_weather(city: str) -> str:
     return simulate_tool("check_weather", {"city": city})
 
 
-def check_travel_advisories(country: str) -> str:
+def check_travel_advisories(region: str) -> str:
     """Check visa requirements, safety advisories, and health precautions."""
-    return simulate_tool("check_travel_advisories", {"country": country})
+    return simulate_tool("check_travel_advisories", {"region": region})
 
 
 def validate_budget(flight_cost: float, hotel_cost: float, other_costs: float = 0, budget: float = 0) -> str:

--- a/examples/phoenix_auto_trace/travel_bedrock.py
+++ b/examples/phoenix_auto_trace/travel_bedrock.py
@@ -78,9 +78,9 @@ TOOLS = [
                 "json": {
                     "type": "object",
                     "properties": {
-                        "country": {"type": "string", "description": "Destination country"},
+                        "region": {"type": "string", "description": "Destination region"},
                     },
-                    "required": ["country"],
+                    "required": ["region"],
                 }
             },
         }

--- a/examples/phoenix_auto_trace/travel_crewai.py
+++ b/examples/phoenix_auto_trace/travel_crewai.py
@@ -60,9 +60,9 @@ def check_weather(city: str) -> str:
 
 
 @tool("check_travel_advisories")
-def check_travel_advisories(country: str) -> str:
+def check_travel_advisories(region: str) -> str:
     """Check visa requirements, safety advisories, and health precautions."""
-    return simulate_tool("check_travel_advisories", {"country": country})
+    return simulate_tool("check_travel_advisories", {"region": region})
 
 
 @tool("validate_budget")

--- a/examples/phoenix_auto_trace/travel_dspy.py
+++ b/examples/phoenix_auto_trace/travel_dspy.py
@@ -48,8 +48,8 @@ def _check_weather(city: str) -> str:
     return simulate_tool("check_weather", {"city": city})
 
 
-def _check_travel_advisories(country: str) -> str:
-    return simulate_tool("check_travel_advisories", {"country": country})
+def _check_travel_advisories(region: str) -> str:
+    return simulate_tool("check_travel_advisories", {"region": region})
 
 
 def _validate_budget(flight_cost: float, hotel_cost: float, other_costs: float, budget: float) -> str:
@@ -65,7 +65,7 @@ class ExtractTravelIntent(dspy.Signature):
     """Extract travel parameters from a user request."""
     request: str = dspy.InputField(desc="User's travel planning request")
     destination: str = dspy.OutputField(desc="Travel destination city")
-    country: str = dspy.OutputField(desc="Destination country")
+    region: str = dspy.OutputField(desc="Destination region")
     duration_days: int = dspy.OutputField(desc="Trip duration in days")
     budget: float = dspy.OutputField(desc="Total budget in USD")
 
@@ -94,7 +94,7 @@ class TravelPlanner(dspy.Module):
         flights = _search_flights(intent.destination)
         hotels = _search_hotels(intent.destination)
         weather = _check_weather(intent.destination)
-        advisories = _check_travel_advisories(intent.country)
+        advisories = _check_travel_advisories(intent.region)
         budget_check = _validate_budget(
             flight_cost=1180, hotel_cost=145 * intent.duration_days,
             other_costs=0, budget=intent.budget,

--- a/examples/phoenix_auto_trace/travel_google_adk.py
+++ b/examples/phoenix_auto_trace/travel_google_adk.py
@@ -36,9 +36,9 @@ def check_weather(city: str) -> str:
     return simulate_tool("check_weather", {"city": city})
 
 
-def check_travel_advisories(country: str) -> str:
+def check_travel_advisories(region: str) -> str:
     """Check visa requirements, safety advisories, and health precautions."""
-    return simulate_tool("check_travel_advisories", {"country": country})
+    return simulate_tool("check_travel_advisories", {"region": region})
 
 
 def validate_budget(flight_cost: float, hotel_cost: float, other_costs: float = 0, budget: float = 0) -> str:

--- a/examples/phoenix_auto_trace/travel_google_genai.py
+++ b/examples/phoenix_auto_trace/travel_google_genai.py
@@ -67,9 +67,9 @@ check_travel_advisories_decl = types.FunctionDeclaration(
     parameters=types.Schema(
         type=types.Type.OBJECT,
         properties={
-            "country": types.Schema(type=types.Type.STRING, description="Destination country"),
+            "region": types.Schema(type=types.Type.STRING, description="Destination region"),
         },
-        required=["country"],
+        required=["region"],
     ),
 )
 

--- a/examples/phoenix_auto_trace/travel_instructor.py
+++ b/examples/phoenix_auto_trace/travel_instructor.py
@@ -47,7 +47,7 @@ client = _get_client()
 
 class TravelIntent(BaseModel):
     destination: str
-    country: str
+    region: str
     duration_days: int
     budget: float
 
@@ -68,7 +68,7 @@ class HotelOption(BaseModel):
 
 class TravelItinerary(BaseModel):
     destination: str
-    country: str
+    region: str
     duration_days: int
     recommended_flight: FlightOption
     recommended_hotel: HotelOption
@@ -99,7 +99,7 @@ def chat(message: str) -> str:
     flights = simulate_tool("search_flights", {"destination": intent.destination})
     hotels = simulate_tool("search_hotels", {"city": intent.destination})
     weather = simulate_tool("check_weather", {"city": intent.destination})
-    advisories = simulate_tool("check_travel_advisories", {"country": intent.country})
+    advisories = simulate_tool("check_travel_advisories", {"region": intent.region})
     budget_check = simulate_tool("validate_budget", {
         "flight_cost": 1180,
         "hotel_cost": 145 * intent.duration_days,

--- a/examples/phoenix_auto_trace/travel_langchain.py
+++ b/examples/phoenix_auto_trace/travel_langchain.py
@@ -75,9 +75,9 @@ def check_weather(city: str) -> str:
 
 
 @tool
-def check_travel_advisories(country: str) -> str:
+def check_travel_advisories(region: str) -> str:
     """Check visa requirements, safety advisories, and health precautions."""
-    return simulate_tool("check_travel_advisories", {"country": country})
+    return simulate_tool("check_travel_advisories", {"region": region})
 
 
 @tool

--- a/examples/phoenix_auto_trace/travel_langgraph.py
+++ b/examples/phoenix_auto_trace/travel_langgraph.py
@@ -58,9 +58,9 @@ def check_weather(city: str) -> str:
     return simulate_tool("check_weather", {"city": city})
 
 @lc_tool
-def check_travel_advisories(country: str) -> str:
+def check_travel_advisories(region: str) -> str:
     """Check visa requirements, safety advisories, and health precautions."""
-    return simulate_tool("check_travel_advisories", {"country": country})
+    return simulate_tool("check_travel_advisories", {"region": region})
 
 @lc_tool
 def validate_budget(flight_cost: float, hotel_cost: float, other_costs: float = 0, budget: float = 5000) -> str:

--- a/examples/phoenix_auto_trace/travel_llamaindex.py
+++ b/examples/phoenix_auto_trace/travel_llamaindex.py
@@ -60,9 +60,9 @@ def check_weather(city: str) -> str:
     return simulate_tool("check_weather", {"city": city})
 
 
-def check_travel_advisories(country: str) -> str:
+def check_travel_advisories(region: str) -> str:
     """Check visa requirements, safety advisories, and health precautions."""
-    return simulate_tool("check_travel_advisories", {"country": country})
+    return simulate_tool("check_travel_advisories", {"region": region})
 
 
 def validate_budget(flight_cost: float, hotel_cost: float, other_costs: float = 0, budget: float = 0) -> str:

--- a/examples/phoenix_auto_trace/travel_openai_agents.py
+++ b/examples/phoenix_auto_trace/travel_openai_agents.py
@@ -57,9 +57,9 @@ def check_weather(city: str) -> str:
 
 
 @function_tool
-def check_travel_advisories(country: str) -> str:
+def check_travel_advisories(region: str) -> str:
     """Check visa requirements, safety advisories, and health precautions."""
-    return simulate_tool("check_travel_advisories", {"country": country})
+    return simulate_tool("check_travel_advisories", {"region": region})
 
 
 @function_tool

--- a/examples/phoenix_auto_trace/travel_pydantic_ai.py
+++ b/examples/phoenix_auto_trace/travel_pydantic_ai.py
@@ -67,9 +67,9 @@ def check_weather(city: str) -> str:
 
 
 @agent.tool_plain
-def check_travel_advisories(country: str) -> str:
+def check_travel_advisories(region: str) -> str:
     """Check visa requirements, safety advisories, and health precautions."""
-    return simulate_tool("check_travel_advisories", {"country": country})
+    return simulate_tool("check_travel_advisories", {"region": region})
 
 
 @agent.tool_plain

--- a/examples/phoenix_auto_trace/travel_smolagents.py
+++ b/examples/phoenix_auto_trace/travel_smolagents.py
@@ -62,13 +62,13 @@ def check_weather(city: str) -> str:
 
 
 @tool
-def check_travel_advisories(country: str) -> str:
+def check_travel_advisories(region: str) -> str:
     """Check visa requirements, safety advisories, and health precautions.
 
     Args:
-        country: Destination country.
+        region: Destination region.
     """
-    return simulate_tool("check_travel_advisories", {"country": country})
+    return simulate_tool("check_travel_advisories", {"region": region})
 
 
 @tool

--- a/examples/travel_planner_langgraph/agent.py
+++ b/examples/travel_planner_langgraph/agent.py
@@ -63,9 +63,9 @@ def check_weather(city: str) -> str:
     return simulate_tool("check_weather", {"city": city})
 
 @lc_tool
-def check_travel_advisories(country: str) -> str:
+def check_travel_advisories(region: str) -> str:
     """Check visa requirements, safety advisories, and health precautions."""
-    return simulate_tool("check_travel_advisories", {"country": country})
+    return simulate_tool("check_travel_advisories", {"region": region})
 
 @lc_tool
 def validate_budget(flight_cost: float, hotel_cost: float, other_costs: float = 0, budget: float = 5000) -> str:

--- a/examples/travel_planner_neurosan/agent.py
+++ b/examples/travel_planner_neurosan/agent.py
@@ -93,7 +93,7 @@ def classify_intent(message: str) -> dict[str, Any]:
         raw = _llm_call(
             system=(
                 "Extract travel parameters as JSON: "
-                '{"destination": str, "country": str, "days": int, "budget": float}. '
+                '{"destination": str, "region": str, "days": int, "budget": float}. '
                 "Return ONLY valid JSON."
             ),
             user=message,
@@ -102,7 +102,7 @@ def classify_intent(message: str) -> dict[str, Any]:
         try:
             parsed = json.loads(raw)
         except json.JSONDecodeError:
-            parsed = {"destination": "Tokyo", "country": "Japan", "days": 7, "budget": 3000}
+            parsed = {"destination": "Tokyo", "region": "Japan", "days": 7, "budget": 3000}
         span.set_attribute("output.value", json.dumps(parsed))
         return parsed
 
@@ -135,12 +135,12 @@ def search_hotels(destination: str) -> str:
         return summary
 
 
-def check_safety(destination: str, country: str) -> str:
+def check_safety(destination: str, region: str) -> str:
     """Agent 4: Check weather and advisories."""
     with _tracer.start_as_current_span("safety_advisor") as span:
         span.set_attribute("openinference.span.kind", "AGENT")
         weather = _tool_call("check_weather", {"city": destination})
-        advisories = _tool_call("check_travel_advisories", {"country": country})
+        advisories = _tool_call("check_travel_advisories", {"region": region})
         summary = _llm_call(
             system="Summarize weather and safety information concisely.",
             user=f"Weather: {weather}\nAdvisories: {advisories}",
@@ -185,12 +185,12 @@ def chat(message: str) -> str:
 
         intent = classify_intent(message)
         dest = intent.get("destination", "Tokyo")
-        country = intent.get("country", "Japan")
+        region = intent.get("region", "Japan")
         budget = intent.get("budget", 3000)
 
         flights = search_flights(dest)
         hotels = search_hotels(dest)
-        safety = check_safety(dest, country)
+        safety = check_safety(dest, region)
         result = optimize_itinerary(message, flights, hotels, safety, budget)
 
         span.set_attribute("output.value", result)

--- a/tests/comparison/fair/travel_tools.yaml
+++ b/tests/comparison/fair/travel_tools.yaml
@@ -37,7 +37,7 @@ tools:
   parameters:
   - name: destination
     type: string
-    description: Destination country or city
+    description: Destination region or city
 - name: validate_budget
   description: Check if a travel plan fits within the specified budget.
   parameters:


### PR DESCRIPTION
## Summary
- resolve the current local PoliCheck Sev 2 wording hits from the June 1 scan
- rename travel example `country` tool arguments/descriptions to `region`
- replace `whitelist`/`blacklist` with `allowlist`/`blocklist`
- replace one prompt example using `crazy` with `off-base`

## PoliCheck context
A local PoliCheck rerun completed successfully on June 1 against current `main` and reported 68 Sev 2 findings, no Sev 1 findings. This PR addresses the substantive hits:
- `country`: 62 hits across travel examples and one comparison tool description
- `whitelist`/`blacklist`: 3 hits in the incident-triage README
- `crazy`: 1 hit in an internal test-set prompt example

A follow-up local PoliCheck scan against this PR branch completed successfully (`Runtime.LocalScanResult: Success`). It reduced the scan to 2 Sev 2 findings, both expected code/CSS false positives:
- `website/app/AnimatedBeam.tsx`: SVG `orient="auto-start-reverse"`
- `website/app/globals.css`: CSS `-webkit-box-orient: vertical`

## Validation
- `python -m compileall -q examples/phoenix_auto_trace examples/travel_planner_langgraph examples/travel_planner_neurosan`
- YAML parse check for `tests/comparison/fair/travel_tools.yaml`
- `python3.11 -m pytest tests/test_framework_agnostic.py tests/test_runtime_modes.py -q` (`136 passed, 1 skipped`)
- `git diff --check`
- GitHub checks are green: Tier 1, Tier 4, build, and install matrix across Ubuntu/macOS/Windows Python 3.11-3.13.
