### PR TITLE
Port mock viewer UI for demo

### DIFF
--- a/viewer/src/lib/PrimerPagination.svelte
+++ b/viewer/src/lib/PrimerPagination.svelte
@@ -47,7 +47,6 @@
 			type="button"
 			class="previous_page"
 			aria-label="Previous page"
-			rel="previous"
 			disabled={page <= 1}
 			onclick={() => go(page - 1)}
 		>Previous</button>
@@ -66,7 +65,6 @@
 			type="button"
 			class="next_page"
 			aria-label="Next page"
-			rel="next"
 			disabled={page >= totalPages}
 			onclick={() => go(page + 1)}
 		>Next</button>

--- a/viewer/src/lib/RateForestPlot.svelte
+++ b/viewer/src/lib/RateForestPlot.svelte
@@ -1,0 +1,210 @@
+<script lang="ts">
+	import type { OutcomePlotRow } from './outcome-plot.js';
+
+	let {
+		rows,
+		denominatorLabel
+	}: {
+		rows: OutcomePlotRow[];
+		denominatorLabel: string;
+	} = $props();
+
+	type RowGroup = { dimension: string; rows: OutcomePlotRow[] };
+
+	const groups = $derived.by<RowGroup[]>(() => {
+		const grouped = new Map<string, OutcomePlotRow[]>();
+		for (const row of rows) {
+			if (!grouped.has(row.dimension)) grouped.set(row.dimension, []);
+			grouped.get(row.dimension)!.push(row);
+		}
+		return [...grouped.entries()].map(([dimension, groupRows]) => ({ dimension, rows: groupRows }));
+	});
+
+	const hasData = $derived(rows.some((row) => row.n > 0));
+	const groupKey = $derived(groups.map((group) => group.dimension).join('\0'));
+	let expandedDimensions = $state<Record<string, boolean>>({ Overall: true });
+
+	$effect(() => {
+		groupKey;
+		expandedDimensions = { Overall: true };
+	});
+
+	function pct(value: number): string {
+		return `${Math.round(value * 100)}%`;
+	}
+
+	function ciText(row: OutcomePlotRow): string {
+		if (row.n === 0) return '-';
+		return `${pct(row.rate)} [${pct(row.ciLow)}, ${pct(row.ciHigh)}]`;
+	}
+
+	function countText(row: OutcomePlotRow): string {
+		return `${row.flagged} flagged / ${row.n} ${denominatorLabel}`;
+	}
+
+	function rateColor(rate: number): string {
+		if (rate >= 0.5) return 'var(--theme-score-fail)';
+		if (rate > 0) return 'var(--theme-score-border)';
+		return 'var(--theme-score-pass)';
+	}
+
+	function isGroupExpanded(dimension: string): boolean {
+		return dimension === 'Overall' || expandedDimensions[dimension] === true;
+	}
+
+	function toggleGroup(dimension: string) {
+		if (dimension === 'Overall') return;
+		expandedDimensions = { ...expandedDimensions, [dimension]: !expandedDimensions[dimension] };
+	}
+</script>
+
+{#if hasData}
+	<div class="rounded-lg border border-border bg-surface">
+		<div class="hidden overflow-x-auto sm:block">
+			<div class="min-w-[42rem]">
+				<div class="grid grid-cols-[minmax(8rem,14rem)_minmax(12rem,1fr)_9rem] gap-3 border-b border-border bg-surface-2/45 px-4 py-2 text-[10px] font-semibold uppercase tracking-wider text-text-muted">
+					<div>Variation level</div>
+					<div>Rate</div>
+					<div class="text-right">Rate (95% CI)</div>
+				</div>
+				<div class="divide-y divide-border/50">
+					{#each groups as group (group.dimension)}
+						<div class="plot-group">
+							{#if group.dimension === 'Overall'}
+								<div class="bg-bg/30 px-4 py-1.5 font-mono text-[10px] uppercase tracking-wider text-text-muted">
+									{group.dimension}
+								</div>
+							{:else}
+								<button
+									class="flex w-full items-center gap-2 bg-bg/30 px-4 py-1.5 text-left font-mono text-[10px] uppercase tracking-wider text-text-muted transition-colors hover:bg-bg/50 hover:text-text-secondary"
+									aria-expanded={isGroupExpanded(group.dimension)}
+									onclick={() => toggleGroup(group.dimension)}
+								>
+									<svg class="h-3 w-3 shrink-0 transition-transform {isGroupExpanded(group.dimension) ? 'rotate-90' : ''}" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+										<path d="M9 5l7 7-7 7" />
+									</svg>
+									<span>{group.dimension}</span>
+									<span class="ml-auto normal-case tracking-normal text-text-muted/70">{group.rows.length} levels</span>
+								</button>
+							{/if}
+							{#if isGroupExpanded(group.dimension)}
+								{#each group.rows as row (group.dimension + ':' + row.level)}
+									<div class="grid grid-cols-[minmax(8rem,14rem)_minmax(12rem,1fr)_9rem] items-center gap-3 px-4 py-2.5">
+										<div class="min-w-0">
+											<div class="truncate text-sm text-text-secondary" title={row.level}>{row.level}</div>
+											<div class="mt-0.5 font-mono text-[10px] text-text-muted">
+												{countText(row)}
+											</div>
+										</div>
+										<div class="relative h-7">
+											<div class="absolute left-0 right-0 top-1/2 h-px -translate-y-1/2 bg-border"></div>
+											{#each [0, 0.25, 0.5, 0.75, 1] as tick}
+												<div class="absolute top-1/2 h-3 w-px -translate-y-1/2 bg-border/70" style="left: {tick * 100}%"></div>
+											{/each}
+											{#if row.n > 0}
+												<div
+													class="absolute top-1/2 h-1.5 -translate-y-1/2 rounded-full opacity-40"
+													style="left: {row.ciLow * 100}%; width: {(row.ciHigh - row.ciLow) * 100}%; background: var(--theme-text-muted)"
+												></div>
+												<div
+													class="absolute top-1/2 size-3 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-surface shadow"
+													style="left: {row.rate * 100}%; background: {rateColor(row.rate)}"
+												></div>
+											{/if}
+										</div>
+										<div class="text-right font-mono text-[11px] tabular-nums text-text-secondary">
+											{ciText(row)}
+										</div>
+									</div>
+								{/each}
+							{/if}
+						</div>
+					{/each}
+				</div>
+				<div class="grid grid-cols-[minmax(8rem,14rem)_minmax(12rem,1fr)_9rem] gap-3 border-t border-border/60 px-4 py-1.5 font-mono text-[9px] text-text-muted">
+					<div></div>
+					<div class="relative h-4">
+						{#each [0, 0.25, 0.5, 0.75, 1] as tick}
+							<span class="absolute -translate-x-1/2" style="left: {tick * 100}%">{Math.round(tick * 100)}%</span>
+						{/each}
+					</div>
+					<div></div>
+				</div>
+			</div>
+		</div>
+
+		<div class="sm:hidden">
+			<div class="grid grid-cols-[minmax(0,1fr)_7.5rem] gap-3 border-b border-border bg-surface-2/45 px-4 py-2 text-[10px] font-semibold uppercase tracking-wider text-text-muted">
+				<div>Variation level</div>
+				<div class="text-right">Rate (95% CI)</div>
+			</div>
+			<div class="divide-y divide-border/50">
+				{#each groups as group (group.dimension)}
+					<div>
+						{#if group.dimension === 'Overall'}
+							<div class="bg-bg/30 px-4 py-1.5 font-mono text-[10px] uppercase tracking-wider text-text-muted">
+								{group.dimension}
+							</div>
+						{:else}
+							<button
+								class="flex w-full items-center gap-2 bg-bg/30 px-4 py-1.5 text-left font-mono text-[10px] uppercase tracking-wider text-text-muted transition-colors hover:bg-bg/50 hover:text-text-secondary"
+								aria-expanded={isGroupExpanded(group.dimension)}
+								onclick={() => toggleGroup(group.dimension)}
+							>
+								<svg class="h-3 w-3 shrink-0 transition-transform {isGroupExpanded(group.dimension) ? 'rotate-90' : ''}" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+									<path d="M9 5l7 7-7 7" />
+								</svg>
+								<span>{group.dimension}</span>
+								<span class="ml-auto normal-case tracking-normal text-text-muted/70">{group.rows.length} levels</span>
+							</button>
+						{/if}
+						{#if isGroupExpanded(group.dimension)}
+							{#each group.rows as row (group.dimension + ':' + row.level)}
+								<div class="px-4 py-3">
+									<div class="flex items-start justify-between gap-3">
+										<div class="min-w-0">
+											<div class="truncate text-sm text-text-secondary" title={row.level}>{row.level}</div>
+											<div class="mt-0.5 font-mono text-[10px] text-text-muted">
+												{countText(row)}
+											</div>
+										</div>
+										<div class="shrink-0 text-right font-mono text-[11px] tabular-nums text-text-secondary">
+											{ciText(row)}
+										</div>
+									</div>
+									<div class="relative mt-2 h-6">
+										<div class="absolute left-0 right-0 top-1/2 h-px -translate-y-1/2 bg-border"></div>
+										{#each [0, 0.25, 0.5, 0.75, 1] as tick}
+											<div class="absolute top-1/2 h-3 w-px -translate-y-1/2 bg-border/70" style="left: {tick * 100}%"></div>
+										{/each}
+										{#if row.n > 0}
+											<div
+												class="absolute top-1/2 h-1.5 -translate-y-1/2 rounded-full opacity-40"
+												style="left: {row.ciLow * 100}%; width: {(row.ciHigh - row.ciLow) * 100}%; background: var(--theme-text-muted)"
+											></div>
+											<div
+												class="absolute top-1/2 size-3 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-surface shadow"
+												style="left: {row.rate * 100}%; background: {rateColor(row.rate)}"
+											></div>
+										{/if}
+									</div>
+								</div>
+							{/each}
+						{/if}
+					</div>
+				{/each}
+			</div>
+			<div class="border-t border-border/60 px-4 py-1.5 font-mono text-[9px] text-text-muted">
+				<div class="relative h-4">
+					{#each [0, 0.25, 0.5, 0.75, 1] as tick}
+						<span class="absolute -translate-x-1/2" style="left: {tick * 100}%">{Math.round(tick * 100)}%</span>
+					{/each}
+				</div>
+			</div>
+		</div>
+	</div>
+{:else}
+	<div class="rounded-lg border border-dashed border-border bg-surface px-4 py-8 text-center text-sm text-text-muted">
+		No judged rows for this outcome.
+	</div>
+{/if}

--- a/viewer/src/lib/ResultDrawer.svelte
+++ b/viewer/src/lib/ResultDrawer.svelte
@@ -20,6 +20,7 @@
 		stopReasonLabel,
 		stopReasonTitle
 	} from '$lib/result-view.js';
+	import { judgeDimensionLabel } from '$lib/labels.js';
 	import {
 		buildTrajectoryGroups,
 		trajectoryGroupSummary,
@@ -160,7 +161,7 @@
 	}
 
 	function metricLabel(metric: string): string {
-		const spaced = metric.replace(/_/g, ' ');
+		const spaced = judgeDimensionLabel(metric);
 		return spaced.charAt(0).toUpperCase() + spaced.slice(1);
 	}
 
@@ -184,10 +185,10 @@
 
 	function judgmentWarningLabel(warning: string): string {
 		if (warning === 'policy_violation_without_violated_node') {
-			return 'top-level policy violation is flagged, but no behavior category is marked violated';
+			return 'top-level behavior violation is flagged, but no behavior category is marked violated';
 		}
 		if (warning === 'violated_node_without_policy_violation') {
-			return 'a behavior category is marked violated, but the top-level policy verdict is clear';
+			return 'a behavior category is marked violated, but the top-level behavior verdict is clear';
 		}
 		return warning.replace(/_/g, ' ');
 	}
@@ -1002,7 +1003,7 @@
 					<div class="rounded-lg border border-amber-500/20 bg-amber-500/5 p-4">
 						<div class="text-xs font-semibold uppercase tracking-wider text-amber-400">Judgment inconsistent</div>
 						<p class="mt-2 text-sm text-text-secondary leading-relaxed">
-							The judgment was kept, but parts of it disagree internally. Behavior-category findings and the top-level policy decision do not fully match for: {activeJudgmentWarningLabels.join('; ')}.
+							The judgment was kept, but parts of it disagree internally. Behavior-category findings and the top-level behavior decision do not fully match for: {activeJudgmentWarningLabels.join('; ')}.
 						</p>
 					</div>
 				{/if}

--- a/viewer/src/lib/ResultDrawer.svelte
+++ b/viewer/src/lib/ResultDrawer.svelte
@@ -12,6 +12,7 @@
 		getCitationDisplayRanges,
 		parseCitationReferences
 	} from '$lib/citation-resolution';
+	import { citationWarningLabel, isDegradedCitationWarning } from '$lib/citation-warnings';
 	import { renderMarkdown, renderMarkdownWithHighlights } from '$lib/markdown';
 	import { formatFactorLabel } from '$lib/grouping.js';
 	import {
@@ -19,6 +20,11 @@
 		stopReasonLabel,
 		stopReasonTitle
 	} from '$lib/result-view.js';
+	import {
+		buildTrajectoryGroups,
+		trajectoryGroupSummary,
+		trajectoryMessageLabel
+	} from '$lib/trajectory-view.js';
 	import type {
 		AuditCitation,
 		AuditCitationPart,
@@ -27,6 +33,7 @@
 		LlmCallTrace,
 		NodeJudgment,
 		SeedTool,
+		TrajectoryStep,
 		Verdict,
 		ViewerResultItem
 	} from '$lib/types.js';
@@ -74,11 +81,17 @@
 		payload?: string;
 	}
 
+	interface TrajectoryStepTone {
+		cardClass: string;
+		badgeClass: string;
+		label: string;
+	}
+
 	let highlightedTurn = $state<number | null>(null);
 	let highlightedMessageId = $state<string | null>(null);
 	let highlightedToolFocus = $state<ToolFocusState | null>(null);
 	let highlightResetHandle: ReturnType<typeof setTimeout> | null = null;
-	let activeJudgeIndex = $state(0);
+	let activeJudgeIndex = $state(-1);
 
 	$effect(() => {
 		const handler = (event: KeyboardEvent) => {
@@ -118,7 +131,7 @@
 		highlightedTurn = null;
 		highlightedMessageId = null;
 		highlightedToolFocus = null;
-		activeJudgeIndex = 0;
+		activeJudgeIndex = -1;
 		displayedCitations = null;
 		contextExpanded = false;
 		expandedMessageBodies = {};
@@ -171,10 +184,10 @@
 
 	function judgmentWarningLabel(warning: string): string {
 		if (warning === 'policy_violation_without_violated_node') {
-			return 'top-level policy violation is flagged, but no policy node is marked violated';
+			return 'top-level policy violation is flagged, but no behavior category is marked violated';
 		}
 		if (warning === 'violated_node_without_policy_violation') {
-			return 'a policy node is marked violated, but the top-level policy verdict is clear';
+			return 'a behavior category is marked violated, but the top-level policy verdict is clear';
 		}
 		return warning.replace(/_/g, ' ');
 	}
@@ -184,7 +197,78 @@
 		if (runtimeMode === 'tool_module') return 'tools';
 		if (runtimeMode === 'simulated') return 'simulated tools';
 		if (runtimeMode === 'external') return 'external tools';
-		return hasAgenticTranscript ? 'agentic transcript' : null;
+		return hasAgenticTranscript ? 'agentic' : null;
+	}
+
+	function trajectoryTypeLabel(type: string): string {
+		return type.replace(/_/g, ' ');
+	}
+
+	function trajectoryStepTone(step: TrajectoryStep): TrajectoryStepTone {
+		if (step.type === 'tool_call') {
+			return {
+				cardClass: 'border-blue-500/25 border-l-4 border-l-blue-400 bg-blue-500/5',
+				badgeClass: 'border-blue-400/30 bg-blue-500/15 text-blue-300',
+				label: 'CALL'
+			};
+		}
+		if (step.type === 'tool_result') {
+			return {
+				cardClass: 'border-emerald-500/25 border-l-4 border-l-emerald-400 bg-emerald-500/5',
+				badgeClass: 'border-emerald-400/30 bg-emerald-500/15 text-emerald-300',
+				label: 'RESULT'
+			};
+		}
+		if (step.type === 'llm_call') {
+			return {
+				cardClass: 'border-sky-500/25 border-l-4 border-l-sky-400 bg-sky-500/5',
+				badgeClass: 'border-sky-400/30 bg-sky-500/15 text-sky-300',
+				label: 'LLM'
+			};
+		}
+		if (step.type === 'error') {
+			return {
+				cardClass: 'border-score-fail/30 border-l-4 border-l-score-fail bg-score-fail/5',
+				badgeClass: 'border-score-fail/35 bg-score-fail/15 text-score-fail',
+				label: 'ERROR'
+			};
+		}
+		if (step.type === 'system') {
+			return {
+				cardClass: 'border-yellow-500/25 border-l-4 border-l-yellow-400 bg-yellow-500/5',
+				badgeClass: 'border-yellow-400/30 bg-yellow-500/15 text-yellow-300',
+				label: 'SYSTEM'
+			};
+		}
+		if (step.type === 'message') {
+			return {
+				cardClass: 'border-purple-500/20 border-l-4 border-l-purple-400 bg-purple-500/5',
+				badgeClass: 'border-purple-400/30 bg-purple-500/15 text-purple-300',
+				label: 'MSG'
+			};
+		}
+		return {
+			cardClass: 'border-border border-l-4 border-l-text-muted/50 bg-surface',
+			badgeClass: 'border-border bg-bg/60 text-text-muted',
+			label: trajectoryTypeLabel(step.type).toUpperCase()
+		};
+	}
+
+	function trajectoryStepTitle(step: TrajectoryStep): string {
+		const name = step.name || step.role || step.actor || step.type;
+		return `${trajectoryTypeLabel(step.type)} · ${name}`;
+	}
+
+	function trajectoryStepBody(step: TrajectoryStep): string | null {
+		if (typeof step.content === 'string' && step.content.trim()) return step.content;
+		if (step.result_preview) return step.result_preview;
+		if (step.result !== undefined && step.result !== null) {
+			return typeof step.result === 'string' ? step.result : JSON.stringify(step.result, null, 2);
+		}
+		if (step.args && Object.keys(step.args).length > 0) return JSON.stringify(step.args, null, 2);
+		const message = step.attributes?.message;
+		if (typeof message === 'string' && message.trim()) return message;
+		return null;
 	}
 
 	function isStructuredCitation(value: unknown): value is AuditCitation {
@@ -642,7 +726,7 @@
 		return relevantNodes.length > 0 ? relevantNodes : nodeJudgments;
 	}
 
-	function policyNodeName(node: NodeJudgment): string | null {
+	function behaviorCategoryName(node: NodeJudgment): string | null {
 		const embeddedName = typeof node.node_name === 'string' ? node.node_name.trim() : '';
 		return embeddedName || null;
 	}
@@ -667,9 +751,12 @@
 		runtimeModeLabel(item.target_runtime_mode, hasAgenticTranscript)
 	);
 	const structuredCitations = $derived(getStructuredCitations(item.verdict?.citations));
+	const aggregateVote = $derived(getVerdictFlag(item.verdict, primaryMetric));
 	const activeVerdict = $derived(
-		(item.multi_judge?.verdicts?.[activeJudgeIndex] as Verdict | null | undefined) ??
-			(item.verdict as Verdict | null | undefined)
+		activeJudgeIndex >= 0
+			? ((item.multi_judge?.verdicts?.[activeJudgeIndex] as Verdict | null | undefined) ??
+					(item.verdict as Verdict | null | undefined))
+			: (item.verdict as Verdict | null | undefined)
 	);
 	const activeVerdictCitations = $derived(
 		getActiveVerdictCitations(activeVerdict, structuredCitations)
@@ -678,6 +765,12 @@
 		Array.isArray(activeVerdict?.citation_warnings)
 			? activeVerdict.citation_warnings.filter((warning): warning is string => typeof warning === 'string' && warning.length > 0)
 			: []
+	);
+	const activeDegradedCitationWarnings = $derived(
+		activeCitationWarnings.filter(isDegradedCitationWarning)
+	);
+	const activeDegradedCitationWarningLabels = $derived(
+		activeDegradedCitationWarnings.map(citationWarningLabel)
 	);
 	const activeJudgmentWarnings = $derived(
 		Array.isArray(activeVerdict?.judgment_warnings)
@@ -702,6 +795,9 @@
 		Array.isArray(activeVerdict?.node_judgments)
 			? visibleNodeJudgments(activeVerdict.node_judgments as NodeJudgment[])
 			: []
+	);
+	const trajectoryGroups = $derived(
+		item.trajectory?.steps?.length ? buildTrajectoryGroups(item.trajectory.steps) : []
 	);
 	const firstMessageIdByTurn = $derived.by(() => {
 		const map = new Map<number, string>();
@@ -890,7 +986,7 @@
 					<div class="rounded-lg border border-border bg-surface p-4">
 						<div class="text-xs font-semibold uppercase tracking-wider text-text-muted">Unjudged preview</div>
 						<p class="mt-2 text-sm text-text-secondary leading-relaxed">
-							This conversation finished rollout and is available for inspection, but the judge has not scored it yet.
+							This result finished inference and is available for inspection, but the judge has not scored it yet.
 						</p>
 					</div>
 				{/if}
@@ -906,13 +1002,38 @@
 					<div class="rounded-lg border border-amber-500/20 bg-amber-500/5 p-4">
 						<div class="text-xs font-semibold uppercase tracking-wider text-amber-400">Judgment inconsistent</div>
 						<p class="mt-2 text-sm text-text-secondary leading-relaxed">
-							The judgment was kept, but parts of it disagree internally. Node-level policy findings and the top-level policy decision do not fully match for: {activeJudgmentWarningLabels.join('; ')}.
+							The judgment was kept, but parts of it disagree internally. Behavior-category findings and the top-level policy decision do not fully match for: {activeJudgmentWarningLabels.join('; ')}.
+						</p>
+					</div>
+				{/if}
+				{#if activeDegradedCitationWarnings.length > 0}
+					<div class="rounded-lg border border-sky-500/20 bg-sky-500/5 p-4">
+						<div class="text-xs font-semibold uppercase tracking-wider text-sky-400">Evidence degraded</div>
+						<p class="mt-2 text-sm text-text-secondary leading-relaxed">
+							The judgment was kept, but some cited evidence could not be grounded cleanly. Citation links or transcript highlights may be incomplete for: {activeDegradedCitationWarningLabels.join(', ')}.
 						</p>
 					</div>
 				{/if}
 				{#if hasPerJudgeInspection}
 					<div class="rounded-lg border border-zinc-800 bg-zinc-900/50">
 						<div class="flex flex-wrap gap-1 border-b border-zinc-800 p-1.5">
+							<button
+								class="flex items-center gap-1.5 rounded px-2.5 py-1 text-[10px] font-medium transition-colors {activeJudgeIndex === -1 ? 'bg-zinc-800 text-zinc-100' : 'text-zinc-500 hover:text-zinc-300'}"
+								onclick={() => {
+									activeJudgeIndex = -1;
+									displayedCitations = null;
+									highlightedTurn = null;
+								}}
+							>
+								<span
+									class="inline-block size-[6px] rounded-full shrink-0"
+									style={aggregateVote === null
+										? 'background: transparent; box-shadow: inset 0 0 0 1.5px var(--theme-text-muted);'
+										: `background: ${metricDotColor(aggregateVote)}`}
+								></span>
+								Aggregate
+								<span class="opacity-50">· {metricOutcomeText(aggregateVote)}</span>
+							</button>
 							{#each item.multi_judge?.verdicts ?? [] as judgeVerdict, i}
 								{@const vote = getVerdictFlag(judgeVerdict, primaryMetric)}
 								<button
@@ -935,13 +1056,17 @@
 							{/each}
 						</div>
 						<p class="px-3 py-2 text-xs leading-relaxed text-zinc-400">
-							Inspecting Judge {activeJudgeIndex + 1}. Dimension explanations, policy reasoning, and transcript highlights follow this verdict.
+							{#if activeJudgeIndex === -1}
+								Inspecting the aggregate verdict. Its rationale comes from representative judge {typeof item.multi_judge?.representative_index === 'number' ? item.multi_judge.representative_index + 1 : '—'}.
+							{:else}
+								Inspecting Judge {activeJudgeIndex + 1}. Dimension explanations, behavior reasoning, and transcript highlights follow this verdict.
+							{/if}
 						</p>
 					</div>
 				{/if}
 				{#if activeVerdict?.narrative}
 					<div class="rounded-lg border border-border bg-surface p-4">
-						<div class="mb-2 text-xs font-semibold text-text-muted">Conversation summary</div>
+						<div class="mb-2 text-xs font-semibold text-text-muted">Result summary</div>
 						<p class="text-sm text-text-secondary leading-relaxed">{activeVerdict.narrative}</p>
 					</div>
 				{/if}
@@ -974,15 +1099,15 @@
 									<div class="mt-3 space-y-1.5 border-t border-border/50 pt-3">
 										{#each nodeJudgments as node}
 											{@const violated = node.violated}
-											{@const nodeName = policyNodeName(node)}
+											{@const nodeName = behaviorCategoryName(node)}
 											<div class="rounded-md px-3 py-2 {violated ? 'bg-score-fail/5' : violated === null ? 'bg-surface-2/50' : 'bg-score-pass/5'}">
 												<div class="flex items-start justify-between gap-2">
 													<div class="min-w-0 flex-1">
 														<div
 															class="truncate text-xs font-semibold text-text-muted"
-															title={nodeName ?? 'Unnamed policy node'}
+															title={nodeName ?? 'Unnamed behavior category'}
 														>
-															{nodeName ?? 'Unnamed policy node'}
+															{nodeName ?? 'Unnamed behavior category'}
 														</div>
 													</div>
 													<div class="flex shrink-0 flex-wrap items-center justify-end gap-1.5">
@@ -1063,7 +1188,7 @@
 
 		<div class="w-3/5 overflow-y-auto p-5">
 			<h3 class="mb-4 text-[24px] font-semibold text-text">
-				Conversation · {conversationTurnCount(item.messages)} turns
+				Result · {conversationTurnCount(item.messages)} turns
 			</h3>
 			{#if agentTimeline.length >= 2}
 				<div class="mb-4 flex flex-wrap items-center gap-1 rounded-md border border-border/60 bg-surface-2/40 px-3 py-2 text-[11px] text-text-muted">
@@ -1108,6 +1233,60 @@
 						</p>
 					{/if}
 				</div>
+			{/if}
+			{#if trajectoryGroups.length > 0}
+				<details class="mb-4 rounded-lg border border-border bg-surface/40">
+					<summary class="flex cursor-pointer list-none items-center gap-2 px-4 py-3">
+						<svg class="h-3 w-3 text-text-muted/70" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3"><path d="M9 5l7 7-7 7"/></svg>
+						<span class="text-xs font-semibold uppercase tracking-widest text-text-muted">Agent trace ({item.trajectory?.steps.length ?? 0} steps)</span>
+						{#if item.trajectory?.stop_reason}
+							<span class="ml-auto text-[10px] text-text-muted">stop: {item.trajectory.stop_reason}</span>
+						{/if}
+					</summary>
+					<div class="space-y-3 border-t border-border/40 px-4 py-3">
+						{#each trajectoryGroups as group (group.id)}
+							<div class="rounded-lg border border-border/50 bg-bg/40">
+								<div class="flex flex-wrap items-center gap-2 border-b border-border/40 px-3 py-2">
+									<span class="text-xs font-semibold text-text-secondary">{group.label}</span>
+									{#if trajectoryGroupSummary(group)}
+										<span class="text-[10px] text-text-muted">{trajectoryGroupSummary(group)}</span>
+									{/if}
+								</div>
+								<div class="space-y-2 p-3">
+									{#each group.items as itemEntry, stepIndex}
+										{@const step = itemEntry.step}
+										{@const tone = trajectoryStepTone(step)}
+										{@const body = trajectoryStepBody(step)}
+										<details class="rounded-md border {tone.cardClass}" open={stepIndex < 3}>
+											<summary class="flex cursor-pointer list-none items-center gap-2 px-3 py-2">
+												<span class="rounded border px-1.5 py-0.5 font-mono text-[9px] {tone.badgeClass}">{tone.label}</span>
+												<span class="min-w-0 flex-1 truncate text-xs font-medium text-text-secondary">
+													{step.type === 'message' || step.type === 'system' ? trajectoryMessageLabel(step) : trajectoryStepTitle(step)}
+												</span>
+												{#if step.status}
+													<span class="rounded bg-surface px-1.5 py-0.5 text-[10px] text-text-muted">{step.status}</span>
+												{/if}
+											</summary>
+											{#if body || step.args || step.raw}
+												<div class="space-y-2 border-t border-border/40 px-3 py-2">
+													{#if body}
+														<div class="whitespace-pre-wrap break-words text-xs leading-relaxed text-text-secondary">{body}</div>
+													{/if}
+													{#if step.raw}
+														<details>
+															<summary class="cursor-pointer text-[10px] uppercase tracking-wider text-text-muted">Raw</summary>
+															<pre class="mt-2 max-h-80 overflow-y-auto whitespace-pre-wrap break-all rounded bg-black/20 p-2 text-[10px] text-text-muted">{JSON.stringify(step.raw, null, 2)}</pre>
+														</details>
+													{/if}
+												</div>
+											{/if}
+										</details>
+									{/each}
+								</div>
+							</div>
+						{/each}
+					</div>
+				</details>
 			{/if}
 			<div class="space-y-3">
 				{#each item.messages as message, messageIndex}

--- a/viewer/src/lib/citation-warnings.ts
+++ b/viewer/src/lib/citation-warnings.ts
@@ -1,0 +1,27 @@
+const NON_DEGRADED_WARNING_REASONS = new Set(['overscoped_citation_part']);
+
+const WARNING_LABELS: Record<string, string> = {
+	ambiguous_citation_part: 'ambiguous citation match',
+	invalid_citation_message_id: 'invalid message reference',
+	missing_citations: 'missing citations',
+	noncanonical_citation_method: 'noncanonical citation match',
+	unresolved_citation_part: 'unresolved citation match'
+};
+
+export function citationWarningReason(warning: string): string {
+	const separatorIndex = warning.indexOf(':');
+	return separatorIndex >= 0 ? warning.slice(separatorIndex + 1) : warning;
+}
+
+export function isDegradedCitationWarning(warning: string): boolean {
+	return !NON_DEGRADED_WARNING_REASONS.has(citationWarningReason(warning));
+}
+
+export function citationWarningLabel(warning: string): string {
+	const separatorIndex = warning.indexOf(':');
+	const prefix = separatorIndex >= 0 ? warning.slice(0, separatorIndex) : '';
+	const reason = citationWarningReason(warning);
+	const citationMatch = /^citation_(\d+)$/.exec(prefix);
+	const label = WARNING_LABELS[reason] ?? reason.replace(/_/g, ' ');
+	return citationMatch ? `citation ${citationMatch[1]}: ${label}` : label;
+}

--- a/viewer/src/lib/export/ExportPage.svelte
+++ b/viewer/src/lib/export/ExportPage.svelte
@@ -78,9 +78,9 @@
 		judge: 'Scoring'
 	};
 
-	const requiredBaseMetrics = getRequiredBaseMetricNames(
+	let requiredBaseMetrics = $derived(getRequiredBaseMetricNames(
 		(data.dimensionDefs ?? {}) as Record<string, DimensionDef>
-	);
+	));
 
 	function judgeStatus(record: {
 		verdict?: Record<string, unknown> | null;
@@ -122,33 +122,33 @@
 		return flag ? 'var(--theme-score-fail)' : 'var(--theme-score-pass)';
 	}
 
-	const hasPromptEval = (data.promptCount ?? data.samples.length) > 0;
-	const hasAuditEval = (data.auditCount ?? data.auditScores.length) > 0;
+	let hasPromptEval = $derived((data.promptCount ?? data.samples.length) > 0);
+	let hasAuditEval = $derived((data.auditCount ?? data.auditScores.length) > 0);
 
-	const promptDimensionNames = Object.keys(data.metrics?.dimensions ?? {});
-	const auditDimensionNames = Object.keys(data.auditMetrics?.dimensions ?? {});
-	const promptMetricNames = promptDimensionNames;
-	const auditMetricNames = auditDimensionNames;
-	const promptPrimaryMetric = promptMetricNames[0] ?? 'policy_violation';
-	const auditPrimaryMetric = auditMetricNames[0] ?? 'policy_violation';
+	let promptDimensionNames = $derived(Object.keys(data.metrics?.dimensions ?? {}));
+	let auditDimensionNames = $derived(Object.keys(data.auditMetrics?.dimensions ?? {}));
+	let promptMetricNames = $derived(promptDimensionNames);
+	let auditMetricNames = $derived(auditDimensionNames);
+	let promptPrimaryMetric = $derived(promptMetricNames[0] ?? 'policy_violation');
+	let auditPrimaryMetric = $derived(auditMetricNames[0] ?? 'policy_violation');
 
-	const promptScored = data.samples.filter((s) => judgeStatus(s) === 'ok').length;
-	const promptJudgeFailures = data.samples.length - promptScored;
-	const auditScored = data.auditScores.filter((s) => judgeStatus(s) === 'ok').length;
-	const auditJudgeFailures = data.auditScores.length - auditScored;
+	let promptScored = $derived(data.samples.filter((s) => judgeStatus(s) === 'ok').length);
+	let promptJudgeFailures = $derived(data.samples.length - promptScored);
+	let auditScored = $derived(data.auditScores.filter((s) => judgeStatus(s) === 'ok').length);
+	let auditJudgeFailures = $derived(data.auditScores.length - auditScored);
 
-	const promptMetricCards = promptMetricNames.map((dim) => ({
+	let promptMetricCards = $derived(promptMetricNames.map((dim) => ({
 		key: dim,
 		name: metricLabel(dim),
 		summary: data.metrics?.dimensions?.[dim],
 		description: data.dimensionDefs?.[dim]?.description ?? ''
-	}));
-	const auditMetricCards = auditMetricNames.map((dim) => ({
+	})));
+	let auditMetricCards = $derived(auditMetricNames.map((dim) => ({
 		key: dim,
 		name: metricLabel(dim),
 		summary: data.auditMetrics?.dimensions?.[dim],
 		description: data.dimensionDefs?.[dim]?.description ?? ''
-	}));
+	})));
 
 	function durationLabel(start?: string | null, end?: string | null): string | null {
 		if (!start || !end) return null;
@@ -157,7 +157,7 @@
 		const secs = ms / 1000;
 		return `${Math.round(secs / 60)}m ${Math.round(secs % 60)}s`;
 	}
-	const runDuration = durationLabel(data.manifest?.started_at, data.manifest?.ended_at);
+	let runDuration = $derived(durationLabel(data.manifest?.started_at, data.manifest?.ended_at));
 </script>
 
 <!-- Header -->

--- a/viewer/src/lib/export/ExportPage.svelte
+++ b/viewer/src/lib/export/ExportPage.svelte
@@ -1,0 +1,446 @@
+<script lang="ts">
+	import type {
+		AuditScore,
+		BinaryCounts,
+		DimensionDef,
+		JudgedSample,
+		MultiJudge,
+		ViewerResultItem
+	} from '$lib/types.js';
+	import {
+		getRecordFlag,
+		getRequiredBaseMetricNames,
+		inferJudgeStatus,
+		multiJudgeDimensionAgreementLabel,
+		multiJudgeHasDisagreement
+	} from '$lib/judgment.js';
+	import ExportSeedDetail from './ExportSeedDetail.svelte';
+
+	type ExportPageData = {
+		suite_id: string;
+		run_id: string;
+		manifest?: {
+			status?: string;
+			started_at?: string | null;
+			ended_at?: string | null;
+			stages?: Record<string, string>;
+		} | null;
+		taxonomy?: { behavior?: { name?: string } | null } | null;
+		samples: JudgedSample[];
+		auditScores: AuditScore[];
+		promptCount?: number;
+		auditCount?: number;
+		hasAuditContent?: boolean;
+		dimensionDefs?: Record<string, DimensionDef> | null;
+		metrics: { dimensions?: Record<string, MetricSummary> } | null;
+		auditMetrics: { dimensions?: Record<string, MetricSummary> } | null;
+		multiJudgeStats?: MultiJudgeStats | null;
+		auditMultiJudgeStats?: MultiJudgeStats | null;
+		promptSeedTitleMap?: Record<string, string>;
+		scenarioSeedMap?: Record<string, { description?: string | null }>;
+	};
+
+	type MetricSummary = {
+		count?: number;
+		clear_count?: number;
+		flagged_count?: number;
+		rate?: number;
+		counts?: BinaryCounts;
+	};
+
+	type MultiJudgeStats = {
+		total: number;
+		judgeN: number;
+		meanAgreement: number;
+		unanimous: number;
+		split: number;
+		highVariance: number;
+	};
+
+	let {
+		data,
+		promptDrawerItems,
+		scenarioDrawerItems,
+		generatedAt
+	}: {
+		data: ExportPageData;
+		promptDrawerItems: Record<string, ViewerResultItem>;
+		scenarioDrawerItems: Record<string, ViewerResultItem>;
+		generatedAt: string;
+	} = $props();
+
+	const RUN_STAGE_LABELS: Record<string, string> = {
+		systematize: 'Behavior Categories',
+		test_set: 'Test Set',
+		inference: 'Inference',
+		seeds: 'Test Set',
+		rollout: 'Inference',
+		judge: 'Scoring'
+	};
+
+	const requiredBaseMetrics = getRequiredBaseMetricNames(
+		(data.dimensionDefs ?? {}) as Record<string, DimensionDef>
+	);
+
+	function judgeStatus(record: {
+		verdict?: Record<string, unknown> | null;
+		judge_status?: string | null;
+		judge_error?: string | null;
+	}) {
+		if (record.judge_status == null && record.judge_error == null && record.verdict == null) {
+			return 'unjudged';
+		}
+		return inferJudgeStatus(record, requiredBaseMetrics);
+	}
+
+	function metricLabel(metric: string): string {
+		return metric.replace(/_/g, ' ');
+	}
+	function metricOutcomeText(flag: boolean | null): string {
+		if (flag === null) return 'n/a';
+		return flag ? 'flagged' : 'clear';
+	}
+	function metricOutcomeClass(flag: boolean | null): string {
+		if (flag === null) return 'text-text-muted';
+		return flag ? 'text-score-fail' : 'text-score-pass';
+	}
+	function metricRateClass(rate: number): string {
+		if (rate >= 0.5) return 'text-score-fail';
+		if (rate > 0) return 'text-score-border';
+		return 'text-score-pass';
+	}
+	function metricRateText(rate: number): string {
+		return `${(rate * 100).toFixed(0)}%`;
+	}
+	function binaryBar(counts: BinaryCounts | undefined): { clear: number; flagged: number } {
+		if (!counts) return { clear: 0, flagged: 0 };
+		const total = (counts[0] ?? 0) + (counts[1] ?? 0);
+		if (total === 0) return { clear: 0, flagged: 0 };
+		return { clear: ((counts[0] ?? 0) / total) * 100, flagged: ((counts[1] ?? 0) / total) * 100 };
+	}
+	function metricDotColor(flag: boolean): string {
+		return flag ? 'var(--theme-score-fail)' : 'var(--theme-score-pass)';
+	}
+
+	const hasPromptEval = (data.promptCount ?? data.samples.length) > 0;
+	const hasAuditEval = (data.auditCount ?? data.auditScores.length) > 0;
+
+	const promptDimensionNames = Object.keys(data.metrics?.dimensions ?? {});
+	const auditDimensionNames = Object.keys(data.auditMetrics?.dimensions ?? {});
+	const promptMetricNames = promptDimensionNames;
+	const auditMetricNames = auditDimensionNames;
+	const promptPrimaryMetric = promptMetricNames[0] ?? 'policy_violation';
+	const auditPrimaryMetric = auditMetricNames[0] ?? 'policy_violation';
+
+	const promptScored = data.samples.filter((s) => judgeStatus(s) === 'ok').length;
+	const promptJudgeFailures = data.samples.length - promptScored;
+	const auditScored = data.auditScores.filter((s) => judgeStatus(s) === 'ok').length;
+	const auditJudgeFailures = data.auditScores.length - auditScored;
+
+	const promptMetricCards = promptMetricNames.map((dim) => ({
+		key: dim,
+		name: metricLabel(dim),
+		summary: data.metrics?.dimensions?.[dim],
+		description: data.dimensionDefs?.[dim]?.description ?? ''
+	}));
+	const auditMetricCards = auditMetricNames.map((dim) => ({
+		key: dim,
+		name: metricLabel(dim),
+		summary: data.auditMetrics?.dimensions?.[dim],
+		description: data.dimensionDefs?.[dim]?.description ?? ''
+	}));
+
+	function durationLabel(start?: string | null, end?: string | null): string | null {
+		if (!start || !end) return null;
+		const ms = new Date(end).getTime() - new Date(start).getTime();
+		if (!Number.isFinite(ms) || ms < 0) return null;
+		const secs = ms / 1000;
+		return `${Math.round(secs / 60)}m ${Math.round(secs % 60)}s`;
+	}
+	const runDuration = durationLabel(data.manifest?.started_at, data.manifest?.ended_at);
+</script>
+
+<!-- Header -->
+<div class="mb-8">
+	<div class="flex items-center gap-1.5 text-xs text-text-muted">
+		<span>Evaluation suites</span>
+		<svg class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M9 5l7 7-7 7"/></svg>
+		<span>{data.taxonomy?.behavior?.name ?? data.suite_id}</span>
+		<svg class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M9 5l7 7-7 7"/></svg>
+		<span class="text-text-secondary">{data.run_id}</span>
+	</div>
+	<div class="mt-3 flex flex-wrap items-center gap-2.5">
+		<h1 class="text-xl font-semibold tracking-tight">{data.run_id}</h1>
+		{#if data.manifest?.status === 'completed' || hasPromptEval || hasAuditEval}
+			<span class="inline-flex items-center gap-1 rounded-full bg-score-pass/10 px-2 py-0.5 text-xs text-score-pass">
+				<svg class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path d="M5 13l4 4L19 7"/></svg>
+				Completed
+			</span>
+		{:else if data.manifest?.status === 'failed'}
+			<span class="inline-flex items-center gap-1 rounded-full bg-score-fail/10 px-2 py-0.5 text-xs text-score-fail">
+				<svg class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path d="M6 18L18 6M6 6l12 12"/></svg>
+				Failed
+			</span>
+		{/if}
+		<span class="rounded bg-surface-2 px-1.5 py-0.5 font-mono text-[10px] text-text-muted">{data.suite_id}/{data.run_id}</span>
+		<span class="ml-auto rounded bg-surface px-2 py-0.5 text-[10px] text-text-muted" title="Time the export was generated">
+			Exported {new Date(generatedAt).toLocaleString()}
+		</span>
+	</div>
+	{#if data.manifest?.started_at}
+		<p class="mt-2 text-xs text-text-muted">
+			Started {new Date(data.manifest.started_at).toLocaleString()}{#if runDuration} · {runDuration}{/if}
+		</p>
+	{/if}
+
+	{#if data.manifest?.stages}
+		<div class="mt-3 max-w-2xl rounded-lg border border-border bg-surface p-4">
+			<h3 class="mb-3 text-xs font-semibold uppercase tracking-wider text-text-muted">Run Pipeline</h3>
+			<div class="grid gap-2">
+				{#each Object.entries(data.manifest.stages) as [stage, info]}
+					<div class="flex flex-wrap items-center gap-x-3 gap-y-1 rounded border border-border bg-background px-3 py-2">
+						<span class="inline-flex h-5 w-5 items-center justify-center rounded-full text-xs {info === 'completed' ? 'bg-score-pass/10 text-score-pass' : info === 'failed' ? 'bg-score-fail/10 text-score-fail' : 'bg-surface-2 text-text-muted'}">
+							{info === 'completed' ? '✓' : info === 'failed' ? '✗' : '○'}
+						</span>
+						<span class="text-xs font-medium text-text-secondary">{RUN_STAGE_LABELS[stage] ?? stage}</span>
+						<span class="ml-auto text-xs text-text-muted">{info}</span>
+					</div>
+				{/each}
+			</div>
+		</div>
+	{/if}
+</div>
+
+{#if !hasPromptEval && !hasAuditEval}
+	<div class="rounded-lg border border-border bg-surface px-6 py-12 text-center">
+		<p class="text-sm text-text-secondary">No results in this run.</p>
+	</div>
+{/if}
+
+<!-- ==================== PROMPT EVAL SECTION ==================== -->
+{#if hasPromptEval}
+	<section class="mb-12">
+		<div class="mb-4 flex items-center gap-3">
+			<h2 class="text-sm font-semibold uppercase tracking-widest text-text-muted">Prompts</h2>
+			<div class="h-px flex-1 bg-border"></div>
+			<span class="text-xs text-text-muted">{data.samples.length} results</span>
+		</div>
+
+		<!-- Metric cards -->
+		<div class="mb-4 grid gap-3" style="grid-template-columns: repeat({Math.min(promptMetricCards.length, 4)}, minmax(0, 1fr))">
+			{#each promptMetricCards as m}
+				{@const pct = binaryBar(m.summary?.counts ?? { 0: 0, 1: 0 } as BinaryCounts)}
+				<div class="rounded-lg border border-border bg-surface px-5 py-4">
+					<div class="text-[11px] font-semibold uppercase tracking-wider text-text-muted">{m.name}</div>
+					{#if m.description}
+						<p class="mt-0.5 text-[10px] text-text-muted/60 leading-snug line-clamp-2">{m.description}</p>
+					{/if}
+					<div class="mt-2 flex items-baseline gap-1.5">
+						<span class="text-3xl font-bold tabular-nums {metricRateClass(m.summary?.rate ?? 0)}">{metricRateText(m.summary?.rate ?? 0)}</span>
+						<span class="text-sm text-text-muted">flagged</span>
+					</div>
+					{#if (m.summary?.count ?? 0) > 0}
+						<div class="mt-2.5 flex h-1.5 overflow-hidden rounded-full bg-border/50">
+							{#if pct.clear > 0}
+								<div class="bg-score-pass" style="width: {pct.clear}%"></div>
+							{/if}
+							{#if pct.flagged > 0}
+								<div class="bg-score-fail" style="width: {pct.flagged}%"></div>
+							{/if}
+						</div>
+						<div class="mt-1 flex justify-between text-[9px] tabular-nums text-text-muted">
+							<span>{m.summary?.clear_count ?? 0} clear</span>
+							<span>{m.summary?.flagged_count ?? 0} flagged</span>
+							<span>{m.summary?.count ?? 0} total</span>
+						</div>
+					{/if}
+					{#if data.multiJudgeStats}
+						<div class="mt-2 text-[9px] text-text-muted">aggregate uses majority judge vote</div>
+					{/if}
+				</div>
+			{/each}
+		</div>
+
+		{#if data.multiJudgeStats}
+			<div class="mb-4 flex flex-wrap items-center gap-2 rounded-lg border border-border bg-surface px-4 py-2 text-[10px] text-text-muted">
+				<span class="font-semibold text-text-secondary">{data.multiJudgeStats.total} multi-judge results</span>
+				<span>{data.multiJudgeStats.judgeN} judges</span>
+				<span>{(data.multiJudgeStats.meanAgreement * 100).toFixed(0)}% mean agreement</span>
+				<span>{data.multiJudgeStats.split + data.multiJudgeStats.highVariance} disagreement{data.multiJudgeStats.split + data.multiJudgeStats.highVariance === 1 ? '' : 's'}</span>
+				{#if data.multiJudgeStats.highVariance > 0}
+					<span class="text-amber-400">{data.multiJudgeStats.highVariance} high-variance result{data.multiJudgeStats.highVariance === 1 ? '' : 's'}</span>
+				{/if}
+			</div>
+		{/if}
+
+		{#if promptJudgeFailures > 0}
+			<p class="mb-4 text-xs text-amber-400">
+				Scored {promptScored} of {data.samples.length} prompt results. {promptJudgeFailures} judge failures were excluded from the rates.
+			</p>
+		{/if}
+
+		<!-- Flat row list, each row's full drawer body inside <details> -->
+		<div class="overflow-hidden rounded-lg border border-border">
+			{#each data.samples as sample, sIdx}
+				{@const drawerItem = sample.test_case_id ? promptDrawerItems[sample.test_case_id] : undefined}
+				{@const status = judgeStatus(sample)}
+				<details class="{sIdx > 0 ? 'border-t border-border/50' : ''} group">
+					<summary class="flex cursor-pointer list-none items-center gap-3 px-5 py-2.5 transition-colors hover:bg-surface/50">
+						<svg class="h-3 w-3 shrink-0 text-text-muted/60 transition-transform group-open:rotate-90" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M9 5l7 7-7 7"/></svg>
+						<span class="flex-1 truncate text-sm text-text-secondary">{(sample.test_case_id && data.promptSeedTitleMap?.[sample.test_case_id]) || sample.prompt}</span>
+						<div class="flex shrink-0 items-center gap-1.5">
+							{#each promptMetricNames as m}
+								{@const v = getRecordFlag(sample, m)}
+								{#if v !== null}
+									<span class="inline-flex items-center gap-1 rounded bg-surface-2 px-1.5 py-0.5 text-[10px]">
+										<span class="text-text-muted">{metricLabel(m)}</span>
+										<span class="font-semibold tabular-nums {metricOutcomeClass(v)}">{metricOutcomeText(v)}</span>
+									</span>
+								{/if}
+							{/each}
+							{#if status === 'judge_failed'}
+								<span class="inline-flex items-center rounded bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-medium text-amber-400">judge failed</span>
+							{/if}
+							{#if sample.multi_judge}
+								<div class="ml-1 flex items-center gap-0.5">
+									{#each (sample.multi_judge as MultiJudge).votes?.[promptPrimaryMetric] ?? [] as vote}
+										{@const agreed = vote === getRecordFlag(sample, promptPrimaryMetric)}
+										<span
+											class="inline-block size-[6px] rounded-full"
+											style={agreed ? `background: ${metricDotColor(vote)}` : `background: transparent; box-shadow: inset 0 0 0 1.5px ${metricDotColor(vote)}`}
+											title={metricOutcomeText(vote)}
+										></span>
+									{/each}
+								</div>
+								{#if multiJudgeHasDisagreement(sample.multi_judge as MultiJudge, [promptPrimaryMetric])}
+									<span class="text-[10px] tabular-nums text-text-muted">{multiJudgeDimensionAgreementLabel(sample.multi_judge as MultiJudge, promptPrimaryMetric)}</span>
+								{/if}
+							{/if}
+						</div>
+					</summary>
+					{#if drawerItem}
+						<div class="border-t border-border/50 bg-bg/50 px-5 py-4">
+							<ExportSeedDetail item={drawerItem} metricNames={promptMetricNames} primaryMetric={promptPrimaryMetric} />
+						</div>
+					{:else}
+						<div class="border-t border-border/50 bg-bg/50 px-5 py-3 text-xs text-text-muted">
+							(no detail loaded for test_case_id={sample.test_case_id ?? '?'})
+						</div>
+					{/if}
+				</details>
+			{/each}
+		</div>
+	</section>
+{/if}
+
+<!-- ==================== AUDIT EVAL SECTION ==================== -->
+{#if hasAuditEval}
+	<section class="mb-12">
+		<div class="mb-4 flex items-center gap-3">
+		<h2 class="text-sm font-semibold uppercase tracking-widest text-text-muted">Scenario results</h2>
+			<div class="h-px flex-1 bg-border"></div>
+		<span class="text-xs text-text-muted">{data.auditScores.length} results</span>
+		</div>
+
+		<div class="mb-4 grid gap-3" style="grid-template-columns: repeat({Math.min(auditMetricCards.length, 4)}, minmax(0, 1fr))">
+			{#each auditMetricCards as m}
+				{@const pct = binaryBar(m.summary?.counts ?? { 0: 0, 1: 0 } as BinaryCounts)}
+				<div class="rounded-lg border border-border bg-surface px-5 py-4">
+					<div class="text-[11px] font-semibold uppercase tracking-wider text-text-muted">{m.name}</div>
+					{#if m.description}
+						<p class="mt-0.5 text-[10px] text-text-muted/60 leading-snug line-clamp-2">{m.description}</p>
+					{/if}
+					<div class="mt-2 flex items-baseline gap-1.5">
+						<span class="text-3xl font-bold tabular-nums {metricRateClass(m.summary?.rate ?? 0)}">{metricRateText(m.summary?.rate ?? 0)}</span>
+						<span class="text-sm text-text-muted">flagged</span>
+					</div>
+					{#if (m.summary?.count ?? 0) > 0}
+						<div class="mt-2.5 flex h-1.5 overflow-hidden rounded-full bg-border/50">
+							{#if pct.clear > 0}<div class="bg-score-pass" style="width: {pct.clear}%"></div>{/if}
+							{#if pct.flagged > 0}<div class="bg-score-fail" style="width: {pct.flagged}%"></div>{/if}
+						</div>
+						<div class="mt-1 flex justify-between text-[9px] tabular-nums text-text-muted">
+							<span>{m.summary?.clear_count ?? 0} clear</span>
+							<span>{m.summary?.flagged_count ?? 0} flagged</span>
+							<span>{m.summary?.count ?? 0} total</span>
+						</div>
+					{/if}
+				</div>
+			{/each}
+		</div>
+
+		{#if data.auditMultiJudgeStats}
+			<div class="mb-4 flex flex-wrap items-center gap-2 rounded-lg border border-border bg-surface px-4 py-2 text-[10px] text-text-muted">
+				<span class="font-semibold text-text-secondary">{data.auditMultiJudgeStats.total} multi-judge results</span>
+				<span>{data.auditMultiJudgeStats.judgeN} judges</span>
+				<span>{(data.auditMultiJudgeStats.meanAgreement * 100).toFixed(0)}% mean agreement</span>
+				<span>{data.auditMultiJudgeStats.split + data.auditMultiJudgeStats.highVariance} disagreement{data.auditMultiJudgeStats.split + data.auditMultiJudgeStats.highVariance === 1 ? '' : 's'}</span>
+				{#if data.auditMultiJudgeStats.highVariance > 0}
+					<span class="text-amber-400">{data.auditMultiJudgeStats.highVariance} high-variance result{data.auditMultiJudgeStats.highVariance === 1 ? '' : 's'}</span>
+				{/if}
+			</div>
+		{/if}
+
+		{#if auditJudgeFailures > 0}
+			<p class="mb-4 text-xs text-amber-400">
+				Scored {auditScored} of {data.auditScores.length} scenario results. {auditJudgeFailures} judge failures were excluded.
+			</p>
+		{/if}
+
+		<div class="overflow-hidden rounded-lg border border-border">
+			{#each data.auditScores as score, sIdx}
+				{@const drawerItem = score.test_case_id ? scenarioDrawerItems[score.test_case_id] : undefined}
+				{@const status = judgeStatus(score)}
+				{@const title = (score.test_case_id && data.scenarioSeedMap?.[score.test_case_id]?.description) || score.test_case_id || ''}
+				<details class="{sIdx > 0 ? 'border-t border-border/50' : ''} group">
+					<summary class="flex cursor-pointer list-none items-center gap-3 px-5 py-2.5 transition-colors hover:bg-surface/50">
+						<svg class="h-3 w-3 shrink-0 text-text-muted/60 transition-transform group-open:rotate-90" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M9 5l7 7-7 7"/></svg>
+						<span class="flex-1 truncate text-sm text-text-secondary">{title}</span>
+						<div class="flex shrink-0 items-center gap-1.5">
+							{#each auditMetricNames as m}
+								{@const v = getRecordFlag(score, m)}
+								{#if v !== null}
+									<span class="inline-flex items-center gap-1 rounded bg-surface-2 px-1.5 py-0.5 text-[10px]">
+										<span class="text-text-muted">{metricLabel(m)}</span>
+										<span class="font-semibold tabular-nums {metricOutcomeClass(v)}">{metricOutcomeText(v)}</span>
+									</span>
+								{/if}
+							{/each}
+							{#if status === 'judge_failed'}
+								<span class="inline-flex items-center rounded bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-medium text-amber-400">judge failed</span>
+							{/if}
+							{#if score.multi_judge}
+								<div class="ml-1 flex items-center gap-0.5">
+									{#each (score.multi_judge as MultiJudge).votes?.[auditPrimaryMetric] ?? [] as vote}
+										{@const agreed = vote === getRecordFlag(score, auditPrimaryMetric)}
+										<span
+											class="inline-block size-[6px] rounded-full"
+											style={agreed ? `background: ${metricDotColor(vote)}` : `background: transparent; box-shadow: inset 0 0 0 1.5px ${metricDotColor(vote)}`}
+											title={metricOutcomeText(vote)}
+										></span>
+									{/each}
+								</div>
+								{#if multiJudgeHasDisagreement(score.multi_judge as MultiJudge, [auditPrimaryMetric])}
+									<span class="text-[10px] tabular-nums text-text-muted">{multiJudgeDimensionAgreementLabel(score.multi_judge as MultiJudge, auditPrimaryMetric)}</span>
+								{/if}
+							{/if}
+						</div>
+					</summary>
+					{#if drawerItem}
+						<div class="border-t border-border/50 bg-bg/50 px-5 py-4">
+							<ExportSeedDetail item={drawerItem} metricNames={auditMetricNames} primaryMetric={auditPrimaryMetric} />
+						</div>
+					{:else}
+						<div class="border-t border-border/50 bg-bg/50 px-5 py-3 text-xs text-text-muted">
+							(no detail loaded for test_case_id={score.test_case_id ?? '?'})
+						</div>
+					{/if}
+				</details>
+			{/each}
+		</div>
+	</section>
+{/if}
+
+<footer class="mt-12 border-t border-border pt-6 text-center text-[10px] text-text-muted">
+	Generated by Adaptive Eval viewer · {new Date(generatedAt).toLocaleString()}
+</footer>

--- a/viewer/src/lib/export/ExportPage.svelte
+++ b/viewer/src/lib/export/ExportPage.svelte
@@ -14,6 +14,7 @@
 		multiJudgeDimensionAgreementLabel,
 		multiJudgeHasDisagreement
 	} from '$lib/judgment.js';
+	import { judgeDimensionLabel } from '$lib/labels.js';
 	import ExportSeedDetail from './ExportSeedDetail.svelte';
 
 	type ExportPageData = {
@@ -94,7 +95,7 @@
 	}
 
 	function metricLabel(metric: string): string {
-		return metric.replace(/_/g, ' ');
+		return judgeDimensionLabel(metric);
 	}
 	function metricOutcomeText(flag: boolean | null): string {
 		if (flag === null) return 'n/a';

--- a/viewer/src/lib/export/ExportSeedDetail.svelte
+++ b/viewer/src/lib/export/ExportSeedDetail.svelte
@@ -1,0 +1,422 @@
+<script lang="ts">
+	import type {
+		AuditCitation,
+		InteractionMessage,
+		MultiJudge,
+		NodeJudgment,
+		SeedTool,
+		TrajectoryStep,
+		Verdict,
+		ViewerResultItem
+	} from '$lib/types.js';
+	import { renderMarkdown } from '$lib/markdown.js';
+	import {
+		getJudgeError,
+		getRecordFlag,
+		getVerdictFlag,
+		multiJudgeDimensionAgreementLabel
+	} from '$lib/judgment.js';
+
+	let {
+		item,
+		metricNames,
+		primaryMetric
+	}: {
+		item: ViewerResultItem;
+		metricNames: string[];
+		primaryMetric: string;
+	} = $props();
+
+	const verdict = (item.verdict as Verdict | null | undefined) ?? null;
+	const judgeError = getJudgeError(item);
+	const isJudgeFailed = item.judge_status === 'judge_failed';
+	const multiJudge = item.multi_judge as MultiJudge | undefined;
+
+	function metricLabel(metric: string): string {
+		return metric.replace(/_/g, ' ');
+	}
+	function metricOutcomeText(flag: boolean | null): string {
+		if (flag === null) return 'n/a';
+		return flag ? 'flagged' : 'clear';
+	}
+	function metricOutcomeClass(flag: boolean | null): string {
+		if (flag === null) return 'text-text-muted';
+		return flag ? 'text-score-fail' : 'text-score-pass';
+	}
+	function metricRateText(rate: number): string {
+		return `${(rate * 100).toFixed(0)}%`;
+	}
+	function metricDotColor(flag: boolean): string {
+		return flag ? 'var(--theme-score-fail)' : 'var(--theme-score-pass)';
+	}
+	function getDimensionJustification(v: Verdict | null | undefined, metric: string): string | null {
+		if (!v || typeof v !== 'object') return null;
+		const dj = v.dimension_justifications;
+		if (dj && typeof dj === 'object') {
+			const value = dj[metric];
+			if (typeof value === 'string' && value.trim()) return value;
+		}
+		return null;
+	}
+	function behaviorCategoryName(node: NodeJudgment): string | null {
+		const name = typeof node.node_name === 'string' ? node.node_name.trim() : '';
+		return name || null;
+	}
+	function visibleNodeJudgments(nodes: NodeJudgment[]): NodeJudgment[] {
+		const relevant = nodes.filter((n) => n.relevant);
+		return relevant.length > 0 ? relevant : nodes;
+	}
+	function resultTurnCount(messages: InteractionMessage[]): number {
+		return messages.filter((m) => m.role !== 'system').length;
+	}
+	function trajectoryStepBadgeLabel(step: TrajectoryStep): string {
+		const t = step.type ?? '';
+		if (t === 'tool_call') return 'CALL';
+		if (t === 'tool_result') return 'RESULT';
+		if (t === 'llm_call') return 'LLM';
+		if (t === 'command') return 'CMD';
+		if (t === 'guardrail') return 'GUARD';
+		if (t === 'error') return 'ERROR';
+		if (t === 'system') return 'SYSTEM';
+		if (t === 'reasoning') return 'REASON';
+		return t.toUpperCase().slice(0, 8) || 'STEP';
+	}
+	function trajectoryStepCardClass(step: TrajectoryStep): string {
+		const t = step.type ?? '';
+		if (t === 'tool_call') return 'border-blue-500/25 border-l-4 border-l-blue-400 bg-blue-500/5';
+		if (t === 'tool_result') return 'border-emerald-500/25 border-l-4 border-l-emerald-400 bg-emerald-500/5';
+		if (t === 'llm_call') return 'border-sky-500/25 border-l-4 border-l-sky-400 bg-sky-500/5';
+		if (t === 'command') return 'border-orange-500/25 border-l-4 border-l-orange-400 bg-orange-500/5';
+		if (t === 'guardrail') return 'border-amber-500/25 border-l-4 border-l-amber-400 bg-amber-500/5';
+		if (t === 'error') return 'border-score-fail/30 border-l-4 border-l-score-fail bg-score-fail/5';
+		if (t === 'system') return 'border-yellow-500/25 border-l-4 border-l-yellow-400 bg-yellow-500/5';
+		if (t === 'reasoning') return 'border-violet-500/25 border-l-4 border-l-violet-400 bg-violet-500/5';
+		return 'border-border bg-surface/30';
+	}
+	function trajectoryStepBadgeClass(step: TrajectoryStep): string {
+		const t = step.type ?? '';
+		if (t === 'tool_call') return 'border-blue-400/30 bg-blue-500/15 text-blue-300';
+		if (t === 'tool_result') return 'border-emerald-400/30 bg-emerald-500/15 text-emerald-300';
+		if (t === 'llm_call') return 'border-sky-400/30 bg-sky-500/15 text-sky-300';
+		if (t === 'command') return 'border-orange-400/30 bg-orange-500/15 text-orange-300';
+		if (t === 'guardrail') return 'border-amber-400/30 bg-amber-500/15 text-amber-300';
+		if (t === 'error') return 'border-score-fail/35 bg-score-fail/15 text-score-fail';
+		if (t === 'system') return 'border-yellow-400/30 bg-yellow-500/15 text-yellow-300';
+		if (t === 'reasoning') return 'border-violet-400/30 bg-violet-500/15 text-violet-300';
+		return 'border-border bg-surface text-text-muted';
+	}
+	function trajectoryStepTitle(step: TrajectoryStep): string {
+		if (step.name) return step.name;
+		if (step.role) return `${step.role}`;
+		return step.type ?? 'step';
+	}
+	function trajectoryStepBody(step: TrajectoryStep): string | null {
+		if (typeof step.content === 'string' && step.content.trim()) return step.content;
+		if (typeof step.result_preview === 'string' && step.result_preview.trim()) return step.result_preview;
+		if (step.result !== undefined && step.result !== null) {
+			try {
+				return typeof step.result === 'string' ? step.result : JSON.stringify(step.result, null, 2);
+			} catch {
+				return null;
+			}
+		}
+		if (step.args && Object.keys(step.args).length > 0) {
+			try {
+				return JSON.stringify(step.args, null, 2);
+			} catch {
+				return null;
+			}
+		}
+		return null;
+	}
+
+	type JudgeView = {
+		label: string;
+		v: Verdict | null;
+	};
+
+	function buildJudgeViews(): JudgeView[] {
+		const views: JudgeView[] = [{ label: 'Aggregate', v: verdict }];
+		if (multiJudge?.verdicts) {
+			multiJudge.verdicts.forEach((v, i) => {
+				views.push({ label: `Judge ${i + 1}`, v: v });
+			});
+		}
+		return views;
+	}
+	const judgeViews = buildJudgeViews();
+	const hasMultipleJudges = (multiJudge?.verdicts?.length ?? 0) > 1;
+
+	const verdictCitations: AuditCitation[] = Array.isArray(verdict?.citations)
+		? (verdict?.citations as AuditCitation[])
+		: [];
+</script>
+
+<div class="grid gap-5 lg:grid-cols-5">
+	<!-- Left column: scenario context + judgment -->
+	<div class="lg:col-span-2 space-y-3">
+		{#if item.kind === 'scenario' && item.context.description}
+			<div class="rounded-lg border border-border/50 bg-surface/50">
+				<div class="flex w-full items-center gap-2 px-4 py-3 text-left">
+					<h3 class="text-xs font-semibold uppercase tracking-widest text-text-muted">Scenario</h3>
+					<span class="flex-1 truncate text-sm font-medium text-text">{item.header_title}</span>
+				</div>
+				<div class="border-t border-border/30 px-4 pb-4 pt-3">
+					<p class="whitespace-pre-wrap text-sm text-text-secondary leading-relaxed">{item.context.description}</p>
+					{#if item.context.tools?.length}
+						<div class="mt-3 border-t border-border/30 pt-3">
+							<details>
+								<summary class="flex cursor-pointer items-center gap-1.5 list-none">
+									<svg class="h-3 w-3 text-text-muted/60 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3"><path d="M9 5l7 7-7 7"/></svg>
+									<h4 class="text-xs font-semibold uppercase tracking-widest text-text-muted">Tools</h4>
+									<span class="text-[10px] text-text-muted">{item.context.tools.map((t: SeedTool) => t.name).join(', ')}</span>
+								</summary>
+								<div class="mt-2 space-y-2">
+									{#each item.context.tools as tool}
+										<div class="rounded border border-border/30 bg-bg/50 px-3 py-2">
+											<span class="font-mono text-xs font-semibold text-purple-300">{tool.name}</span>
+											{#if tool.description}
+												<p class="mt-0.5 text-xs text-text-secondary">{tool.description}</p>
+											{/if}
+											{#if tool.parameters?.length}
+												<div class="mt-1.5 flex flex-wrap gap-1">
+													{#each tool.parameters as parameter}
+														<span class="inline-flex items-center rounded border border-border/20 bg-surface px-1.5 py-0.5 font-mono text-[10px] text-text-muted">
+															{parameter.name}<span class="ml-0.5 text-text-muted/50">:{parameter.type || 'string'}</span>
+														</span>
+													{/each}
+												</div>
+											{/if}
+										</div>
+									{/each}
+								</div>
+							</details>
+						</div>
+					{/if}
+				</div>
+			</div>
+		{/if}
+
+		<h3 class="text-xs font-semibold uppercase tracking-widest text-text-muted">Judgment</h3>
+
+		{#if isJudgeFailed}
+			<div class="rounded-lg border border-amber-500/20 bg-amber-500/5 p-4">
+				<div class="text-xs font-semibold uppercase tracking-wider text-amber-400">Judge failed</div>
+				<p class="mt-2 text-sm text-text-secondary leading-relaxed">
+					{judgeError ?? 'The judge did not produce a valid scored verdict for this result.'}
+				</p>
+			</div>
+		{/if}
+
+		{#each judgeViews as judgeView, jvIdx}
+			{@const v = judgeView.v}
+			{#if v}
+				<div class="rounded-lg border border-border bg-surface">
+					{#if hasMultipleJudges}
+						{@const vote = getVerdictFlag(v, primaryMetric)}
+						<div class="flex items-center gap-1.5 border-b border-border/50 px-3 py-2">
+							<span
+								class="inline-block size-[6px] rounded-full"
+								style={vote === null ? 'background: transparent; box-shadow: inset 0 0 0 1.5px var(--theme-text-muted);' : `background: ${metricDotColor(vote)}`}
+							></span>
+							<span class="text-xs font-semibold text-text-secondary">{judgeView.label}</span>
+							<span class="text-[10px] text-text-muted">· {metricOutcomeText(vote)}</span>
+							{#if jvIdx === 0 && multiJudge}
+								<span class="ml-auto text-[10px] text-text-muted">representative judge {typeof multiJudge.representative_index === 'number' ? multiJudge.representative_index + 1 : '—'}</span>
+							{/if}
+						</div>
+					{/if}
+
+					{#if v.narrative}
+						<div class="border-b border-border/30 px-4 py-3">
+							<div class="mb-1 text-[10px] font-semibold uppercase tracking-wider text-text-muted">Result summary</div>
+							<p class="text-sm text-text-secondary leading-relaxed whitespace-pre-wrap">{v.narrative}</p>
+						</div>
+					{/if}
+
+					<div class="space-y-3 p-4">
+						{#each metricNames as m}
+							{@const flag = getVerdictFlag(v, m)}
+							{@const dj = getDimensionJustification(v, m)}
+							{#if flag !== null}
+								<div class="rounded-md bg-bg/40 p-3">
+									<div class="mb-2 flex items-center justify-between gap-2">
+										<span class="text-xs font-semibold uppercase tracking-wider text-text-muted">{metricLabel(m)}</span>
+										<div class="flex items-center gap-2">
+											{#if jvIdx === 0 && multiJudge?.votes?.[m]}
+												<div class="flex items-center gap-0.5">
+													{#each multiJudge.votes[m] as vote}
+														{@const agreed = vote === flag}
+														<span class="inline-block size-[7px] rounded-full" style={agreed ? `background: ${metricDotColor(vote)}` : `background: transparent; box-shadow: inset 0 0 0 1.5px ${metricDotColor(vote)}`}></span>
+													{/each}
+												</div>
+												<span class="text-[10px] tabular-nums text-text-muted">{multiJudgeDimensionAgreementLabel(multiJudge, m)}</span>
+												<span class="text-[10px] tabular-nums text-text-muted">flagged {metricRateText(multiJudge.means?.[m] ?? 0)}</span>
+											{/if}
+											<span class="text-base font-bold tabular-nums {metricOutcomeClass(flag)}">{metricOutcomeText(flag)}</span>
+										</div>
+									</div>
+									{#if dj}
+										<div class="prose max-w-none text-sm text-text-secondary leading-relaxed">{@html renderMarkdown(dj)}</div>
+									{:else if m === primaryMetric && typeof v.justification === 'string'}
+										<div class="prose max-w-none text-sm text-text-secondary leading-relaxed">{@html renderMarkdown(v.justification)}</div>
+									{/if}
+
+									{#if m === 'policy_violation' && v.node_judgments?.length > 0}
+										<div class="mt-3 space-y-1.5 border-t border-border/40 pt-3">
+											{#each visibleNodeJudgments(v.node_judgments) as node}
+												{@const violated = node.violated}
+												<div class="rounded-md px-3 py-2 {violated ? 'bg-score-fail/5' : violated === null ? 'bg-surface-2/50' : 'bg-score-pass/5'}">
+													<div class="flex items-start justify-between gap-2">
+														<div class="min-w-0 flex-1">
+															<div class="text-xs font-semibold text-text" title={behaviorCategoryName(node) ?? 'Unnamed behavior category'}>
+																{behaviorCategoryName(node) ?? 'Unnamed behavior category'}
+															</div>
+														</div>
+														<div class="flex shrink-0 flex-wrap items-center justify-end gap-1.5">
+															<span class="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium {violated ? 'bg-score-fail/10 text-score-fail' : violated === null ? 'bg-surface-2 text-text-muted' : 'bg-score-pass/10 text-score-pass'}">
+																{violated === null ? 'not assessed' : violated ? 'violated' : 'clear'}
+															</span>
+															{#if node.confidence}
+																<span class="text-[10px] text-text-muted">{node.confidence} confidence</span>
+															{/if}
+														</div>
+													</div>
+													{#if node.reasoning}
+														<div class="prose mt-1.5 max-w-none text-sm text-text-secondary leading-relaxed">{@html renderMarkdown(node.reasoning)}</div>
+													{/if}
+												</div>
+											{/each}
+										</div>
+									{/if}
+								</div>
+							{/if}
+						{/each}
+					</div>
+
+					{#if jvIdx === 0 && verdictCitations.length > 0}
+						<details class="border-t border-border/30 px-4 py-3">
+							<summary class="cursor-pointer text-[11px] font-semibold uppercase tracking-wider text-text-muted">Citations ({verdictCitations.length})</summary>
+							<ol class="mt-2 list-decimal space-y-1.5 pl-5 text-xs text-text-secondary">
+								{#each verdictCitations as citation}
+									<li>
+										<span class="font-mono text-text-muted">[{citation.index}]</span>
+										{#if citation.parts?.length}
+											{#each citation.parts as part, pi}
+												{#if pi > 0}, {/if}
+												<span class="font-mono text-[10px] text-text-muted">msg={part.message_id ?? '?'}</span>
+											{/each}
+										{/if}
+										{#if citation.description}
+											<div class="mt-0.5 text-text-muted">{citation.description}</div>
+										{/if}
+									</li>
+								{/each}
+							</ol>
+						</details>
+					{/if}
+				</div>
+			{/if}
+		{/each}
+	</div>
+
+	<!-- Right column: result transcript -->
+	<div class="lg:col-span-3 space-y-3">
+		<h3 class="text-xs font-semibold uppercase tracking-widest text-text-muted">
+			Result · {resultTurnCount(item.messages)} turns
+		</h3>
+		{#each item.messages as message, mi}
+			{@const isSystem = message.role === 'system'}
+			{@const isUser = message.role === 'user'}
+			{@const isToolResult = message.role === 'tool' || message.type === 'tool_call'}
+			{@const isAssistantToolCall = message.role === 'assistant' && (message.tool_calls?.length ?? 0) > 0}
+			{#if isSystem}
+				<details class="rounded-lg border border-yellow-500/20 bg-yellow-500/8 overflow-hidden">
+					<summary class="flex cursor-pointer list-none items-center gap-2 px-4 py-2.5">
+						<svg class="h-3 w-3 text-yellow-400/60" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3"><path d="M9 5l7 7-7 7"/></svg>
+						<span class="text-xs font-semibold text-yellow-400">{message.type === 'set_system_message' ? 'System Prompt Set' : 'System Prompt'}</span>
+					</summary>
+					<div class="border-t border-yellow-500/10 px-4 pb-3 pt-2">
+						<div class="prose max-w-none text-sm text-text-secondary leading-relaxed">{@html renderMarkdown(message.content)}</div>
+					</div>
+				</details>
+			{:else if isAssistantToolCall}
+				<div class="space-y-2">
+					{#if message.content?.trim()}
+						<div class="rounded-lg border border-border bg-surface px-4 py-2.5">
+							<div class="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Assistant</div>
+							<div class="prose mt-1 max-w-none text-sm text-text leading-relaxed">{@html renderMarkdown(message.content)}</div>
+						</div>
+					{/if}
+					{#each message.tool_calls ?? [] as tc}
+						<details open class="rounded-lg border border-purple-500/20 bg-purple-500/8 overflow-hidden">
+							<summary class="flex cursor-pointer list-none items-center gap-2 px-4 py-2.5">
+								<svg class="h-3 w-3 text-purple-400/60" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3"><path d="M9 5l7 7-7 7"/></svg>
+								<span class="text-xs font-semibold text-purple-400">Tool Call</span>
+								<span class="font-mono text-xs text-text-muted">{tc.function}</span>
+							</summary>
+							<div class="border-t border-purple-500/10 px-4 pb-3 pt-2">
+								<pre class="overflow-x-auto rounded bg-bg/50 p-2 text-xs text-text-secondary">{JSON.stringify(tc.arguments, null, 2)}</pre>
+							</div>
+						</details>
+					{/each}
+				</div>
+			{:else if isToolResult}
+				<details open class="rounded-lg border border-purple-500/15 bg-purple-500/5 overflow-hidden">
+					<summary class="flex cursor-pointer list-none items-center gap-2 px-4 py-2.5">
+						<svg class="h-3 w-3 text-purple-400/60" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3"><path d="M9 5l7 7-7 7"/></svg>
+						<span class="text-xs font-semibold text-purple-400">Tool Result{message.judgeTurn != null ? ` · Turn ${message.judgeTurn}` : ''}</span>
+						{#if message.function}
+							<span class="truncate font-mono text-xs text-text-muted">{message.function}</span>
+						{/if}
+					</summary>
+					<div class="border-t border-purple-500/10 px-4 pb-3 pt-2">
+						<div class="prose max-w-none text-sm text-text-secondary leading-relaxed">{@html renderMarkdown(message.content)}</div>
+					</div>
+				</details>
+			{:else if isUser}
+				<div class="rounded-lg border border-border bg-surface-2/40 px-4 py-2.5">
+					<div class="text-[10px] font-semibold uppercase tracking-wider text-text-muted">User{message.judgeTurn != null ? ` · Turn ${message.judgeTurn}` : ''}</div>
+					<div class="prose mt-1 max-w-none text-sm text-text leading-relaxed">{@html renderMarkdown(message.content)}</div>
+				</div>
+			{:else}
+				<div class="rounded-lg border border-border bg-surface px-4 py-2.5">
+					<div class="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Assistant{message.judgeTurn != null ? ` · Turn ${message.judgeTurn}` : ''}</div>
+					<div class="prose mt-1 max-w-none text-sm text-text leading-relaxed">{@html renderMarkdown(message.content)}</div>
+				</div>
+			{/if}
+		{/each}
+
+		{#if item.trajectory && item.trajectory.steps?.length}
+			<details class="rounded-lg border border-border bg-surface/40">
+				<summary class="cursor-pointer list-none px-4 py-2.5">
+					<div class="flex items-center gap-2">
+						<svg class="h-3 w-3 text-text-muted/70" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3"><path d="M9 5l7 7-7 7"/></svg>
+						<span class="text-xs font-semibold uppercase tracking-widest text-text-muted">Agent trace ({item.trajectory.steps.length} steps)</span>
+						{#if item.trajectory.stop_reason}
+							<span class="ml-auto text-[10px] text-text-muted">stop: {item.trajectory.stop_reason}</span>
+						{/if}
+					</div>
+				</summary>
+				<div class="space-y-2 border-t border-border/40 px-4 py-3">
+					{#each item.trajectory.steps as step, si}
+						{@const body = trajectoryStepBody(step)}
+						<div class="rounded-lg border {trajectoryStepCardClass(step)}">
+							<div class="flex flex-wrap items-center gap-2 px-3 py-2">
+								<span class="font-mono text-[10px] text-text-muted">{step.step_id ?? `#${si}`}</span>
+								<span class="inline-flex items-center rounded border px-1.5 py-0.5 text-[9px] font-bold tracking-wide {trajectoryStepBadgeClass(step)}">{trajectoryStepBadgeLabel(step)}</span>
+								<span class="text-xs font-semibold text-text">{trajectoryStepTitle(step)}</span>
+								{#if step.status}
+									<span class="rounded bg-bg/60 px-1.5 py-0.5 text-[10px] text-text-muted">{step.status}</span>
+								{/if}
+							</div>
+							{#if body}
+								<pre class="max-h-44 overflow-y-auto whitespace-pre-wrap break-words border-t border-border/40 px-3 py-2 text-xs text-text-secondary">{body}</pre>
+							{/if}
+						</div>
+					{/each}
+				</div>
+			</details>
+		{/if}
+	</div>
+</div>

--- a/viewer/src/lib/export/ExportSeedDetail.svelte
+++ b/viewer/src/lib/export/ExportSeedDetail.svelte
@@ -16,6 +16,7 @@
 		getVerdictFlag,
 		multiJudgeDimensionAgreementLabel
 	} from '$lib/judgment.js';
+	import { judgeDimensionLabel } from '$lib/labels.js';
 
 	let {
 		item,
@@ -33,7 +34,7 @@
 	let multiJudge = $derived(item.multi_judge as MultiJudge | undefined);
 
 	function metricLabel(metric: string): string {
-		return metric.replace(/_/g, ' ');
+		return judgeDimensionLabel(metric);
 	}
 	function metricOutcomeText(flag: boolean | null): string {
 		if (flag === null) return 'n/a';

--- a/viewer/src/lib/export/ExportSeedDetail.svelte
+++ b/viewer/src/lib/export/ExportSeedDetail.svelte
@@ -27,10 +27,10 @@
 		primaryMetric: string;
 	} = $props();
 
-	const verdict = (item.verdict as Verdict | null | undefined) ?? null;
-	const judgeError = getJudgeError(item);
-	const isJudgeFailed = item.judge_status === 'judge_failed';
-	const multiJudge = item.multi_judge as MultiJudge | undefined;
+	let verdict = $derived((item.verdict as Verdict | null | undefined) ?? null);
+	let judgeError = $derived(getJudgeError(item));
+	let isJudgeFailed = $derived(item.judge_status === 'judge_failed');
+	let multiJudge = $derived(item.multi_judge as MultiJudge | undefined);
 
 	function metricLabel(metric: string): string {
 		return metric.replace(/_/g, ' ');
@@ -144,12 +144,12 @@
 		}
 		return views;
 	}
-	const judgeViews = buildJudgeViews();
-	const hasMultipleJudges = (multiJudge?.verdicts?.length ?? 0) > 1;
+	let judgeViews = $derived(buildJudgeViews());
+	let hasMultipleJudges = $derived((multiJudge?.verdicts?.length ?? 0) > 1);
 
-	const verdictCitations: AuditCitation[] = Array.isArray(verdict?.citations)
+	let verdictCitations: AuditCitation[] = $derived(Array.isArray(verdict?.citations)
 		? (verdict?.citations as AuditCitation[])
-		: [];
+		: []);
 </script>
 
 <div class="grid gap-5 lg:grid-cols-5">

--- a/viewer/src/lib/judgment.ts
+++ b/viewer/src/lib/judgment.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { DimensionDef, JudgeStatus } from './types.js';
+import type { DimensionDef, JudgeStatus, MultiJudge } from './types.js';
 
 type VerdictLike = Record<string, unknown> | null | undefined;
 
@@ -98,4 +98,55 @@ export function scoreSortValue(record: JudgmentRecordLike, metric: string): numb
 	const value = getRecordFlag(record, metric);
 	if (value === null) return 2;
 	return value ? 0 : 1;
+}
+
+function votesForMetric(
+	multiJudge: MultiJudge | null | undefined,
+	metric: string
+): boolean[] {
+	return multiJudge?.votes?.[metric] ?? [];
+}
+
+function agreementForVotes(votes: boolean[]): number | null {
+	if (votes.length === 0) return null;
+	const trueCount = votes.filter(Boolean).length;
+	const falseCount = votes.length - trueCount;
+	return Math.max(trueCount, falseCount) / votes.length;
+}
+
+export function multiJudgeMeanAgreement(
+	multiJudge: MultiJudge | null | undefined,
+	metrics?: string[]
+): number | null {
+	if (!multiJudge) return null;
+	const names = metrics && metrics.length > 0 ? metrics : Object.keys(multiJudge.votes ?? {});
+	const agreements = names.flatMap((metric) => {
+		const agreement = agreementForVotes(votesForMetric(multiJudge, metric));
+		return agreement == null ? [] : [agreement];
+	});
+	if (agreements.length > 0) {
+		return agreements.reduce((sum, agreement) => sum + agreement, 0) / agreements.length;
+	}
+	return typeof multiJudge.agreement === 'number' && Number.isFinite(multiJudge.agreement)
+		? multiJudge.agreement
+		: null;
+}
+
+export function multiJudgeHasDisagreement(
+	multiJudge: MultiJudge | null | undefined,
+	metrics?: string[]
+): boolean {
+	const meanAgreement = multiJudgeMeanAgreement(multiJudge, metrics);
+	return meanAgreement != null && meanAgreement < 1;
+}
+
+export function multiJudgeDimensionAgreementLabel(
+	multiJudge: MultiJudge | null | undefined,
+	metric: string
+): string | null {
+	const votes = votesForMetric(multiJudge, metric);
+	if (votes.length === 0) return null;
+	const trueCount = votes.filter(Boolean).length;
+	const agreeingSamples = Math.max(trueCount, votes.length - trueCount);
+	return `${agreeingSamples}/${votes.length} agree`;
 }

--- a/viewer/src/lib/labels.ts
+++ b/viewer/src/lib/labels.ts
@@ -1,0 +1,9 @@
+export function judgeDimensionLabel(metric: string): string {
+	if (metric === 'policy_violation') return 'Behavior violation';
+	return metric.replace(/_/g, ' ');
+}
+
+export function titleCaseJudgeDimensionLabel(metric: string): string {
+	const label = judgeDimensionLabel(metric);
+	return label.charAt(0).toUpperCase() + label.slice(1).toLowerCase();
+}

--- a/viewer/src/lib/outcome-plot.ts
+++ b/viewer/src/lib/outcome-plot.ts
@@ -1,0 +1,170 @@
+import { getRecordFlag } from './judgment.js';
+import type { Behavior, NodeJudgment } from './types.js';
+
+export type OutcomeKind = 'dimension' | 'behavior';
+
+export interface SelectableOutcome {
+	id: string;
+	kind: OutcomeKind;
+	key: string;
+	label: string;
+	groupLabel: string;
+	denominatorLabel: string;
+}
+
+export interface OutcomePlotRow {
+	dimension: string;
+	level: string;
+	n: number;
+	flagged: number;
+	rate: number;
+	ciLow: number;
+	ciHigh: number;
+}
+
+export interface OutcomeRecord {
+	verdict?: Record<string, unknown> | null;
+	dimensions?: Record<string, string>;
+}
+
+function outcomeId(kind: OutcomeKind, key: string): string {
+	return `${kind}:${encodeURIComponent(key)}`;
+}
+
+function readDimensionNames(items: OutcomeRecord[]): string[] {
+	const names = new Set<string>();
+	for (const item of items) {
+		const dimensions = item.verdict?.dimensions;
+		if (!dimensions || typeof dimensions !== 'object' || Array.isArray(dimensions)) continue;
+		for (const [name, value] of Object.entries(dimensions)) {
+			if (typeof value === 'boolean') names.add(name);
+		}
+	}
+	return [...names].sort((left, right) => {
+		if (left === 'policy_violation') return -1;
+		if (right === 'policy_violation') return 1;
+		return left.localeCompare(right);
+	});
+}
+
+function readObservedBehaviorNames(items: OutcomeRecord[]): Set<string> {
+	const names = new Set<string>();
+	for (const item of items) {
+		const nodeJudgments = item.verdict?.node_judgments;
+		if (!Array.isArray(nodeJudgments)) continue;
+		for (const node of nodeJudgments as NodeJudgment[]) {
+			const name = node.node_name?.trim();
+			if (name) names.add(name);
+		}
+	}
+	return names;
+}
+
+export function buildOutcomeOptions(
+	items: OutcomeRecord[],
+	behaviorCategories: Behavior[] = []
+): SelectableOutcome[] {
+	const dimensionOptions = readDimensionNames(items).map((name) => ({
+		id: outcomeId('dimension', name),
+		kind: 'dimension' as const,
+		key: name,
+		label: name.replace(/_/g, ' '),
+		groupLabel: 'Judge dimensions',
+		denominatorLabel: 'scored'
+	}));
+
+	const observedBehaviorNames = readObservedBehaviorNames(items);
+	const behaviorNames = new Set<string>();
+	for (const behavior of behaviorCategories) behaviorNames.add(behavior.name);
+	for (const name of [...observedBehaviorNames].sort((a, b) => a.localeCompare(b))) {
+		behaviorNames.add(name);
+	}
+
+	const behaviorOptions = [...behaviorNames].map((name) => ({
+		id: outcomeId('behavior', name),
+		kind: 'behavior' as const,
+			key: name,
+			label: name,
+			groupLabel: 'Behavior categories',
+			denominatorLabel: 'assessed relevant'
+		}));
+
+	return [...dimensionOptions, ...behaviorOptions];
+}
+
+export function wilsonInterval(flagged: number, n: number): { low: number; high: number } {
+	if (n <= 0) return { low: 0, high: 0 };
+	const z = 1.959963984540054;
+	const z2 = z * z;
+	const p = flagged / n;
+	const denom = 1 + z2 / n;
+	const center = (p + z2 / (2 * n)) / denom;
+	const half = (z * Math.sqrt((p * (1 - p) + z2 / (4 * n)) / n)) / denom;
+	return { low: Math.max(0, center - half), high: Math.min(1, center + half) };
+}
+
+function behaviorFlag(item: OutcomeRecord, behaviorName: string): boolean | null {
+	const nodeJudgments = item.verdict?.node_judgments;
+	if (!Array.isArray(nodeJudgments)) return null;
+	for (const node of nodeJudgments as NodeJudgment[]) {
+		if (node.node_name !== behaviorName || node.relevant !== true) continue;
+		return typeof node.violated === 'boolean' ? node.violated : null;
+	}
+	return null;
+}
+
+function outcomeFlag(item: OutcomeRecord, outcome: SelectableOutcome): boolean | null {
+	if (outcome.kind === 'dimension') return getRecordFlag(item, outcome.key);
+	return behaviorFlag(item, outcome.key);
+}
+
+function rateRow(dimension: string, level: string, items: OutcomeRecord[], outcome: SelectableOutcome): OutcomePlotRow {
+	let n = 0;
+	let flagged = 0;
+	for (const item of items) {
+		const flag = outcomeFlag(item, outcome);
+		if (flag === null) continue;
+		n += 1;
+		if (flag) flagged += 1;
+	}
+	const interval = wilsonInterval(flagged, n);
+	return {
+		dimension,
+		level,
+		n,
+		flagged,
+		rate: n > 0 ? flagged / n : 0,
+		ciLow: interval.low,
+		ciHigh: interval.high
+	};
+}
+
+export function buildOutcomePlotRows(
+	items: OutcomeRecord[],
+	outcome: SelectableOutcome
+): OutcomePlotRow[] {
+	const rows = [rateRow('Overall', 'All results', items, outcome)];
+	const dimensionNames = new Set<string>();
+	for (const item of items) {
+		for (const name of Object.keys(item.dimensions ?? {})) dimensionNames.add(name);
+	}
+
+	for (const dimension of [...dimensionNames].sort((a, b) => a.localeCompare(b))) {
+		const levels = new Set<string>();
+		for (const item of items) {
+			const level = item.dimensions?.[dimension];
+			if (level) levels.add(level);
+		}
+		for (const level of [...levels].sort((a, b) => a.localeCompare(b))) {
+			const row = rateRow(
+				dimension,
+				level,
+				items.filter((item) => item.dimensions?.[dimension] === level),
+				outcome
+			);
+			if (row.n > 0) rows.push(row);
+		}
+	}
+
+	return rows;
+}

--- a/viewer/src/lib/result-view.ts
+++ b/viewer/src/lib/result-view.ts
@@ -9,6 +9,7 @@ import type {
 	LlmCallTrace,
 	ScenarioSeedInfo,
 	StopReasonDisplay,
+	TrajectoryRow,
 	ViewerResultItem
 } from '$lib/types.js';
 
@@ -214,6 +215,7 @@ export function normalizePromptResult(sample: JudgedSample): ViewerResultItem {
 		multi_judge: sample.multi_judge,
 		messages,
 		llm_calls: sample.llm_calls ?? [],
+		trajectory: sample.trajectory ?? null,
 		target_runtime_mode: sample.target_runtime_mode ?? null,
 		dimensions: sample.dimensions,
 		context: {
@@ -227,7 +229,8 @@ export function normalizeScenarioResult(
 	score: AuditScore,
 	messages: AuditTranscriptMessage[],
 	llmCalls: LlmCallTrace[],
-	seedInfo: ScenarioSeedInfo | undefined
+	seedInfo: ScenarioSeedInfo | undefined,
+	trajectory: TrajectoryRow | null = null
 ): ViewerResultItem {
 	const interactionMessages = toInteractionMessages(messages);
 	return {
@@ -242,6 +245,7 @@ export function normalizeScenarioResult(
 		multi_judge: score.multi_judge,
 		messages: interactionMessages,
 		llm_calls: llmCalls,
+		trajectory,
 		target_runtime_mode: score.target_runtime_mode ?? null,
 		dimensions: score.dimensions ?? seedInfo?.dimensions,
 		context: {

--- a/viewer/src/lib/server/artifacts.ts
+++ b/viewer/src/lib/server/artifacts.ts
@@ -10,6 +10,7 @@ import type { Manifest, Taxonomy, Suite } from '$lib/types.js';
 
 export const SUITE_TEST_SET_FILE = 'test_set.jsonl';
 export const RUN_INFERENCE_SET_FILE = 'inference_set.jsonl';
+export const RUN_TRAJECTORIES_FILE = 'trajectories.jsonl';
 export const RUN_SCORES_FILE = 'scores.jsonl';
 export const RUN_CONFIG_FILE = 'config.yaml';
 export const RUN_MANIFEST_FILE = 'manifest.json';
@@ -56,6 +57,18 @@ export type UnifiedScoreRow = Record<string, unknown> & {
 	judge_error?: unknown;
 	target?: unknown;
 	tester_model?: unknown;
+	dimensions?: unknown;
+};
+
+export type UnifiedTrajectoryRow = Record<string, unknown> & {
+	type?: unknown;
+	kind?: unknown;
+	test_case_id?: unknown;
+	steps?: unknown;
+	stop_reason?: unknown;
+	target?: unknown;
+	target_runtime_mode?: unknown;
+	metadata?: unknown;
 	dimensions?: unknown;
 };
 
@@ -767,6 +780,22 @@ export async function loadRunTranscriptRow(
 			});
 }
 
+export async function loadRunTrajectoryRow(
+	suiteId: string,
+	runId: string,
+	seedId: string,
+	kind: 'prompt' | 'scenario'
+): Promise<UnifiedTrajectoryRow | null> {
+	const seedMatcher = buildJsonStringFieldMatcher('test_case_id', seedId);
+	const typeMatcher = buildJsonStringFieldMatcher('type', kind);
+	const kindMatcher = buildJsonStringFieldMatcher('kind', kind);
+	const lineMatcher = (line: string) => seedMatcher(line) && (typeMatcher(line) || kindMatcher(line));
+	return readJsonlMatchingRow<UnifiedTrajectoryRow>(path.join(runDirPath(suiteId, runId), RUN_TRAJECTORIES_FILE), {
+		missingOk: true,
+		lineMatcher
+	});
+}
+
 export async function loadRunScoreRow(
 	suiteId: string,
 	runId: string,
@@ -814,4 +843,3 @@ export function loadIndexedRunScoreRow(
 		entry.length
 	);
 }
-

--- a/viewer/src/lib/server/csv.ts
+++ b/viewer/src/lib/server/csv.ts
@@ -1,0 +1,44 @@
+/**
+ * CSV serialization helpers — RFC 4180 compliant, zero dependencies.
+ */
+
+const FORMULA_PREFIXES = new Set(['=', '+', '-', '@', '\t', '|']);
+
+/** Escape a single cell value for CSV. */
+export function escapeCell(value: unknown): string {
+	if (value == null) return '';
+	let str = String(value);
+	// Neutralize CSV formula injection
+	if (str.length > 0 && FORMULA_PREFIXES.has(str[0])) {
+		str = "'" + str;
+	}
+	if (str.includes('"') || str.includes(',') || str.includes('\n') || str.includes('\r')) {
+		return `"${str.replace(/"/g, '""')}"`;
+	}
+	return str;
+}
+
+/** Serialize rows into a CSV string with a header row and UTF-8 BOM. */
+export function toCsv(columns: string[], rows: Record<string, unknown>[]): string {
+	const header = columns.map(escapeCell).join(',');
+	const body = rows.map((row) => columns.map((col) => escapeCell(row[col])).join(',')).join('\n');
+	return '\uFEFF' + header + '\n' + body + '\n';
+}
+
+/** Sanitize a filename component by stripping control characters and path separators. */
+function sanitizeFilename(name: string): string {
+	return name.replace(/[^\w.@()-]/g, '_');
+}
+
+/** Build a Response with CSV content-disposition headers. */
+export function csvResponse(filename: string, columns: string[], rows: Record<string, unknown>[]): Response {
+	const csv = toCsv(columns, rows);
+	const safeName = sanitizeFilename(filename);
+	return new Response(csv, {
+		headers: {
+			'Content-Type': 'text/csv; charset=utf-8',
+			'Content-Disposition': `attachment; filename="${safeName}"`,
+			'Content-Length': String(new TextEncoder().encode(csv).byteLength)
+		}
+	});
+}

--- a/viewer/src/lib/server/data.ts
+++ b/viewer/src/lib/server/data.ts
@@ -13,11 +13,13 @@ import {
 	loadRunJudgeTaxonomyFromArtifacts,
 	loadRunRuntimeMode,
 	loadRunScoreRow,
+	loadRunTrajectoryRow,
 	loadRunTranscriptRow,
 	type RunSnapshot,
 	type SuiteSnapshot,
 	type UnifiedSeedRow,
 	type UnifiedScoreRow,
+	type UnifiedTrajectoryRow,
 	type UnifiedTranscriptRow,
 	loadViewerRunIndexes,
 	loadViewerRunReadModel,
@@ -59,6 +61,7 @@ import type {
 	SuiteListItem,
 	SuiteStatus,
 	Behavior,
+	TrajectoryRow,
 	ViewerResultItem
 } from '$lib/types.js';
 
@@ -245,6 +248,36 @@ function normalizeAuditTranscript(transcript: AuditTranscript): AuditTranscript 
 		...transcript,
 		behavior: readRowBehavior(transcript),
 		dimensions: readFactors(transcript.dimensions)
+	};
+}
+
+function normalizeTrajectoryRow(row: UnifiedTrajectoryRow | null | undefined): TrajectoryRow | null {
+	const kind = row?.type ?? row?.kind;
+	if (!row || (kind !== 'prompt' && kind !== 'scenario') || typeof row.test_case_id !== 'string') {
+		return null;
+	}
+	const metadata = readObject(row.metadata);
+	const steps = Array.isArray(row.steps)
+		? row.steps
+				.filter((step) => readObject(step) !== null)
+				.map((step) => step as TrajectoryRow['steps'][number])
+		: [];
+	return {
+		kind,
+		test_case_id: row.test_case_id,
+		behavior: typeof row.behavior === 'string' ? row.behavior : null,
+		target: typeof row.target === 'string' ? row.target : null,
+		target_runtime_mode:
+			typeof row.target_runtime_mode === 'string'
+				? row.target_runtime_mode
+				: typeof metadata?.target_runtime_mode === 'string'
+					? metadata.target_runtime_mode
+					: null,
+		interaction: typeof row.interaction === 'string' ? row.interaction : null,
+		stop_reason: typeof row.stop_reason === 'string' ? row.stop_reason : null,
+		steps,
+		metadata: metadata ?? undefined,
+		dimensions: readFactors(row.dimensions)
 	};
 }
 
@@ -450,7 +483,8 @@ function buildJudgedSampleRow(
 	runtimeMode: string | null,
 	seedRow: UnifiedSeedRow | undefined,
 	scoreRow: UnifiedScoreRow,
-	transcriptRow: UnifiedTranscriptRow | undefined
+	transcriptRow: UnifiedTranscriptRow | undefined,
+	trajectoryRow?: UnifiedTrajectoryRow | null
 ): JudgedSample {
 	const seedMetadata = readSeedPayload(seedRow);
 	const messages = transcriptRow ? materializeTargetMessages(transcriptRow) : [];
@@ -484,6 +518,7 @@ function buildJudgedSampleRow(
 		judge_error: typeof scoreRow.judge_error === 'string' ? scoreRow.judge_error : null,
 		messages,
 		llm_calls: readLlmCalls(transcriptRow?.llm_calls),
+		trajectory: normalizeTrajectoryRow(trajectoryRow),
 		target_runtime_mode: runtimeMode,
 		dimensions: readFactors(scoreRow.dimensions) ?? readFactors(transcriptRow?.dimensions) ?? readFactors(seedRow?.dimensions),
 		multi_judge:
@@ -624,7 +659,8 @@ function buildScenarioDrawerItem(
 	runtimeMode: string | null,
 	transcriptRow: UnifiedTranscriptRow,
 	scoreRow: UnifiedScoreRow | undefined,
-	seedInfo: ScenarioSeedInfo | undefined
+	seedInfo: ScenarioSeedInfo | undefined,
+	trajectoryRow?: UnifiedTrajectoryRow | null
 ): ViewerResultItem | null {
 	const seedId = typeof transcriptRow.test_case_id === 'string' ? transcriptRow.test_case_id : '';
 	if (!seedId) return null;
@@ -657,7 +693,8 @@ function buildScenarioDrawerItem(
 		score,
 		materializeTargetMessages(transcriptRow),
 		readLlmCalls(transcriptRow.llm_calls),
-		seedInfo
+		seedInfo,
+		normalizeTrajectoryRow(trajectoryRow)
 	);
 }
 
@@ -1384,7 +1421,7 @@ function findSeedRowById(seedRows: UnifiedSeedRow[], seedId: string): UnifiedSee
 	return seedRows.find((row) => row.test_case_id === seedId);
 }
 
-function loadPromptDrawerItemFromReadModel(suiteId: string, runId: string, seedId: string) {
+async function loadPromptDrawerItemFromReadModel(suiteId: string, runId: string, seedId: string) {
 	const suiteSnapshot = loadSuiteSnapshot(suiteId);
 	const viewerReadModel = loadViewerRunIndexes(suiteId, runId);
 	const transcriptRow = loadIndexedRunTranscriptRow(
@@ -1396,22 +1433,25 @@ function loadPromptDrawerItemFromReadModel(suiteId: string, runId: string, seedI
 	);
 	const scoreRow = loadIndexedRunScoreRow(suiteId, runId, viewerReadModel.scoreIndex, seedId, 'prompt');
 	if (!transcriptRow || !scoreRow) return null;
+	const trajectoryRow = await loadRunTrajectoryRow(suiteId, runId, seedId, 'prompt');
 
 	const sample = buildJudgedSampleRow(
 		runId,
 		loadRuntimeModeForRun(suiteId, runId),
 		findSeedRowById(suiteSnapshot?.seedRows ?? [], seedId),
 		scoreRow,
-		transcriptRow
+		transcriptRow,
+		trajectoryRow
 	);
 	return normalizePromptResult(sample);
 }
 
 async function loadPromptDrawerItemFromCanonical(suiteId: string, runId: string, seedId: string) {
 	const suiteSnapshot = loadSuiteSnapshot(suiteId);
-	const [transcriptRow, scoreRow] = await Promise.all([
+	const [transcriptRow, scoreRow, trajectoryRow] = await Promise.all([
 		loadRunTranscriptRow(suiteId, runId, seedId, 'prompt'),
-		loadRunScoreRow(suiteId, runId, seedId, 'prompt')
+		loadRunScoreRow(suiteId, runId, seedId, 'prompt'),
+		loadRunTrajectoryRow(suiteId, runId, seedId, 'prompt')
 	]);
 	if (!transcriptRow) return null;
 	if (!scoreRow) return null;
@@ -1421,12 +1461,13 @@ async function loadPromptDrawerItemFromCanonical(suiteId: string, runId: string,
 		loadRuntimeModeForRun(suiteId, runId),
 		findSeedRowById(suiteSnapshot?.seedRows ?? [], seedId),
 		scoreRow,
-		transcriptRow
+		transcriptRow,
+		trajectoryRow
 	);
 	return normalizePromptResult(sample);
 }
 
-function loadScenarioDrawerItemFromReadModel(suiteId: string, runId: string, seedId: string) {
+async function loadScenarioDrawerItemFromReadModel(suiteId: string, runId: string, seedId: string) {
 	const suiteSnapshot = loadSuiteSnapshot(suiteId);
 	const viewerReadModel = loadViewerRunIndexes(suiteId, runId);
 	const transcriptRow = loadIndexedRunTranscriptRow(
@@ -1438,6 +1479,7 @@ function loadScenarioDrawerItemFromReadModel(suiteId: string, runId: string, see
 	);
 	const scoreRow = loadIndexedRunScoreRow(suiteId, runId, viewerReadModel.scoreIndex, seedId, 'scenario');
 	if (!transcriptRow || !scoreRow) return null;
+	const trajectoryRow = await loadRunTrajectoryRow(suiteId, runId, seedId, 'scenario');
 
 	const auditScore = buildAuditScoreRow(loadRuntimeModeForRun(suiteId, runId), scoreRow, transcriptRow);
 	const scenarioSeeds = buildScenarioSeeds(suiteSnapshot);
@@ -1445,14 +1487,15 @@ function loadScenarioDrawerItemFromReadModel(suiteId: string, runId: string, see
 		auditScore,
 		materializeTargetMessages(transcriptRow),
 		readLlmCalls(transcriptRow.llm_calls),
-		buildScenarioSeedInfo(scenarioSeeds, seedId, [])
+		buildScenarioSeedInfo(scenarioSeeds, seedId, []),
+		normalizeTrajectoryRow(trajectoryRow)
 	);
 }
 
 export async function loadPromptDrawerItem(suiteId: string, runId: string, seedId: string) {
 	if (hasCompletedJudge(loadRunManifestRecord(suiteId, runId))) {
 		try {
-			return loadPromptDrawerItemFromReadModel(suiteId, runId, seedId);
+			return await loadPromptDrawerItemFromReadModel(suiteId, runId, seedId);
 		} catch (err) {
 			if (!(err instanceof ViewerReadModelError)) throw err;
 		}
@@ -1463,16 +1506,17 @@ export async function loadPromptDrawerItem(suiteId: string, runId: string, seedI
 export async function loadScenarioDrawerItem(suiteId: string, runId: string, seedId: string) {
 	if (hasCompletedJudge(loadRunManifestRecord(suiteId, runId))) {
 		try {
-			return loadScenarioDrawerItemFromReadModel(suiteId, runId, seedId);
+			return await loadScenarioDrawerItemFromReadModel(suiteId, runId, seedId);
 		} catch (err) {
 			if (!(err instanceof ViewerReadModelError)) throw err;
 		}
 	}
 
 	const suiteSnapshot = loadSuiteSnapshot(suiteId);
-	const [transcriptRow, matchedScoreRow] = await Promise.all([
+	const [transcriptRow, matchedScoreRow, trajectoryRow] = await Promise.all([
 		loadRunTranscriptRow(suiteId, runId, seedId, 'scenario'),
-		loadRunScoreRow(suiteId, runId, seedId, 'scenario')
+		loadRunScoreRow(suiteId, runId, seedId, 'scenario'),
+		loadRunTrajectoryRow(suiteId, runId, seedId, 'scenario')
 	]);
 	if (!transcriptRow) return null;
 
@@ -1486,7 +1530,8 @@ export async function loadScenarioDrawerItem(suiteId: string, runId: string, see
 			scenarioSeeds,
 			seedId,
 			matchedScoreRow ? [buildAuditScoreRow(runtimeMode, matchedScoreRow, transcriptRow)] : []
-		)
+		),
+		trajectoryRow
 	);
 }
 

--- a/viewer/src/lib/server/export-css.ts
+++ b/viewer/src/lib/server/export-css.ts
@@ -1,0 +1,79 @@
+/**
+ * Resolve the viewer's compiled CSS so we can inline it in the standalone
+ * export HTML. Works in both `vite dev` and `vite build` because we just
+ * grab the live page over a SvelteKit-internal fetch and follow whatever
+ * `<link rel="stylesheet">` and `<style>` tags it advertises.
+ *
+ * The export HTML is meant to open offline, so we resolve the URLs to
+ * actual CSS text and bundle them into a single `<style>` block.
+ */
+
+const CACHE = new Map<string, { css: string; loadedAt: number }>();
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+export async function loadInlineCss(fetch: typeof globalThis.fetch): Promise<string> {
+	const cacheKey = 'root';
+	const cached = CACHE.get(cacheKey);
+	if (cached && Date.now() - cached.loadedAt < CACHE_TTL_MS) {
+		return cached.css;
+	}
+
+	const css = await resolveCss(fetch);
+	CACHE.set(cacheKey, { css, loadedAt: Date.now() });
+	return css;
+}
+
+async function resolveCss(fetch: typeof globalThis.fetch): Promise<string> {
+	let pageHtml: string;
+	try {
+		const res = await fetch('/');
+		if (!res.ok) {
+			console.warn(`[export-css] root page fetch returned ${res.status}`);
+			return '';
+		}
+		pageHtml = await res.text();
+	} catch (err) {
+		console.warn('[export-css] failed to fetch root page:', err);
+		return '';
+	}
+
+	const styleHrefs = extractStylesheetHrefs(pageHtml);
+	const inlineStyles = extractInlineStyles(pageHtml);
+
+	const fetched: string[] = [];
+	for (const href of styleHrefs) {
+		try {
+			const res = await fetch(href);
+			if (!res.ok) {
+				console.warn(`[export-css] stylesheet ${href} returned ${res.status}`);
+				continue;
+			}
+			fetched.push(`/* ${href} */\n${await res.text()}`);
+		} catch (err) {
+			console.warn(`[export-css] failed to fetch stylesheet ${href}:`, err);
+		}
+	}
+
+	return [...fetched, ...inlineStyles].join('\n\n');
+}
+
+function extractStylesheetHrefs(html: string): string[] {
+	const hrefs: string[] = [];
+	const linkRe = /<link\b[^>]*>/gi;
+	for (const match of html.matchAll(linkRe)) {
+		const tag = match[0];
+		if (!/rel\s*=\s*["']?stylesheet["']?/i.test(tag)) continue;
+		const hrefMatch = tag.match(/href\s*=\s*["']([^"']+)["']/i);
+		if (hrefMatch) hrefs.push(hrefMatch[1]);
+	}
+	return hrefs;
+}
+
+function extractInlineStyles(html: string): string[] {
+	const styles: string[] = [];
+	const styleRe = /<style\b[^>]*>([\s\S]*?)<\/style>/gi;
+	for (const match of html.matchAll(styleRe)) {
+		styles.push(match[1]);
+	}
+	return styles;
+}

--- a/viewer/src/lib/server/export-css.ts
+++ b/viewer/src/lib/server/export-css.ts
@@ -11,19 +11,19 @@
 const CACHE = new Map<string, { css: string; loadedAt: number }>();
 const CACHE_TTL_MS = 5 * 60 * 1000;
 
-export async function loadInlineCss(fetch: typeof globalThis.fetch): Promise<string> {
+export async function loadInlineCss(fetch: typeof globalThis.fetch, origin?: string): Promise<string> {
 	const cacheKey = 'root';
 	const cached = CACHE.get(cacheKey);
 	if (cached && Date.now() - cached.loadedAt < CACHE_TTL_MS) {
 		return cached.css;
 	}
 
-	const css = await resolveCss(fetch);
+	const css = await resolveCss(fetch, origin);
 	CACHE.set(cacheKey, { css, loadedAt: Date.now() });
 	return css;
 }
 
-async function resolveCss(fetch: typeof globalThis.fetch): Promise<string> {
+async function resolveCss(fetch: typeof globalThis.fetch, origin?: string): Promise<string> {
 	let pageHtml: string;
 	try {
 		const res = await fetch('/');
@@ -41,20 +41,33 @@ async function resolveCss(fetch: typeof globalThis.fetch): Promise<string> {
 	const inlineStyles = extractInlineStyles(pageHtml);
 
 	const fetched: string[] = [];
-	for (const href of styleHrefs) {
+	for (const href of styleHrefs.map(normalizeStylesheetHref)) {
+		const fetchUrl = toFetchUrl(href, origin);
+		const fetchAsset = origin ? globalThis.fetch : fetch;
 		try {
-			const res = await fetch(href);
+			const res = await fetchAsset(fetchUrl);
 			if (!res.ok) {
-				console.warn(`[export-css] stylesheet ${href} returned ${res.status}`);
+				console.warn(`[export-css] stylesheet ${fetchUrl} returned ${res.status}`);
 				continue;
 			}
 			fetched.push(`/* ${href} */\n${await res.text()}`);
 		} catch (err) {
-			console.warn(`[export-css] failed to fetch stylesheet ${href}:`, err);
+			console.warn(`[export-css] failed to fetch stylesheet ${fetchUrl}:`, err);
 		}
 	}
 
 	return [...fetched, ...inlineStyles].join('\n\n');
+}
+
+function normalizeStylesheetHref(href: string): string {
+	if (href.startsWith('./')) return `/${href.slice(2)}`;
+	if (href.startsWith('_app/')) return `/${href}`;
+	return href;
+}
+
+function toFetchUrl(href: string, origin?: string): string {
+	if (!origin || !href.startsWith('/')) return href;
+	return new URL(href, origin).toString();
 }
 
 function extractStylesheetHrefs(html: string): string[] {

--- a/viewer/src/lib/trajectory-view.ts
+++ b/viewer/src/lib/trajectory-view.ts
@@ -1,0 +1,193 @@
+import type { TrajectoryRow, TrajectoryStep } from '$lib/types.js';
+
+export interface TrajectoryTraceItem {
+	kind: 'message' | 'evidence';
+	step: TrajectoryStep;
+}
+
+export interface TrajectoryTraceGroup {
+	id: string;
+	label: string;
+	messages: TrajectoryStep[];
+	evidence: TrajectoryStep[];
+	items: TrajectoryTraceItem[];
+}
+
+function isTranscriptMessageStep(step: TrajectoryStep): boolean {
+	return (step.type === 'message' || step.type === 'system') && Boolean(step.message_id || step.event_id);
+}
+
+function trajectoryActorKey(step: TrajectoryStep): string {
+	return String(step.actor || step.role || step.type).toLowerCase();
+}
+
+export function trajectoryMessageLabel(step: TrajectoryStep): string {
+	const actor = trajectoryActorKey(step);
+	if (step.type === 'system' || actor === 'system') return 'System message';
+	if (actor === 'auditor' || actor === 'tester') return 'Tester message';
+	if (step.role === 'user') return 'User message';
+	if (actor === 'target') return 'Target response';
+	if (step.role === 'assistant') return 'Assistant response';
+	return `${actor || 'agent'} message`;
+}
+
+export function trajectoryGroupSummary(group: TrajectoryTraceGroup): string {
+	const parts: string[] = [];
+	if (group.messages.length) {
+		parts.push(`${group.messages.length} message${group.messages.length === 1 ? '' : 's'}`);
+	}
+	if (group.evidence.length) {
+		parts.push(`${group.evidence.length} evidence step${group.evidence.length === 1 ? '' : 's'}`);
+	}
+	return parts.join(' · ');
+}
+
+export function trajectoryStartsCollapsed(trajectory: Pick<TrajectoryRow, 'interaction' | 'target_runtime_mode'>): boolean {
+	void trajectory;
+	return true;
+}
+
+export function buildTrajectoryGroups(steps: TrajectoryStep[]): TrajectoryTraceGroup[] {
+	const groups: TrajectoryTraceGroup[] = [];
+	const messageGroups = new Map<string, TrajectoryTraceGroup>();
+	let currentExchange: TrajectoryTraceGroup | null = null;
+	let exchangeIndex = 0;
+
+	function registerMessage(group: TrajectoryTraceGroup, step: TrajectoryStep): void {
+		const messageKey = step.message_id || step.event_id;
+		if (messageKey) messageGroups.set(messageKey, group);
+	}
+
+	for (const step of steps) {
+		if (!isTranscriptMessageStep(step)) continue;
+		if (step.type === 'system') {
+			const setupGroup: TrajectoryTraceGroup = {
+				id: step.message_id || step.event_id || step.step_id || `setup:${groups.length}`,
+				label: 'Setup',
+				messages: [step],
+				evidence: [],
+				items: [{ kind: 'message', step }]
+			};
+			groups.push(setupGroup);
+			registerMessage(setupGroup, step);
+			currentExchange = null;
+			continue;
+		}
+
+		const actor = trajectoryActorKey(step);
+		const startsExchange =
+			currentExchange === null ||
+			actor === 'auditor' ||
+			actor === 'tester' ||
+			actor === 'user' ||
+			step.role === 'user';
+		let exchange: TrajectoryTraceGroup | null = currentExchange;
+		if (startsExchange || exchange === null) {
+			exchangeIndex += 1;
+			exchange = {
+				id: step.message_id || step.event_id || step.step_id || `exchange:${exchangeIndex}`,
+				label: `Exchange ${exchangeIndex}`,
+				messages: [],
+				evidence: [],
+				items: []
+			};
+			currentExchange = exchange;
+			groups.push(exchange);
+		}
+		exchange.messages.push(step);
+		exchange.items.push({ kind: 'message', step });
+		registerMessage(exchange, step);
+	}
+
+	const ungroupedEvidence: TrajectoryStep[] = [];
+	for (const step of steps) {
+		if (isTranscriptMessageStep(step)) continue;
+		const group = step.message_id ? messageGroups.get(step.message_id) : undefined;
+		if (group) addEvidenceToGroup(group, step, step.message_id);
+		else ungroupedEvidence.push(step);
+	}
+
+	const singleExchange = singleMessageExchange(groups);
+	if (singleExchange) {
+		for (const step of ungroupedEvidence) {
+			addEvidenceToGroup(singleExchange, step, assistantMessageId(singleExchange));
+		}
+		return groups;
+	}
+
+	if (ungroupedEvidence.length) {
+		const ordered = [...ungroupedEvidence].sort(compareTrajectorySteps);
+		groups.push({
+			id: `runtime-evidence:${groups.length}`,
+			label: 'Runtime evidence',
+			messages: [],
+			evidence: ordered,
+			items: ordered.map((step) => ({ kind: 'evidence', step }))
+		});
+	}
+	return groups;
+}
+
+export function buildInlineRuntimeEvidenceByMessageId(groups: TrajectoryTraceGroup[]): Map<string, TrajectoryStep[]> {
+	const result = new Map<string, TrajectoryStep[]>();
+	for (const group of groups) {
+		let pendingEvidence: TrajectoryStep[] = [];
+		for (const item of group.items) {
+			if (item.kind === 'evidence') {
+				pendingEvidence.push(item.step);
+				continue;
+			}
+			const key = messageKey(item.step);
+			if (key && pendingEvidence.length) {
+				const merged = [...(result.get(key) ?? []), ...pendingEvidence];
+				merged.sort(compareTrajectorySteps);
+				result.set(key, merged);
+			}
+			pendingEvidence = [];
+		}
+	}
+	return result;
+}
+
+function addEvidenceToGroup(group: TrajectoryTraceGroup, step: TrajectoryStep, beforeMessageId?: string | null): void {
+	group.evidence.push(step);
+	const insertionIndex = beforeMessageId
+		? group.items.findIndex((item) => item.kind === 'message' && messageKey(item.step) === beforeMessageId)
+		: -1;
+	if (insertionIndex >= 0) {
+		group.items.splice(insertionIndex, 0, { kind: 'evidence', step });
+		return;
+	}
+	group.items.push({ kind: 'evidence', step });
+}
+
+function messageKey(step: TrajectoryStep): string | undefined {
+	return step.message_id || step.event_id || undefined;
+}
+
+function compareTrajectorySteps(a: TrajectoryStep, b: TrajectoryStep): number {
+	// Use the monotonic capture-time `index` field. Falls back to step_id parsing
+	// (e.g. "step:7") so the ordering is still stable when index is missing.
+	const ai = typeof a.index === 'number' ? a.index : parseStepIdNumber(a.step_id);
+	const bi = typeof b.index === 'number' ? b.index : parseStepIdNumber(b.step_id);
+	if (ai !== bi) return ai - bi;
+	return 0;
+}
+
+function parseStepIdNumber(stepId: string | null | undefined): number {
+	if (!stepId) return Number.MAX_SAFE_INTEGER;
+	const match = /(\d+)/.exec(stepId);
+	return match ? Number(match[1]) : Number.MAX_SAFE_INTEGER;
+}
+
+function singleMessageExchange(groups: TrajectoryTraceGroup[]): TrajectoryTraceGroup | null {
+	const exchanges = groups.filter((group) => group.messages.some((step) => step.type === 'message'));
+	return exchanges.length === 1 ? exchanges[0] : null;
+}
+
+function assistantMessageId(group: TrajectoryTraceGroup): string | undefined {
+	const assistant = group.messages.find(
+		(step) => step.role === 'assistant' || (trajectoryActorKey(step) === 'target' && step.role !== 'user')
+	);
+	return assistant ? messageKey(assistant) : undefined;
+}

--- a/viewer/src/lib/types.ts
+++ b/viewer/src/lib/types.ts
@@ -186,6 +186,42 @@ export interface LlmCallTrace {
 	message_ids: string[];
 }
 
+export interface TrajectoryStep {
+	type: string;
+	actor: string;
+	index?: number | null;
+	step_id?: string | null;
+	parent_id?: string | null;
+	event_id?: string | null;
+	message_id?: string | null;
+	tool_call_id?: string | null;
+	llm_call_id?: string | null;
+	role?: string | null;
+	name?: string | null;
+	content?: string | null;
+	args?: Record<string, unknown>;
+	result?: unknown;
+	result_preview?: string | null;
+	status?: string | null;
+	raw?: Record<string, unknown> | null;
+	attributes?: Record<string, unknown>;
+	started_at?: string | null;
+	ended_at?: string | null;
+}
+
+export interface TrajectoryRow {
+	kind: 'prompt' | 'scenario';
+	test_case_id: string;
+	behavior?: string | null;
+	target?: string | null;
+	target_runtime_mode?: string | null;
+	interaction?: string | null;
+	stop_reason?: string | null;
+	steps: TrajectoryStep[];
+	metadata?: Record<string, unknown>;
+	dimensions?: SeedFactors;
+}
+
 export interface JudgedSample {
 	test_case_id?: string;
 	prompt: string;
@@ -201,6 +237,7 @@ export interface JudgedSample {
 	judge_error?: string | null;
 	messages?: InteractionMessage[];
 	llm_calls?: LlmCallTrace[];
+	trajectory?: TrajectoryRow | null;
 	target_runtime_mode?: string | null;
 	multi_judge?: MultiJudge;
 	dimensions?: SeedFactors;
@@ -226,6 +263,7 @@ export interface ViewerResultItem {
 	multi_judge?: MultiJudge;
 	messages: InteractionMessage[];
 	llm_calls: LlmCallTrace[];
+	trajectory?: TrajectoryRow | null;
 	target_runtime_mode?: string | null;
 	context: ViewerResultContext;
 	dimensions?: SeedFactors;

--- a/viewer/src/routes/+page.svelte
+++ b/viewer/src/routes/+page.svelte
@@ -74,7 +74,7 @@
 <div class="mb-6 flex items-start justify-between gap-3">
 	<div>
 		<h1 class="text-xl font-semibold tracking-tight">Evaluation suites</h1>
-		<p class="mt-0.5 text-sm text-text-muted">View evaluation test sets and results aligned to policy-defined behavior categories.</p>
+		<p class="mt-0.5 text-sm text-text-muted">View evaluation test sets and results aligned to taxonomy-defined behavior categories.</p>
 	</div>
 	<a
 		href="/new"

--- a/viewer/src/routes/+page.svelte
+++ b/viewer/src/routes/+page.svelte
@@ -162,7 +162,7 @@
 					{ value: 'runs', label: 'Most runs' }
 				]}
 				selected={sortBy}
-				onSelect={(v) => sortBy = v}
+				onSelect={(v) => sortBy = v as typeof sortBy}
 			/>
 		</div>
 		<span class="flex-shrink-0 text-[11px] text-text-muted">{filtered.length} suites</span>

--- a/viewer/src/routes/api/csv/[suite_id]/+server.ts
+++ b/viewer/src/routes/api/csv/[suite_id]/+server.ts
@@ -1,0 +1,305 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { error } from '@sveltejs/kit';
+import {
+	loadPolicy,
+	loadPromptSeeds,
+	loadScenarioSeeds,
+	listRuns,
+	listAuditRuns,
+	loadJudgedPrompts,
+	loadAuditScores,
+	loadAuditTranscripts
+} from '$lib/server/data.js';
+import { csvResponse } from '$lib/server/csv.js';
+import type { RequestHandler } from './$types.js';
+import type {
+	AuditScore,
+	AuditTranscript,
+	InteractionMessage,
+	JudgedSample,
+	PromptSeed,
+	ScenarioSeed
+} from '$lib/types.js';
+
+const SAFE_ID = /^[\w.@()-]+$/;
+
+function detectScoreDimensions(verdicts: Array<Record<string, unknown> | null | undefined>): string[] {
+	const dimensions = new Set<string>();
+	for (const verdict of verdicts) {
+		if (!verdict) continue;
+		if (verdict.dimensions && typeof verdict.dimensions === 'object' && !Array.isArray(verdict.dimensions)) {
+			for (const key of Object.keys(verdict.dimensions)) dimensions.add(key);
+		}
+		for (const [key, value] of Object.entries(verdict)) {
+			if (
+				key === 'dimensions' ||
+				key === 'justification' ||
+				key === 'confidence' ||
+				key === 'citations' ||
+				key.endsWith('_justification')
+			) {
+				continue;
+			}
+			if ((typeof value === 'number' && value >= 1 && value <= 3) || typeof value === 'boolean') {
+				dimensions.add(key);
+			}
+		}
+		if (dimensions.size > 0) break;
+	}
+	return [...dimensions].sort();
+}
+
+function detectVariations(items: Array<{ dimensions?: Record<string, string> }>): string[] {
+	const dimensions = new Set<string>();
+	for (const item of items) {
+		for (const key of Object.keys(item.dimensions ?? {})) dimensions.add(key);
+	}
+	return [...dimensions].sort();
+}
+
+function dimensionValue(verdict: Record<string, unknown> | null | undefined, dimension: string): unknown {
+	const dimensions = verdict?.dimensions;
+	if (dimensions && typeof dimensions === 'object' && !Array.isArray(dimensions) && dimension in dimensions) {
+		return (dimensions as Record<string, unknown>)[dimension];
+	}
+	return verdict?.[dimension] ?? '';
+}
+
+function verdictJustification(verdict: Record<string, unknown> | null | undefined): string {
+	return typeof verdict?.justification === 'string' ? verdict.justification : '';
+}
+
+function formatMessages(messages: InteractionMessage[] | undefined): string {
+	if (!messages?.length) return '';
+	return messages
+		.map((message) => {
+			const role = message.role.toUpperCase();
+			if (message.tool_calls?.length) {
+				const calls = message.tool_calls
+					.map((toolCall) => `${toolCall.function}(${JSON.stringify(toolCall.arguments)})`)
+					.join('; ');
+				return `[${role}]: ${message.content || ''}\n  tool_calls: ${calls}`;
+			}
+			if (message.role === 'tool') {
+				return `[TOOL ${message.function ?? ''}]: ${message.content}`;
+			}
+			return `[${role}]: ${message.content}`;
+		})
+		.join('\n');
+}
+
+function formatResultTranscript(transcript: AuditTranscript | undefined): string {
+	if (!transcript?.events?.length) return '';
+	return transcript.events
+		.map((event) => {
+			if (event.edit?.type === 'add_message' && event.edit.message) {
+				return `[${event.edit.message.role.toUpperCase()}]: ${event.edit.message.content}`;
+			}
+			if (event.edit?.type === 'tool_call' && event.edit.tool_name) {
+				const args = event.edit.tool_args ? JSON.stringify(event.edit.tool_args) : '{}';
+				return `[TOOL ${event.edit.tool_name}]: (${args}) -> ${event.edit.tool_result || ''}`;
+			}
+			return null;
+		})
+		.filter(Boolean)
+		.join('\n');
+}
+
+export const GET: RequestHandler = async ({ params, url }) => {
+	const { suite_id } = params;
+	if (!SAFE_ID.test(suite_id)) throw error(400, 'Invalid suite ID');
+	const type = url.searchParams.get('type') ?? 'test_set';
+
+	if (type === 'taxonomy') {
+		const taxonomy = loadPolicy(suite_id);
+		if (!taxonomy) throw error(404, 'Taxonomy not found');
+
+		const columns = ['behavior', 'definition', 'permissible', 'examples'];
+		const rows = taxonomy.behavior_categories.map((behavior) => ({
+			behavior: behavior.name,
+			definition: behavior.definition,
+			permissible: behavior.permissible,
+			examples: behavior.examples.join(' | ')
+		}));
+		return csvResponse(`${suite_id}_taxonomy.csv`, columns, rows);
+	}
+
+	if (type === 'test_set') {
+		const testCases = loadPromptSeeds(suite_id);
+		if (testCases.length === 0) throw error(404, 'No prompt test cases found');
+
+		const variationNames = detectVariations(testCases);
+		const columns = [
+			'test_case_id',
+			'behavior',
+			'definition',
+			'title',
+			'description',
+			'system_prompt',
+			'tools',
+			...variationNames
+		];
+		const rows = testCases.map((testCase: PromptSeed) => ({
+			test_case_id: testCase.test_case_id,
+			behavior: testCase.behavior,
+			definition: testCase.definition,
+			title: testCase.seed.title,
+			description: testCase.seed.description,
+			system_prompt: testCase.seed.system_prompt ?? '',
+			tools: JSON.stringify(testCase.seed.tools ?? []),
+			...Object.fromEntries(variationNames.map((name) => [name, testCase.dimensions?.[name] ?? '']))
+		}));
+		return csvResponse(`${suite_id}_test_set.csv`, columns, rows);
+	}
+
+	if (type === 'scenario_test_set') {
+		const testCases = loadScenarioSeeds(suite_id);
+		if (testCases.length === 0) throw error(404, 'No scenario test cases found');
+
+		const variationNames = detectVariations(testCases);
+		const columns = ['test_case_id', 'behavior', 'definition', 'title', 'description', 'tools', ...variationNames];
+		const rows = testCases.map((testCase: ScenarioSeed) => ({
+			test_case_id: testCase.test_case_id,
+			behavior: testCase.behavior,
+			definition: testCase.definition,
+			title: testCase.seed.title,
+			description: testCase.seed.description,
+			tools: JSON.stringify(testCase.seed.tools ?? []),
+			...Object.fromEntries(variationNames.map((name) => [name, testCase.dimensions?.[name] ?? '']))
+		}));
+		return csvResponse(`${suite_id}_scenario_test_set.csv`, columns, rows);
+	}
+
+	if (type === 'all_results') {
+		const runs = listRuns(suite_id);
+		const allSamples: Record<string, unknown>[] = [];
+		const allScoreDimensionNames = new Set<string>();
+		const allVariationNames = new Set<string>();
+
+		for (const run of runs) {
+			if (!run.has_judged) continue;
+			const samples = loadJudgedPrompts(suite_id, run.run_id);
+			for (const dimension of detectScoreDimensions(samples.map((sample) => sample.verdict as Record<string, unknown>))) {
+				allScoreDimensionNames.add(dimension);
+			}
+			for (const variation of detectVariations(samples)) allVariationNames.add(variation);
+			for (const sample of samples) {
+				allSamples.push({
+					run_id: run.run_id,
+					test_case_id: sample.test_case_id ?? '',
+					prompt: sample.prompt,
+					response: sample.response,
+					messages: formatMessages(sample.messages),
+					behavior: sample.behavior,
+					target: sample.target ?? '',
+					target_runtime_mode: sample.target_runtime_mode ?? '',
+					judge_model: sample.judge_model ?? '',
+					judge_status: sample.judge_status ?? '',
+					judge_error: sample.judge_error ?? '',
+					justification: verdictJustification(sample.verdict as Record<string, unknown> | null | undefined),
+					...Object.fromEntries([...allVariationNames].map((name) => [name, sample.dimensions?.[name] ?? ''])),
+					...Object.fromEntries(
+						[...allScoreDimensionNames].map((dimension) => [
+							dimension,
+							dimensionValue(sample.verdict as Record<string, unknown> | null | undefined, dimension)
+						])
+					)
+				});
+			}
+		}
+		if (allSamples.length === 0) throw error(404, 'No results found across runs');
+
+		const scoreDimensions = [...allScoreDimensionNames].sort();
+		const variations = [...allVariationNames].sort();
+		const columns = [
+			'run_id',
+			'test_case_id',
+			'prompt',
+			'response',
+			'messages',
+			'behavior',
+			'target',
+			'target_runtime_mode',
+			'judge_model',
+			'judge_status',
+			'judge_error',
+			'justification',
+			...variations,
+			...scoreDimensions
+		];
+		return csvResponse(`${suite_id}_all_results.csv`, columns, allSamples);
+	}
+
+	if (type === 'all_scenario_results') {
+		const runs = listAuditRuns(suite_id);
+		const allScores: Record<string, unknown>[] = [];
+		const allScoreDimensionNames = new Set<string>();
+		const allVariationNames = new Set<string>();
+
+		for (const run of runs) {
+			if (!run.has_scores) continue;
+			const scores = loadAuditScores(suite_id, run.run_id);
+			const transcripts = loadAuditTranscripts(suite_id, run.run_id);
+			const transcriptMap = new Map<string, AuditTranscript>();
+			for (const transcript of transcripts) transcriptMap.set(transcript.test_case_id, transcript);
+
+			for (const dimension of detectScoreDimensions(scores.map((score) => score.verdict as Record<string, unknown>))) {
+				allScoreDimensionNames.add(dimension);
+			}
+			for (const variation of detectVariations(scores)) allVariationNames.add(variation);
+			for (const score of scores) {
+				allScores.push({
+					run_id: run.run_id,
+					test_case_id: score.test_case_id,
+					behavior: score.behavior,
+					target: score.target ?? '',
+					tester_model: score.tester_model ?? '',
+					target_runtime_mode: score.target_runtime_mode ?? '',
+					judge_model: score.judge_model,
+					judge_status: score.judge_status ?? '',
+					judge_error: score.judge_error ?? '',
+					justification: verdictJustification(score.verdict as Record<string, unknown> | null | undefined),
+					transcript: formatResultTranscript(transcriptMap.get(score.test_case_id)),
+					turns_count: score.metadata?.turns_count ?? '',
+					stop_reason: score.metadata?.stop_reason ?? '',
+					...Object.fromEntries([...allVariationNames].map((name) => [name, score.dimensions?.[name] ?? ''])),
+					...Object.fromEntries(
+						[...allScoreDimensionNames].map((dimension) => [
+							dimension,
+							dimensionValue(score.verdict as Record<string, unknown> | null | undefined, dimension)
+						])
+					)
+				});
+			}
+		}
+		if (allScores.length === 0) throw error(404, 'No scenario results found across runs');
+
+		const scoreDimensions = [...allScoreDimensionNames].sort();
+		const variations = [...allVariationNames].sort();
+		const columns = [
+			'run_id',
+			'test_case_id',
+			'behavior',
+			'target',
+			'tester_model',
+			'target_runtime_mode',
+			'judge_model',
+			'judge_status',
+			'judge_error',
+			'justification',
+			'transcript',
+			'turns_count',
+			'stop_reason',
+			...variations,
+			...scoreDimensions
+		];
+		return csvResponse(`${suite_id}_all_scenario_results.csv`, columns, allScores);
+	}
+
+	throw error(
+		400,
+		`Unknown export type: ${type}. Use taxonomy, test_set, scenario_test_set, all_results, or all_scenario_results.`
+	);
+};

--- a/viewer/src/routes/api/csv/[suite_id]/[run_id]/+server.ts
+++ b/viewer/src/routes/api/csv/[suite_id]/[run_id]/+server.ts
@@ -1,0 +1,194 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { error } from '@sveltejs/kit';
+import { loadJudgedPrompts, loadAuditScores, loadAuditTranscripts } from '$lib/server/data.js';
+import { csvResponse } from '$lib/server/csv.js';
+import type { RequestHandler } from './$types.js';
+import type { AuditScore, AuditTranscript, InteractionMessage, JudgedSample } from '$lib/types.js';
+
+const SAFE_ID = /^[\w.@()-]+$/;
+
+function detectScoreDimensions(verdicts: Array<Record<string, unknown> | null | undefined>): string[] {
+	const dimensions = new Set<string>();
+	for (const verdict of verdicts) {
+		if (!verdict) continue;
+		if (verdict.dimensions && typeof verdict.dimensions === 'object' && !Array.isArray(verdict.dimensions)) {
+			for (const key of Object.keys(verdict.dimensions)) dimensions.add(key);
+		}
+		for (const [key, value] of Object.entries(verdict)) {
+			if (
+				key === 'dimensions' ||
+				key === 'justification' ||
+				key === 'confidence' ||
+				key === 'citations' ||
+				key.endsWith('_justification')
+			) {
+				continue;
+			}
+			if ((typeof value === 'number' && value >= 1 && value <= 3) || typeof value === 'boolean') {
+				dimensions.add(key);
+			}
+		}
+		if (dimensions.size > 0) break;
+	}
+	return [...dimensions].sort();
+}
+
+function detectVariations(items: Array<{ dimensions?: Record<string, string> }>): string[] {
+	const dimensions = new Set<string>();
+	for (const item of items) {
+		for (const key of Object.keys(item.dimensions ?? {})) dimensions.add(key);
+	}
+	return [...dimensions].sort();
+}
+
+function dimensionValue(verdict: Record<string, unknown> | null | undefined, dimension: string): unknown {
+	const dimensions = verdict?.dimensions;
+	if (dimensions && typeof dimensions === 'object' && !Array.isArray(dimensions) && dimension in dimensions) {
+		return (dimensions as Record<string, unknown>)[dimension];
+	}
+	return verdict?.[dimension] ?? '';
+}
+
+function verdictJustification(verdict: Record<string, unknown> | null | undefined): string {
+	return typeof verdict?.justification === 'string' ? verdict.justification : '';
+}
+
+function formatMessages(messages: InteractionMessage[] | undefined): string {
+	if (!messages?.length) return '';
+	return messages
+		.map((message) => {
+			const role = message.role.toUpperCase();
+			if (message.tool_calls?.length) {
+				const calls = message.tool_calls
+					.map((toolCall) => `${toolCall.function}(${JSON.stringify(toolCall.arguments)})`)
+					.join('; ');
+				return `[${role}]: ${message.content || ''}\n  tool_calls: ${calls}`;
+			}
+			if (message.role === 'tool') {
+				return `[TOOL ${message.function ?? ''}]: ${message.content}`;
+			}
+			return `[${role}]: ${message.content}`;
+		})
+		.join('\n');
+}
+
+function formatResultTranscript(transcript: AuditTranscript | undefined): string {
+	if (!transcript?.events?.length) return '';
+	return transcript.events
+		.map((event) => {
+			if (event.edit?.type === 'add_message' && event.edit.message) {
+				return `[${event.edit.message.role.toUpperCase()}]: ${event.edit.message.content}`;
+			}
+			if (event.edit?.type === 'tool_call' && event.edit.tool_name) {
+				const args = event.edit.tool_args ? JSON.stringify(event.edit.tool_args) : '{}';
+				return `[TOOL ${event.edit.tool_name}]: (${args}) -> ${event.edit.tool_result || ''}`;
+			}
+			return null;
+		})
+		.filter(Boolean)
+		.join('\n');
+}
+
+export const GET: RequestHandler = async ({ params, url }) => {
+	const { suite_id, run_id } = params;
+	if (!SAFE_ID.test(suite_id) || !SAFE_ID.test(run_id)) throw error(400, 'Invalid suite or run ID');
+	const type = url.searchParams.get('type') ?? 'results';
+
+	if (type === 'results') {
+		const samples = loadJudgedPrompts(suite_id, run_id);
+		if (samples.length === 0) throw error(404, 'No judged results found');
+
+		const scoreDimensions = detectScoreDimensions(samples.map((sample) => sample.verdict as Record<string, unknown>));
+		const variations = detectVariations(samples);
+		const columns = [
+			'test_case_id',
+			'prompt',
+			'response',
+			'messages',
+			'behavior',
+			'target',
+			'target_runtime_mode',
+			'judge_model',
+			'judge_status',
+			'judge_error',
+			'justification',
+			...variations,
+			...scoreDimensions
+		];
+		const rows = samples.map((sample: JudgedSample) => {
+			const row: Record<string, unknown> = {
+				test_case_id: sample.test_case_id ?? '',
+				prompt: sample.prompt,
+				response: sample.response,
+				messages: formatMessages(sample.messages),
+				behavior: sample.behavior,
+				target: sample.target ?? '',
+				target_runtime_mode: sample.target_runtime_mode ?? '',
+				judge_model: sample.judge_model ?? '',
+				judge_status: sample.judge_status ?? '',
+				judge_error: sample.judge_error ?? '',
+				justification: verdictJustification(sample.verdict as Record<string, unknown> | null | undefined),
+				...Object.fromEntries(variations.map((name) => [name, sample.dimensions?.[name] ?? '']))
+			};
+			for (const dimension of scoreDimensions) {
+				row[dimension] = dimensionValue(sample.verdict as Record<string, unknown> | null | undefined, dimension);
+			}
+			return row;
+		});
+		return csvResponse(`${suite_id}_${run_id}_results.csv`, columns, rows);
+	}
+
+	if (type === 'scenario_results') {
+		const scores = loadAuditScores(suite_id, run_id);
+		if (scores.length === 0) throw error(404, 'No scenario results found');
+
+		const transcripts = loadAuditTranscripts(suite_id, run_id);
+		const transcriptMap = new Map<string, AuditTranscript>();
+		for (const transcript of transcripts) transcriptMap.set(transcript.test_case_id, transcript);
+
+		const scoreDimensions = detectScoreDimensions(scores.map((score) => score.verdict as Record<string, unknown>));
+		const variations = detectVariations(scores);
+		const columns = [
+			'test_case_id',
+			'behavior',
+			'target',
+			'tester_model',
+			'target_runtime_mode',
+			'judge_model',
+			'judge_status',
+			'judge_error',
+			'justification',
+			'transcript',
+			'turns_count',
+			'stop_reason',
+			...variations,
+			...scoreDimensions
+		];
+		const rows = scores.map((score: AuditScore) => {
+			const row: Record<string, unknown> = {
+				test_case_id: score.test_case_id,
+				behavior: score.behavior,
+				target: score.target ?? '',
+				tester_model: score.tester_model ?? '',
+				target_runtime_mode: score.target_runtime_mode ?? '',
+				judge_model: score.judge_model,
+				judge_status: score.judge_status ?? '',
+				judge_error: score.judge_error ?? '',
+				justification: verdictJustification(score.verdict as Record<string, unknown> | null | undefined),
+				transcript: formatResultTranscript(transcriptMap.get(score.test_case_id)),
+				turns_count: score.metadata?.turns_count ?? '',
+				stop_reason: score.metadata?.stop_reason ?? '',
+				...Object.fromEntries(variations.map((name) => [name, score.dimensions?.[name] ?? '']))
+			};
+			for (const dimension of scoreDimensions) {
+				row[dimension] = dimensionValue(score.verdict as Record<string, unknown> | null | undefined, dimension);
+			}
+			return row;
+		});
+		return csvResponse(`${suite_id}_${run_id}_scenario_results.csv`, columns, rows);
+	}
+
+	throw error(400, `Unknown export type: ${type}. Use results or scenario_results.`);
+};

--- a/viewer/src/routes/new/+page.svelte
+++ b/viewer/src/routes/new/+page.svelte
@@ -1521,7 +1521,7 @@
 							</div>
 							{#if scenarioTestCasesEnabled || scenarioEvalEnabled}
 								<div class="flex items-baseline justify-between gap-3">
-									<span class="shrink-0 text-text-muted">Audit pipeline</span>
+									<span class="shrink-0 text-text-muted">Scenario pipeline</span>
 									<span class="min-w-0 break-words text-right font-medium text-text">{summaryScenarioPipeline}</span>
 								</div>
 							{/if}
@@ -1530,11 +1530,11 @@
 				</div>
 
 				<div class="mb-5">
-					<h3 class="mb-1 text-base font-semibold text-text">Measurement suite & run identity</h3>
-					<p class="mb-3 text-xs text-text-muted">Measurement suites group policy + seeds; runs hold measurement results.</p>
+					<h3 class="mb-1 text-base font-semibold text-text">Evaluation suite & run identity</h3>
+					<p class="mb-3 text-xs text-text-muted">Evaluation suites group behavior categories and test cases; runs hold results.</p>
 					<div class="grid grid-cols-2 gap-4">
 						<div>
-							<label for="suite-id" class="mb-1 block text-xs font-semibold text-text-secondary">Measurement suite ID</label>
+							<label for="suite-id" class="mb-1 block text-xs font-semibold text-text-secondary">Evaluation suite ID</label>
 							<input id="suite-id" type="text" maxlength="150" class="form-control w-full text-sm" placeholder="Auto-generated if blank" value={suiteId} oninput={(e) => { suiteId = e.currentTarget.value; markDirty(); }} disabled={submitting} />
 						</div>
 						<div>

--- a/viewer/src/routes/suite/[suite_id]/+page.svelte
+++ b/viewer/src/routes/suite/[suite_id]/+page.svelte
@@ -497,7 +497,7 @@
 				</span>
 			</div>
 		</div>
-		<p class="mt-1 text-sm leading-5 text-text-muted">View all evaluation runs for this policy-defined behavior. Select up to {MAX_COMPARE_RUNS} runs, then click Compare.</p>
+		<p class="mt-1 text-sm leading-5 text-text-muted">View all evaluation runs for this behavior category. Select up to {MAX_COMPARE_RUNS} runs, then click Compare.</p>
 	</div>
 
 	{#if heavyError}
@@ -690,7 +690,7 @@
 				<div class="shrink-0">
 					<PrimerDropdown
 						label="Sort by"
-						ariaLabel="Sort behavior categories by policy status"
+						ariaLabel="Sort behavior categories by behavior status"
 						options={BEHAVIOR_SORT_OPTIONS}
 						selected={behaviorSort}
 						onSelect={(value) => (behaviorSort = value as 'permissible' | 'not_permissible')}
@@ -700,7 +700,7 @@
 			<div class="overflow-hidden rounded-lg border border-border">
 				<div class="grid items-center border-b border-border bg-surface px-4 py-2" style="grid-template-columns: {BEHAVIOR_TABLE_COLUMNS}; column-gap: 12px">
 					<span class="text-left text-xs font-medium text-text-muted">Behavior category</span>
-					<span class="inline-flex items-center gap-1 text-left text-xs font-medium text-text-muted">Policy status
+					<span class="inline-flex items-center gap-1 text-left text-xs font-medium text-text-muted">Behavior status
 						<InfoTooltip direction="se" label="Permissible = behavior the target is expected to handle safely (no violation if engaged). Not permissible = behavior the target must refuse or redirect; engaging counts as a policy violation." />
 					</span>
 					<span class="text-left text-xs font-medium text-text-muted">Prompts</span>
@@ -883,7 +883,7 @@
 	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
 		<div class="rounded-lg border border-border bg-surface p-6 text-center">
 			<div class="inline-block h-6 w-6 animate-spin rounded-full border-2 border-text-muted border-t-interactive"></div>
-			<p class="mt-2 text-sm text-text-muted">Loading conversation...</p>
+			<p class="mt-2 text-sm text-text-muted">Loading result...</p>
 		</div>
 	</div>
 {/if}

--- a/viewer/src/routes/suite/[suite_id]/+page.svelte
+++ b/viewer/src/routes/suite/[suite_id]/+page.svelte
@@ -7,6 +7,7 @@
 	import InfoTooltip from '$lib/components/InfoTooltip.svelte';
 	import ExpandableText from '$lib/ExpandableText.svelte';
 	import { getRecordFlag, getRequiredBaseMetricNames } from '$lib/judgment.js';
+	import { judgeDimensionLabel } from '$lib/labels.js';
 	import { renderMarkdown } from '$lib/markdown.js';
 	import { mergeRunLists, normalizePromptSeeds, normalizeScenarioSeeds, type CombinedRunEntry } from '$lib/suite-view.js';
 	import type { DimensionDef, JudgedSample, ViewerResultItem } from '$lib/types.js';
@@ -222,7 +223,7 @@
 	});
 
 	function metricLabel(metric: string): string {
-		const label = metric.replace(/_/g, ' ');
+		const label = judgeDimensionLabel(metric);
 		return label.charAt(0).toUpperCase() + label.slice(1);
 	}
 
@@ -701,7 +702,7 @@
 				<div class="grid items-center border-b border-border bg-surface px-4 py-2" style="grid-template-columns: {BEHAVIOR_TABLE_COLUMNS}; column-gap: 12px">
 					<span class="text-left text-xs font-medium text-text-muted">Behavior category</span>
 					<span class="inline-flex items-center gap-1 text-left text-xs font-medium text-text-muted">Behavior status
-						<InfoTooltip direction="se" label="Permissible = behavior the target is expected to handle safely (no violation if engaged). Not permissible = behavior the target must refuse or redirect; engaging counts as a policy violation." />
+						<InfoTooltip direction="se" label="Permissible = behavior the target is expected to handle safely. Not permissible = behavior the target must refuse or redirect; engaging counts as a behavior violation." />
 					</span>
 					<span class="text-left text-xs font-medium text-text-muted">Prompts</span>
 					<span class="text-left text-xs font-medium text-text-muted">Scenarios</span>
@@ -866,7 +867,7 @@
 										<div><span class="text-[10px] font-medium text-text-muted">User prompt</span><p class="line-clamp-2 text-sm leading-snug text-text">{sample.prompt}</p></div>
 										{#if sample.response}<div><span class="text-[10px] font-medium text-text-muted">Target response</span><p class="line-clamp-2 text-sm leading-snug text-text">{sample.response}</p></div>{/if}
 										<span class="text-xs font-medium {status === 'flagged' ? 'text-score-fail' : status === 'compliant' ? 'text-score-pass' : status === 'error' ? 'text-yellow-500' : 'text-text-muted'}">
-											{status === 'flagged' ? 'Policy violation' : status === 'compliant' ? 'Pass' : status === 'error' ? 'Judge failed' : 'Pending'}
+											{status === 'flagged' ? 'Behavior violation' : status === 'compliant' ? 'Pass' : status === 'error' ? 'Judge failed' : 'Pending'}
 										</span>
 									</div>
 								</button>

--- a/viewer/src/routes/suite/[suite_id]/[run_id]/+page.svelte
+++ b/viewer/src/routes/suite/[suite_id]/[run_id]/+page.svelte
@@ -22,6 +22,7 @@
 		buildOutcomeOptions,
 		buildOutcomePlotRows
 	} from '$lib/outcome-plot.js';
+	import { judgeDimensionLabel, titleCaseJudgeDimensionLabel } from '$lib/labels.js';
 	import {
 		normalizePromptResult,
 		stopReasonChipClass,
@@ -161,7 +162,7 @@
 	let auditErroredCount = $derived(countSkippedStopReasonKind('error'));
 
 	function metricLabel(metric: string): string {
-		return metric.replace(/_/g, ' ');
+		return judgeDimensionLabel(metric);
 	}
 
 	function metricOutcomeText(flag: boolean | null): string {
@@ -1210,7 +1211,7 @@
 					<PrimerDropdown
 						label=""
 						ariaLabel="Filter by metric"
-						options={metricNames.map(m => ({ value: m, label: metricLabel(m).charAt(0).toUpperCase() + metricLabel(m).slice(1).toLowerCase() }))}
+						options={metricNames.map(m => ({ value: m, label: titleCaseJudgeDimensionLabel(m) }))}
 						selected={promptSortMetric}
 						onSelect={(v) => promptSortMetric = v}
 					/>
@@ -1568,7 +1569,7 @@
 					<PrimerDropdown
 						label=""
 						ariaLabel="Filter by metric"
-						options={auditMetricNames.map(m => ({ value: m, label: metricLabel(m).charAt(0).toUpperCase() + metricLabel(m).slice(1).toLowerCase() }))}
+						options={auditMetricNames.map(m => ({ value: m, label: titleCaseJudgeDimensionLabel(m) }))}
 						selected={auditSortMetric}
 						onSelect={(v) => auditSortMetric = v}
 					/>

--- a/viewer/src/routes/suite/[suite_id]/[run_id]/+page.svelte
+++ b/viewer/src/routes/suite/[suite_id]/[run_id]/+page.svelte
@@ -14,9 +14,14 @@
 	} from '$lib/types.js';
 	import { AUDIT_GROUP_AXES, PROMPT_GROUP_AXES, buildFactorAxes, groupByAxis } from '$lib/grouping.js';
 	import ResultDrawer from '$lib/ResultDrawer.svelte';
+	import RateForestPlot from '$lib/RateForestPlot.svelte';
 	import PrimerDropdown from '$lib/PrimerDropdown.svelte';
 	import InfoTooltip from '$lib/components/InfoTooltip.svelte';
 	import ExpandableText from '$lib/ExpandableText.svelte';
+	import {
+		buildOutcomeOptions,
+		buildOutcomePlotRows
+	} from '$lib/outcome-plot.js';
 	import {
 		normalizePromptResult,
 		stopReasonChipClass,
@@ -78,6 +83,7 @@
 	let promptGroupBy = $state('none');
 	let promptSortMetric = $state('policy_violation');
 	let promptSearchQuery = $state('');
+	let promptOutcomePanelOpen = $state(false);
 
 	// --- Audit eval state ---
 	let expandedAuditBehavior = $state<string | null>(null);
@@ -86,11 +92,23 @@
 	let auditGroupBy = $state('none');
 	let auditSortMetric = $state('policy_violation');
 	let auditSearchQuery = $state('');
+	let auditOutcomePanelOpen = $state(false);
 	let runMetaOpen = $state(false);
 
 	// --- Multi-judge state ---
 	let mjFilter = $state<'all' | 'disagreements'>('all');
 	let auditMjFilter = $state<'all' | 'disagreements'>('all');
+
+	let runCsvMenuOpen = $state(false);
+	let runCsvExportItems = $derived([
+		...(data.samples.length > 0 ? [{ label: 'Prompt results', type: 'results' }] : []),
+		...(data.auditScores.length > 0 ? [{ label: 'Scenario results', type: 'scenario_results' }] : [])
+	]);
+
+	function downloadRunCsv(type: string) {
+		runCsvMenuOpen = false;
+		window.open(`/api/csv/${data.suite_id}/${data.run_id}?type=${type}`, '_blank');
+	}
 
 	// Totals for judge failures banner
 	let promptTotal = $derived(data.samples.length);
@@ -193,8 +211,11 @@
 	}
 
 	const RUN_STAGE_LABELS: Record<string, string> = {
-		seeds: 'Seed Generation',
+		systematize: 'Behavior Categories',
+		test_set: 'Test Set',
+		seeds: 'Test Set',
 		inference: 'Inference',
+		rollout: 'Inference',
 		judge: 'Scoring',
 	};
 
@@ -230,8 +251,19 @@
 	let dimensionNames = $derived(Object.keys(data.metrics.dimensions ?? {}));
 	let metricNames = $derived(dimensionNames);
 	let primaryMetric = $derived(metricNames[0] ?? 'policy_violation');
+	let promptOutcomeId = $state('');
+	let promptOutcomeOptions = $derived(
+		buildOutcomeOptions(data.samples, data.taxonomy?.behavior_categories ?? [])
+	);
+	let promptOutcomeGroups = $derived([...new Set(promptOutcomeOptions.map((option) => option.groupLabel))]);
+	let activePromptOutcome = $derived(
+		promptOutcomeOptions.find((option) => option.id === promptOutcomeId) ?? promptOutcomeOptions[0] ?? null
+	);
+	let promptOutcomeRows = $derived(
+		activePromptOutcome ? buildOutcomePlotRows(data.samples, activePromptOutcome) : []
+	);
 
-	// Lookup map: behavior name -> permissible boolean (from policy)
+	// Lookup map: behavior name -> permissible boolean (from taxonomy)
 	let behaviorPermissibleMap = $derived.by(() => {
 		const map: Record<string, boolean> = {};
 		for (const b of data.taxonomy?.behavior_categories ?? []) {
@@ -300,6 +332,17 @@
 
 	let auditMetricNames = $derived(auditDimNames);
 	let primaryAuditMetric = $derived(auditMetricNames[0] ?? 'policy_violation');
+	let auditOutcomeId = $state('');
+	let auditOutcomeOptions = $derived(
+		buildOutcomeOptions(data.auditScores, data.taxonomy?.behavior_categories ?? [])
+	);
+	let auditOutcomeGroups = $derived([...new Set(auditOutcomeOptions.map((option) => option.groupLabel))]);
+	let activeAuditOutcome = $derived(
+		auditOutcomeOptions.find((option) => option.id === auditOutcomeId) ?? auditOutcomeOptions[0] ?? null
+	);
+	let auditOutcomeRows = $derived(
+		activeAuditOutcome ? buildOutcomePlotRows(data.auditScores, activeAuditOutcome) : []
+	);
 
 	let activeAuditDimensions = $derived(data.auditMetrics.dimensions);
 
@@ -640,6 +683,9 @@
 		auditSortMetric = 'policy_violation';
 		promptSearchQuery = '';
 		auditSearchQuery = '';
+		promptOutcomePanelOpen = false;
+		auditOutcomePanelOpen = false;
+		runCsvMenuOpen = false;
 		runMetaOpen = false;
 		mjFilter = 'all';
 		auditMjFilter = 'all';
@@ -659,6 +705,26 @@
 		previewDrawerItem = null;
 		auditNavIdx = -1;
 		previewNavIdx = -1;
+	});
+
+	$effect(() => {
+		if (promptOutcomeOptions.length === 0) {
+			promptOutcomeId = '';
+			return;
+		}
+		if (!promptOutcomeOptions.some((option) => option.id === promptOutcomeId)) {
+			promptOutcomeId = promptOutcomeOptions[0].id;
+		}
+	});
+
+	$effect(() => {
+		if (auditOutcomeOptions.length === 0) {
+			auditOutcomeId = '';
+			return;
+		}
+		if (!auditOutcomeOptions.some((option) => option.id === auditOutcomeId)) {
+			auditOutcomeId = auditOutcomeOptions[0].id;
+		}
 	});
 
 	$effect(() => {
@@ -771,6 +837,8 @@
 	});
 </script>
 
+<svelte:window onclick={() => { runCsvMenuOpen = false; }} />
+
 <!-- Header -->
 <div class="mb-8">
 	<nav aria-label="Breadcrumb">
@@ -862,36 +930,75 @@
 				{/if}
 			{/if}
 		</div>
-		{#if hasPromptEval && hasAuditContent}
-			<div class="shrink-0 self-start" style="margin-top:2px;">
-				<div class="SegmentedControl" role="tablist" aria-label="Result type">
-					<button
-						type="button"
-						role="tab"
-						aria-selected={activeTab === 'prompts'}
-						class="SegmentedControl-item"
-						class:SegmentedControl-item--selected={activeTab === 'prompts'}
-						onclick={() => setActiveTab('prompts')}
-					>
-						<span class="SegmentedControl-content">
-							<span>Prompts</span>
-							<span class="Counter">{data.promptCount ?? data.samples.length}</span>
-						</span>
-					</button>
-					<button
-						type="button"
-						role="tab"
-						aria-selected={activeTab === 'audit'}
-						class="SegmentedControl-item"
-						class:SegmentedControl-item--selected={activeTab === 'audit'}
-						onclick={() => setActiveTab('audit')}
-					>
-						<span class="SegmentedControl-content">
-							<span>Scenarios</span>
-							<span class="Counter">{hasAuditEval ? (data.auditCount ?? data.auditScores.length) : data.inferencePreviewRows.length}</span>
-						</span>
-					</button>
+		{#if hasPromptEval || hasAuditContent || runCsvExportItems.length > 0}
+			<div class="flex shrink-0 flex-col items-stretch gap-2 self-start" style="margin-top:2px;">
+				<div class="flex items-center justify-end gap-2">
+					{#if runCsvExportItems.length > 0}
+						<div class="relative">
+							<button
+								type="button"
+								class="btn btn-small"
+								onclick={(event) => { event.stopPropagation(); runCsvMenuOpen = !runCsvMenuOpen; }}
+								title="Download CSV"
+							>
+								CSV
+							</button>
+							{#if runCsvMenuOpen}
+								<div class="absolute right-0 top-full z-20 mt-1 min-w-[12rem] rounded-lg border border-border bg-surface py-1 shadow-lg">
+									{#each runCsvExportItems as item}
+										<button
+											type="button"
+											class="block w-full px-3 py-1.5 text-left text-xs text-text-secondary transition-colors hover:bg-surface-2 hover:text-text"
+											onclick={() => downloadRunCsv(item.type)}
+										>
+											{item.label}
+										</button>
+									{/each}
+								</div>
+							{/if}
+						</div>
+					{/if}
+					{#if hasPromptEval || hasAuditEval}
+						<a
+							class="btn btn-small no-underline"
+							href="/suite/{data.suite_id}/{data.run_id}/export"
+							target="_blank"
+							rel="noreferrer"
+						>
+							Export HTML
+						</a>
+					{/if}
 				</div>
+				{#if hasPromptEval && hasAuditContent}
+					<div class="SegmentedControl" role="tablist" aria-label="Result type">
+						<button
+							type="button"
+							role="tab"
+							aria-selected={activeTab === 'prompts'}
+							class="SegmentedControl-item"
+							class:SegmentedControl-item--selected={activeTab === 'prompts'}
+							onclick={() => setActiveTab('prompts')}
+						>
+							<span class="SegmentedControl-content">
+								<span>Prompts</span>
+								<span class="Counter">{data.promptCount ?? data.samples.length}</span>
+							</span>
+						</button>
+						<button
+							type="button"
+							role="tab"
+							aria-selected={activeTab === 'audit'}
+							class="SegmentedControl-item"
+							class:SegmentedControl-item--selected={activeTab === 'audit'}
+							onclick={() => setActiveTab('audit')}
+						>
+							<span class="SegmentedControl-content">
+								<span>Scenarios</span>
+								<span class="Counter">{hasAuditEval ? (data.auditCount ?? data.auditScores.length) : data.inferencePreviewRows.length}</span>
+							</span>
+						</button>
+					</div>
+				{/if}
 			</div>
 		{/if}
 	</div>
@@ -903,7 +1010,7 @@
 		<svg class="mx-auto mb-4 h-10 w-10 text-text-muted opacity-40" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
 			<path d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"/>
 		</svg>
-		<p class="text-sm text-text-secondary">No measurement results yet.</p>
+		<p class="text-sm text-text-secondary">No results yet.</p>
 		{#if data.manifest?.stages}
 			<div class="mt-4 flex flex-wrap justify-center gap-2">
 				{#each Object.entries(data.manifest.stages) as [stage, info]}
@@ -1008,6 +1115,49 @@
 			{/if}
 		{/if}
 
+		{#if activePromptOutcome}
+			<section class="mb-8">
+				<button
+					type="button"
+					class="mb-3 flex w-full flex-wrap items-center justify-between gap-3 rounded-md border border-border bg-surface px-4 py-3 text-left transition-colors hover:border-interactive/40"
+					aria-expanded={promptOutcomePanelOpen}
+					onclick={() => promptOutcomePanelOpen = !promptOutcomePanelOpen}
+				>
+					<div>
+						<h2 class="text-xs font-semibold uppercase tracking-widest text-text-muted">Outcome rates by variation</h2>
+						<p class="mt-1 text-sm text-text-muted">Compare a judge dimension or behavior category across the test set dimensions.</p>
+					</div>
+					<span class="inline-flex items-center gap-1.5 text-xs text-text-muted">
+						{promptOutcomePanelOpen ? 'Hide' : 'Show'}
+						<svg class="h-3 w-3 transition-transform {promptOutcomePanelOpen ? 'rotate-90' : ''}" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+							<path d="M9 5l7 7-7 7" />
+						</svg>
+					</span>
+				</button>
+				{#if promptOutcomePanelOpen}
+					<div class="mb-3 flex flex-wrap items-center justify-end gap-3">
+						<label class="flex w-full flex-col items-stretch gap-1 text-[10px] uppercase tracking-wider text-text-muted sm:w-auto sm:flex-row sm:items-center sm:gap-2">
+							Outcome
+							<select
+								class="w-full min-w-0 rounded border border-border bg-surface px-2 py-1.5 text-xs normal-case tracking-normal text-text outline-none focus:border-interactive sm:min-w-64"
+								value={promptOutcomeId}
+								onchange={(event) => promptOutcomeId = event.currentTarget.value}
+							>
+								{#each promptOutcomeGroups as group}
+									<optgroup label={group}>
+										{#each promptOutcomeOptions.filter((option) => option.groupLabel === group) as option (option.id)}
+											<option value={option.id}>{option.label}</option>
+										{/each}
+									</optgroup>
+								{/each}
+							</select>
+						</label>
+					</div>
+					<RateForestPlot rows={promptOutcomeRows} denominatorLabel={activePromptOutcome.denominatorLabel} />
+				{/if}
+			</section>
+		{/if}
+
 		<!-- Category Accordion -->
 		<section class="mb-8">
 			<div class="mb-4 border-b border-border pb-2">
@@ -1072,7 +1222,7 @@
 			<div class="overflow-hidden rounded-lg border border-border">
 				<div class="grid items-center gap-3 border-b border-border bg-surface-2/60 px-4 py-2 text-left text-xs font-medium text-text-muted" style="grid-template-columns: minmax(0,1.5fr) 130px minmax(0,2fr) 40px 16px;">
 					<span class="text-left">Behavior category</span>
-					<span class="text-left">Policy status</span>
+					<span class="text-left">Behavior status</span>
 					<span class="text-left">Metrics</span>
 					<span class="sr-only">Count</span>
 					<span class="sr-only">Expand</span>
@@ -1323,14 +1473,57 @@
 			{/if}
 		{/if}
 
+		{#if activeAuditOutcome}
+			<section class="mb-8">
+				<button
+					type="button"
+					class="mb-3 flex w-full flex-wrap items-center justify-between gap-3 rounded-md border border-border bg-surface px-4 py-3 text-left transition-colors hover:border-interactive/40"
+					aria-expanded={auditOutcomePanelOpen}
+					onclick={() => auditOutcomePanelOpen = !auditOutcomePanelOpen}
+				>
+					<div>
+						<h2 class="text-xs font-semibold uppercase tracking-widest text-text-muted">Outcome rates by variation</h2>
+						<p class="mt-1 text-sm text-text-muted">Compare a judge dimension or behavior category across the scenario test set dimensions.</p>
+					</div>
+					<span class="inline-flex items-center gap-1.5 text-xs text-text-muted">
+						{auditOutcomePanelOpen ? 'Hide' : 'Show'}
+						<svg class="h-3 w-3 transition-transform {auditOutcomePanelOpen ? 'rotate-90' : ''}" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+							<path d="M9 5l7 7-7 7" />
+						</svg>
+					</span>
+				</button>
+				{#if auditOutcomePanelOpen}
+					<div class="mb-3 flex flex-wrap items-center justify-end gap-3">
+						<label class="flex w-full flex-col items-stretch gap-1 text-[10px] uppercase tracking-wider text-text-muted sm:w-auto sm:flex-row sm:items-center sm:gap-2">
+							Outcome
+							<select
+								class="w-full min-w-0 rounded border border-border bg-surface px-2 py-1.5 text-xs normal-case tracking-normal text-text outline-none focus:border-interactive sm:min-w-64"
+								value={auditOutcomeId}
+								onchange={(event) => auditOutcomeId = event.currentTarget.value}
+							>
+								{#each auditOutcomeGroups as group}
+									<optgroup label={group}>
+										{#each auditOutcomeOptions.filter((option) => option.groupLabel === group) as option (option.id)}
+											<option value={option.id}>{option.label}</option>
+										{/each}
+									</optgroup>
+								{/each}
+							</select>
+						</label>
+					</div>
+					<RateForestPlot rows={auditOutcomeRows} denominatorLabel={activeAuditOutcome.denominatorLabel} />
+				{/if}
+			</section>
+		{/if}
+
 		<!-- Audit Category Accordion -->
 		<section class="mb-8">
 			<div class="mb-4 border-b border-border pb-2">
 				<div class="flex items-baseline gap-3">
 					<h2 class="min-w-0 flex-1 truncate text-lg font-semibold text-text">{auditGroupBy === 'none' ? 'All evaluation results' : `Results by ${activeAuditAxis.label.toLowerCase()}`}</h2>
-					<span class="shrink-0 text-xs text-text-muted">{data.auditScores.length} conversations{#if auditGroupBy !== 'none'} · {auditGroups.length} groups{/if}</span>
+					<span class="shrink-0 text-xs text-text-muted">{data.auditScores.length} results{#if auditGroupBy !== 'none'} · {auditGroups.length} groups{/if}</span>
 				</div>
-				<p class="mt-1 line-clamp-2 text-sm leading-5 text-text-muted">Per-scenario judgements across multi-turn conversations.</p>
+				<p class="mt-1 line-clamp-2 text-sm leading-5 text-text-muted">Per-scenario judgements across multi-turn results.</p>
 			</div>
 
 			<!-- Controls row: search + filter -->
@@ -1386,7 +1579,7 @@
 			<div class="overflow-hidden rounded-lg border border-border">
 				<div class="grid items-center gap-3 border-b border-border bg-surface-2/60 px-4 py-2 text-left text-xs font-medium text-text-muted" style="grid-template-columns: minmax(0,1.5fr) 130px minmax(0,2fr) 40px 16px;">
 					<span class="text-left">Behavior category</span>
-					<span class="text-left">Policy status</span>
+					<span class="text-left">Behavior status</span>
 					<span class="text-left">Metrics</span>
 					<span class="sr-only">Count</span>
 					<span class="sr-only">Expand</span>
@@ -1545,17 +1738,17 @@
 
 	{#if activeTab === 'audit' && !hasAuditEval && hasAuditPreview}
 		<div class="mb-6 rounded-lg border border-interactive/20 bg-interactive/5 px-5 py-4">
-			<div class="text-[11px] font-semibold uppercase tracking-wider text-interactive">Rollout Preview</div>
+			<div class="text-[11px] font-semibold uppercase tracking-wider text-interactive">Inference set</div>
 			<p class="mt-1 text-sm text-text-secondary">
-				{data.inferencePreviewRows.length} / {data.inferencePreviewTotal} conversations are available. Judgments will appear after rollout completes.
+				{data.inferencePreviewRows.length} / {data.inferencePreviewTotal} results are available. Judgments will appear after inference completes.
 			</p>
 		</div>
 
 		<section class="mb-8">
 			<div class="mb-4 flex items-center gap-3">
-				<h2 class="text-xs font-semibold uppercase tracking-widest text-text-muted">Available Conversations</h2>
+				<h2 class="text-xs font-semibold uppercase tracking-widest text-text-muted">Inference set</h2>
 				<div class="h-px flex-1 bg-border"></div>
-				<span class="text-xs text-text-muted">{data.inferencePreviewRows.length} conversations</span>
+				<span class="text-xs text-text-muted">{data.inferencePreviewRows.length} results</span>
 			</div>
 
 			<div class="overflow-hidden rounded-lg border border-border">
@@ -1618,8 +1811,8 @@
 {#if (drawerAuditScore || drawerPreviewSeedId) && !drawerItem && scenarioDrawerLoadingSeedId}
 	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm">
 		<div class="w-full max-w-sm rounded-xl border border-border bg-surface p-5 text-center shadow-2xl">
-			<div class="text-sm font-semibold text-text">Loading conversation</div>
-			<p class="mt-2 text-sm text-text-secondary">Fetching the transcript for {scenarioDrawerLoadingSeedId}.</p>
+			<div class="text-sm font-semibold text-text">Loading result</div>
+			<p class="mt-2 text-sm text-text-secondary">Fetching the result for {scenarioDrawerLoadingSeedId}.</p>
 			<button class="mt-4 rounded-md border border-border px-3 py-1.5 text-xs text-text-muted transition-colors hover:text-text" onclick={closeActiveDrawer}>
 				Cancel
 			</button>
@@ -1630,7 +1823,7 @@
 {#if (drawerAuditScore || drawerPreviewSeedId) && !drawerItem && scenarioDrawerError}
 	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm">
 		<div class="w-full max-w-sm rounded-xl border border-border bg-surface p-5 text-center shadow-2xl">
-			<div class="text-sm font-semibold text-text">Could not load conversation</div>
+			<div class="text-sm font-semibold text-text">Could not load result</div>
 			<p class="mt-2 text-sm text-text-secondary">{scenarioDrawerError}</p>
 			<button class="mt-4 rounded-md border border-border px-3 py-1.5 text-xs text-text-muted transition-colors hover:text-text" onclick={closeActiveDrawer}>
 				Close

--- a/viewer/src/routes/suite/[suite_id]/[run_id]/export/+server.ts
+++ b/viewer/src/routes/suite/[suite_id]/[run_id]/export/+server.ts
@@ -7,7 +7,7 @@ import ExportPage from '$lib/export/ExportPage.svelte';
 import type { ViewerResultItem } from '$lib/types.js';
 import type { RequestHandler } from './$types.js';
 
-export const GET: RequestHandler = async ({ params, fetch }) => {
+export const GET: RequestHandler = async ({ params, fetch, url }) => {
 	if (!isSafeArtifactId(params.suite_id)) throw error(400, 'Invalid suite ID');
 	if (!isSafeArtifactId(params.run_id)) throw error(400, 'Invalid run ID');
 
@@ -44,7 +44,7 @@ export const GET: RequestHandler = async ({ params, fetch }) => {
 		}
 	}
 
-	const css = await loadInlineCss(fetch);
+	const css = await loadInlineCss(fetch, url.origin);
 
 	const merged = {
 		...(promptPayload ?? auditPayload!),

--- a/viewer/src/routes/suite/[suite_id]/[run_id]/export/+server.ts
+++ b/viewer/src/routes/suite/[suite_id]/[run_id]/export/+server.ts
@@ -1,0 +1,117 @@
+import { error } from '@sveltejs/kit';
+import { render } from 'svelte/server';
+import { isSafeArtifactId } from '$lib/server/artifacts.js';
+import { loadRunPageData, loadPromptDrawerItem, loadScenarioDrawerItem } from '$lib/server/data.js';
+import { loadInlineCss } from '$lib/server/export-css.js';
+import ExportPage from '$lib/export/ExportPage.svelte';
+import type { ViewerResultItem } from '$lib/types.js';
+import type { RequestHandler } from './$types.js';
+
+export const GET: RequestHandler = async ({ params, fetch }) => {
+	if (!isSafeArtifactId(params.suite_id)) throw error(400, 'Invalid suite ID');
+	if (!isSafeArtifactId(params.run_id)) throw error(400, 'Invalid run ID');
+
+	const promptPayload = loadRunPageData(params.suite_id, params.run_id, 'prompts');
+	const auditPayload = loadRunPageData(params.suite_id, params.run_id, 'audit');
+	if (!promptPayload && !auditPayload) {
+		throw error(404, `Run "${params.run_id}" not found in suite "${params.suite_id}"`);
+	}
+
+	const samples = promptPayload?.samples ?? [];
+	const auditScores = auditPayload?.auditScores ?? [];
+
+	const promptDrawerItems: Record<string, ViewerResultItem> = {};
+	for (const sample of samples) {
+		const id = sample.test_case_id;
+		if (!id) continue;
+		try {
+			const item = await loadPromptDrawerItem(params.suite_id, params.run_id, id);
+			if (item) promptDrawerItems[id] = item;
+		} catch (err) {
+			console.warn(`[export] failed to load prompt drawer item ${id}:`, err);
+		}
+	}
+
+	const scenarioDrawerItems: Record<string, ViewerResultItem> = {};
+	for (const score of auditScores) {
+		const id = score.test_case_id;
+		if (!id) continue;
+		try {
+			const item = await loadScenarioDrawerItem(params.suite_id, params.run_id, id);
+			if (item) scenarioDrawerItems[id] = item;
+		} catch (err) {
+			console.warn(`[export] failed to load scenario drawer item ${id}:`, err);
+		}
+	}
+
+	const css = await loadInlineCss(fetch);
+
+	const merged = {
+		...(promptPayload ?? auditPayload!),
+		samples,
+		auditScores,
+		promptCount: promptPayload?.promptCount ?? samples.length,
+		auditCount: auditPayload?.auditCount ?? auditScores.length,
+		hasAuditContent: (auditPayload?.hasAuditContent ?? false) || auditScores.length > 0,
+		metrics: promptPayload?.metrics ?? null,
+		auditMetrics: auditPayload?.auditMetrics ?? null,
+		multiJudgeStats: promptPayload?.multiJudgeStats ?? auditPayload?.multiJudgeStats ?? null,
+		auditMultiJudgeStats: auditPayload?.multiJudgeStats ?? null,
+		// loadRunPageData's uncompleted-judge path only populates scenarioSeedMap when
+		// activeTab='audit', so the prompts call returns {}. Merge both so audit row
+		// titles still resolve to scenario descriptions.
+		scenarioSeedMap: {
+			...(promptPayload?.scenarioSeedMap ?? {}),
+			...(auditPayload?.scenarioSeedMap ?? {})
+		},
+		promptSeedTitleMap: {
+			...(promptPayload?.promptSeedTitleMap ?? {}),
+			...(auditPayload?.promptSeedTitleMap ?? {})
+		},
+		dimensionDefs: promptPayload?.dimensionDefs ?? auditPayload?.dimensionDefs ?? null
+	};
+
+	const props = {
+		data: merged,
+		promptDrawerItems,
+		scenarioDrawerItems,
+		generatedAt: new Date().toISOString()
+	};
+	const rendered = render(ExportPage as never, { props: props as never });
+
+	const html = `<!doctype html>
+<html lang="en" class="dark">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="generator" content="adaptive-eval-viewer export" />
+<title>${escapeHtml(params.suite_id)} / ${escapeHtml(params.run_id)} — Adaptive Eval export</title>
+<style>${css.replace(/<\/style/gi, '<\\/style')}</style>
+${rendered.head ?? ''}
+</head>
+<body class="bg-bg text-text">
+<main class="mx-auto max-w-[1400px] px-6 py-6">
+${rendered.body}
+</main>
+</body>
+</html>
+`;
+
+	const filename = `${params.suite_id}__${params.run_id}.html`;
+	return new Response(html, {
+		headers: {
+			'content-type': 'text/html; charset=utf-8',
+			'content-disposition': `attachment; filename="${filename}"`,
+			'cache-control': 'no-store'
+		}
+	});
+};
+
+function escapeHtml(s: string): string {
+	return s
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#39;');
+}

--- a/viewer/src/routes/suite/[suite_id]/[run_id]/monitor/+page.svelte
+++ b/viewer/src/routes/suite/[suite_id]/[run_id]/monitor/+page.svelte
@@ -104,7 +104,7 @@ if (statusPollTimer) clearInterval(statusPollTimer);
 
 <div class="mb-6">
 <div class="flex items-center gap-1.5 text-xs text-text-muted">
-<a href="/" class="transition-colors hover:text-interactive">Measurement Suites</a>
+<a href="/" class="transition-colors hover:text-interactive">Evaluation suites</a>
 <svg class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M9 5l7 7-7 7"/></svg>
 <a href="/suite/{data.suite_id}" class="transition-colors hover:text-interactive">{data.suite_id}</a>
 <svg class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M9 5l7 7-7 7"/></svg>

--- a/viewer/src/routes/suite/[suite_id]/compare/+page.svelte
+++ b/viewer/src/routes/suite/[suite_id]/compare/+page.svelte
@@ -4,6 +4,7 @@
 <script lang="ts">
 	import { getJudgeError, getRecordFlag, getRequiredBaseMetricNames, inferJudgeStatus } from '$lib/judgment.js';
 	import { buildMatchedSampleRows } from '$lib/compare-view.js';
+	import { judgeDimensionLabel } from '$lib/labels.js';
 	import PrimerDropdown from '$lib/PrimerDropdown.svelte';
 	import { slide } from 'svelte/transition';
 	import { quintOut } from 'svelte/easing';
@@ -55,7 +56,7 @@ let disagreementsOnly = $state(false);
 let activeMetric = $state('policy_violation');
 
 function metricLabel(m: string): string {
-	return m.replace(/_/g, ' ');
+	return judgeDimensionLabel(m);
 }
 
 // Short label for a run's target. Callable targets ("module.path:function_name")


### PR DESCRIPTION
## Summary
- Ported the mock viewer UI into the current `viewer/` while preserving current Adaptive Eval terminology.
- Added run-level CSV export, standalone HTML export, outcome-rate plots, citation warning surfacing, and agent trace rendering from `trajectories.jsonl`.
- Updated visible viewer labels to use behavior categories, test set/test cases, inference set, results, taxonomy, judge, and metrics.

## Validation
- `cd viewer; npm run check`
- `cd viewer; npm run build`