### PR TITLE
docs: use static MIT license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
                 <img src="https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13-blue.svg" alt="Python 3.11 | 3.12 | 3.13">
         </a>
         <a href="LICENSE">
-                <img src="https://img.shields.io/github/license/responsibleai/ASSERT" alt="License">
+                <img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License">
         </a>
 </p>
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
                 <img src="https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13-blue.svg" alt="Python 3.11 | 3.12 | 3.13">
         </a>
         <a href="LICENSE">
-                <img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License">
+                <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License">
         </a>
 </p>
 <p align="center">


### PR DESCRIPTION
## Summary
- Replace the README's dynamic GitHub license badge with a static MIT badge
- Avoid transient Shields/GitHub license-cache rendering as `license invalid` even though the repo license metadata resolves to MIT

## Validation
- Verified GitHub license API reports `MIT License` / SPDX `MIT`
- Verified the static badge renders `license: MIT`
