### PR TITLE
docs: use absolute README links for PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-        <img src="assets/assert-logo.png" alt="ASSERT logo" width="22" style="vertical-align: middle; margin-right: 5px;"/>
+        <img src="https://raw.githubusercontent.com/responsibleai/ASSERT/main/assets/assert-logo.png" alt="ASSERT logo" width="22" style="vertical-align: middle; margin-right: 5px;"/>
         <span style="vertical-align: middle; font-family: 'Spline Sans Mono', monospace;">ASSERT.</span>
 </h1>
 <p align="center">
@@ -7,19 +7,19 @@
         Local-first. Framework-agnostic. Trace-aware.
 </p>
 <p align="center">
-        <a href="docs/getting-started.md">🚀 Get started</a> |
+        <a href="https://github.com/responsibleai/ASSERT/blob/main/docs/getting-started.md">🚀 Get started</a> |
         <a href="https://responsibleai.github.io/ASSERT/">🌐 Visit project website</a> |
-        <a href="docs/targets/callable.md">🔌 View supported targets</a> |
-        <a href="docs/cli/overview.md">📘 CLI Reference</a> |
-        <a href="examples/README.md">🧪 Examples</a>
+        <a href="https://github.com/responsibleai/ASSERT/blob/main/docs/targets/callable.md">🔌 View supported targets</a> |
+        <a href="https://github.com/responsibleai/ASSERT/blob/main/docs/cli/overview.md">📘 CLI Reference</a> |
+        <a href="https://github.com/responsibleai/ASSERT/blob/main/examples/README.md">🧪 Examples</a>
 </p>
 <p align="center">
         <a href="https://github.com/responsibleai/ASSERT/actions/workflows/build.yml"><img src="https://github.com/responsibleai/ASSERT/actions/workflows/build.yml/badge.svg" alt="Build status"></a>
         <a href="https://www.python.org/downloads/" target="_blank"><img src="https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13-blue.svg" alt="Python 3.11 | 3.12 | 3.13"></a>
-        <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"></a>
+        <a href="https://github.com/responsibleai/ASSERT/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"></a>
 </p>
 <p align="center">
-        <img src="assets/assert-ai-framework-diagram.png" alt="Diagram of the ASSERT evaluation framework" width="100%">
+        <img src="https://raw.githubusercontent.com/responsibleai/ASSERT/main/assets/assert-ai-framework-diagram.png" alt="Diagram of the ASSERT evaluation framework" width="100%">
 </p>
 
 ## Why ASSERT?
@@ -61,7 +61,7 @@ assert-ai run --config examples/travel_planner_langgraph/eval_config.yaml
         <tr>
                 <td style="border: 1px solid #d0d7de; padding: 10px;"><a href="https://aka.ms/assert-ghpage">Learn about ASSERT</a></td>
                 <td style="border: 1px solid #d0d7de; padding: 10px;"><a href="https://aka.ms/assert">Read the Command Line post</a></td>
-                <td style="border: 1px solid #d0d7de; padding: 10px;"><a href="docs/getting-started.md">Follow the full walkthrough</a></td>
+                <td style="border: 1px solid #d0d7de; padding: 10px;"><a href="https://github.com/responsibleai/ASSERT/blob/main/docs/getting-started.md">Follow the full walkthrough</a></td>
                 <td style="border: 1px solid #d0d7de; padding: 10px;"><a href="https://aka.ms/assert-docs">Browse concepts and guides</a></td>
         </tr>
 </table>
@@ -78,4 +78,4 @@ If you configure a target, judge, trace collector, or model provider to send dat
 
 ## Disclaimer: Risks and limitations of ASSERT
 
-See the full section in the [`Concept Doc`](docs/concepts.md#risks-and-limitations).
+See the full section in the [`Concept Doc`](https://github.com/responsibleai/ASSERT/blob/main/docs/concepts.md#risks-and-limitations).


### PR DESCRIPTION
## Summary
- switch README image sources to raw.githubusercontent.com URLs
- rewrite top-level README document links to absolute GitHub blob URLs
- update the additional quickstart and concept links that also break on PyPI

## Related issue
Fixes #211

## Expected behavior
The next PyPI release should render the README images correctly and route the README navigation links to the intended GitHub documentation pages instead of 404s.

## Validation
- `git diff --check`
- verified there are no remaining relative `href`/`src` attributes in `README.md`
- confirmed the rewritten URLs return HTTP 200
