### PR TITLE
docs: polish README website link and badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,9 @@
         <a href="examples/README.md">🧪 Examples</a>
 </p>
 <p align="center">
-        <a href="https://github.com/responsibleai/ASSERT/actions/workflows/build.yml">
-                <img src="https://github.com/responsibleai/ASSERT/actions/workflows/build.yml/badge.svg" alt="Build status">
-        </a>
-        <a href="https://www.python.org/downloads/" target="_blank">
-                <img src="https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13-blue.svg" alt="Python 3.11 | 3.12 | 3.13">
-        </a>
-        <a href="LICENSE">
-                <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License">
-        </a>
+        <a href="https://github.com/responsibleai/ASSERT/actions/workflows/build.yml"><img src="https://github.com/responsibleai/ASSERT/actions/workflows/build.yml/badge.svg" alt="Build status"></a>
+        <a href="https://www.python.org/downloads/" target="_blank"><img src="https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13-blue.svg" alt="Python 3.11 | 3.12 | 3.13"></a>
+        <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"></a>
 </p>
 <p align="center">
         <img src="assets/assert-ai-framework-diagram.png" alt="Diagram of the ASSERT evaluation framework" width="100%">

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 </p>
 <p align="center">
         <a href="docs/getting-started.md">🚀 Get started</a> |
+        <a href="https://aka.ms/assert-ghpage">🌐 Visit project website</a> |
         <a href="docs/targets/callable.md">🔌 View supported targets</a> |
         <a href="docs/cli/overview.md">📘 CLI Reference</a> |
         <a href="examples/README.md">🧪 Examples</a>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </p>
 <p align="center">
         <a href="docs/getting-started.md">🚀 Get started</a> |
-        <a href="https://aka.ms/assert-ghpage">🌐 Visit project website</a> |
+        <a href="https://responsibleai.github.io/ASSERT/">🌐 Visit project website</a> |
         <a href="docs/targets/callable.md">🔌 View supported targets</a> |
         <a href="docs/cli/overview.md">📘 CLI Reference</a> |
         <a href="examples/README.md">🧪 Examples</a>


### PR DESCRIPTION
## Summary
- Add a top README link to the canonical GitHub Pages website URL
- Keep README badge links on one line so GitHub does not underline linked whitespace between badge images

## Validation
- Verified `https://responsibleai.github.io/ASSERT/` returns 200
- Verified this PR only changes README top links and badge markup
