### PR TITLE
Refactor Phoenix lazy-init into assert_ai.auto_trace() helper

### DIFF
--- a/assert_ai/__init__.py
+++ b/assert_ai/__init__.py
@@ -2,3 +2,8 @@
 # Licensed under the MIT License.
 
 """Top-level package for the measurements application."""
+
+from assert_ai.tracing import auto_trace, phoenix_collector_available
+
+__all__ = ["auto_trace", "phoenix_collector_available"]
+

--- a/assert_ai/tracing.py
+++ b/assert_ai/tracing.py
@@ -1,0 +1,130 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Lazy, collector-aware wrapper around ``phoenix.otel.register``.
+
+The "2-line" Phoenix auto-instrumentation pattern (``from phoenix.otel
+import register; register(auto_instrument=True)``) has a hidden cost
+on any system where ``arize-phoenix`` (the UI package) is installed
+alongside ``arize-phoenix-otel``: the two share the ``phoenix.*``
+namespace, so importing the OTel shim eagerly loads the UI package's
+``__init__.py`` and pulls in fastapi, uvicorn, sqlalchemy, strawberry,
+pandas, sklearn, ~5000 modules in total. Cold import is 30-50s. The
+default exporters then spam connection errors trying to reach
+``localhost:6006`` / ``localhost:4317`` when no collector is running.
+
+This wrapper keeps the same ergonomics ("one helper call instruments
+your agent") but skips the import + register entirely when there is
+no collector reachable. Spans are identical when traces do flow,
+because the helper forwards to ``phoenix.otel.register``.
+
+Usage in any agent module::
+
+    from assert_ai import auto_trace
+    auto_trace()
+
+Or with options (mirrors ``phoenix.otel.register`` signature)::
+
+    from assert_ai import auto_trace
+    auto_trace(project_name="my-agent", protocol="http/protobuf", batch=True)
+
+Decision order for whether to import + register:
+
+1. ``PHOENIX_DISABLE_AUTO_INSTRUMENT=1`` -> always skip.
+2. ``PHOENIX_COLLECTOR_ENDPOINT`` or ``OTEL_EXPORTER_OTLP_ENDPOINT`` set
+   -> always init (user explicitly asked for export).
+3. ``ASSERT_AUTO_TRACE_FORCE=1`` -> always init (escape hatch for
+   environments where the localhost probe is unreliable).
+4. TCP-probe ``localhost:6006`` (100ms timeout) -> init iff listening.
+
+Eval runs are unaffected: ``assert_ai/core/otel.py`` installs its own
+in-process span collector and gracefully handles the case where no
+``TracerProvider`` was set by ``register()``.
+"""
+from __future__ import annotations
+
+import os
+import socket
+from typing import Any
+
+__all__ = ["auto_trace", "phoenix_collector_available"]
+
+_PHOENIX_DEFAULT_HOST = "localhost"
+_PHOENIX_DEFAULT_PORT = 6006
+_PROBE_TIMEOUT_SECONDS = 0.1
+
+
+def phoenix_collector_available(
+    *,
+    host: str = _PHOENIX_DEFAULT_HOST,
+    port: int = _PHOENIX_DEFAULT_PORT,
+    timeout: float = _PROBE_TIMEOUT_SECONDS,
+) -> bool:
+    """Return True iff Phoenix auto-instrumentation should be enabled.
+
+    Decision order matches the module docstring. Pure function with no
+    side effects so tests can monkey-patch the socket call directly.
+    """
+    if os.environ.get("PHOENIX_DISABLE_AUTO_INSTRUMENT") == "1":
+        return False
+    if os.environ.get("PHOENIX_COLLECTOR_ENDPOINT") or os.environ.get(
+        "OTEL_EXPORTER_OTLP_ENDPOINT"
+    ):
+        return True
+    if os.environ.get("ASSERT_AUTO_TRACE_FORCE") == "1":
+        return True
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def auto_trace(
+    *,
+    auto_instrument: bool = True,
+    force: bool = False,
+    **register_kwargs: Any,
+) -> bool:
+    """Auto-instrument the calling process via OpenInference, lazily.
+
+    Drop-in replacement for the canonical 2-line Phoenix pattern::
+
+        # Before:
+        from phoenix.otel import register
+        register(auto_instrument=True)
+
+        # After:
+        from assert_ai import auto_trace
+        auto_trace()
+
+    Skips the (expensive) ``import phoenix.otel`` entirely when no
+    collector is reachable -- typical for interactive demos and CI
+    smoke tests. See module docstring for the full decision order.
+
+    Args:
+        auto_instrument: forwarded to ``phoenix.otel.register``. When
+            True (default), Phoenix loads every installed
+            ``openinference-instrumentation-*`` package.
+        force: bypass the reachability check and always attempt
+            ``register()``. Useful for tests or for environments where
+            the TCP probe is unreliable (e.g. behind a proxy that
+            accepts but later refuses the connection).
+        **register_kwargs: forwarded verbatim to
+            ``phoenix.otel.register``. Common values: ``project_name``,
+            ``protocol``, ``batch``, ``verbose``, ``headers``,
+            ``api_key``, ``endpoint``.
+
+    Returns:
+        True if ``phoenix.otel.register`` was called successfully.
+        False if the call was skipped (no collector reachable, env
+        flag set, or ``arize-phoenix-otel`` not installed).
+    """
+    if not force and not phoenix_collector_available():
+        return False
+    try:
+        from phoenix.otel import register
+    except ImportError:
+        return False
+    register(auto_instrument=auto_instrument, **register_kwargs)
+    return True

--- a/examples/azure_doc_qa/auto_trace.py
+++ b/examples/azure_doc_qa/auto_trace.py
@@ -9,8 +9,9 @@ LangChain, LangGraph, OpenAI, and MCP tool calls.
 
 from __future__ import annotations
 
-# pip install openinference-instrumentation-langchain arize-phoenix-otel
-from phoenix.otel import register  # noqa: F401
-register(auto_instrument=True)
+# 1 line to instrument — lazy via assert_ai.auto_trace so importing this
+# module is fast when no Phoenix collector is running. See assert_ai/tracing.py.
+from assert_ai import auto_trace
+auto_trace()
 
 from examples.azure_doc_qa.agent import chat_sync  # noqa: E402

--- a/examples/bank_manager_agent_control/README.md
+++ b/examples/bank_manager_agent_control/README.md
@@ -142,7 +142,19 @@ cp -R examples/bank_manager_agent_control/results artifacts/results/bank-manager
 ```bash
 cd viewer
 npm install        # one-time, ~1-2 min
+```
+
+PowerShell:
+
+```powershell
 $env:VIEWER_EDIT_MODE = "1"
+npm run dev        # serves http://localhost:5173
+```
+
+bash (macOS / Linux):
+
+```bash
+export VIEWER_EDIT_MODE=1
 npm run dev        # serves http://localhost:5173
 ```
 

--- a/examples/bank_manager_agent_control/README.md
+++ b/examples/bank_manager_agent_control/README.md
@@ -286,7 +286,10 @@ assert-ai run --config examples/bank_manager_agent_control/eval_unguarded_prompt
 assert-ai run --config examples/bank_manager_agent_control/eval_guarded_acs.yaml
 ```
 
-Each run writes to `artifacts/results/bank-manager-agent-control/<variant>/`.
+Each run writes to `artifacts/results/bank-manager-agent-control/<variant>/`,
+where `<variant>` is the `run:` value in each yaml (currently suffixed
+`-v2` so fresh runs land in new directories and never overwrite the
+committed `-n100` source shown in the Variants table above).
 The committed source under `examples/bank_manager_agent_control/results/`
 is never touched. To restore the demo working copy after a reproduce
 run, repeat step 1 of [View the demo](#view-the-demo-no-azure-credentials-needed).

--- a/examples/bank_manager_agent_control/README.md
+++ b/examples/bank_manager_agent_control/README.md
@@ -124,22 +124,30 @@ untracked files inside the folder are preserved.
 PowerShell (Windows):
 
 ```powershell
+cd (git rev-parse --show-toplevel)             # cd to repo root (safe from any subdir, eg viewer/)
 git checkout build-demo-final
 git checkout HEAD -- examples/bank_manager_agent_control/
-git pull --ff-only
+git pull --no-rebase --ff-only
 ```
 
 bash (macOS / Linux):
 
 ```bash
+cd "$(git rev-parse --show-toplevel)"          # cd to repo root (safe from any subdir, eg viewer/)
 git checkout build-demo-final
 git checkout HEAD -- examples/bank_manager_agent_control/
-git pull --ff-only
+git pull --no-rebase --ff-only
 ```
 
-> If `git pull --ff-only` errors with "Not possible to fast-forward",
-> your local `build-demo-final` has diverged commits. On a demo-speaker
-> laptop the safe recovery is:
+> The `cd (git rev-parse ...)` first line guards against running this
+> sequence from a subdirectory (eg. you left a terminal in `viewer/`
+> from the previous demo). The `--no-rebase` flag on the pull guards
+> against any local `pull.rebase=true` config interfering with
+> `--ff-only`.
+>
+> If `git pull --no-rebase --ff-only` errors with "Not possible to
+> fast-forward", your local `build-demo-final` has diverged commits.
+> On a demo-speaker laptop the safe recovery is:
 > `git fetch && git reset --hard origin/build-demo-final`
 > &mdash; **this discards all local commits on the branch.** Do not run
 > this on a work laptop with unpushed changes.

--- a/examples/bank_manager_agent_control/README.md
+++ b/examples/bank_manager_agent_control/README.md
@@ -113,6 +113,37 @@ demo data.
 
 Run all commands from the repository root.
 
+### 0. Pull the latest demo branch (discarding any local changes in this folder)
+
+If you have edited anything inside `examples/bank_manager_agent_control/`
+since your last `git pull`, reset the demo folder first so the pull
+fast-forwards cleanly. The commands below discard tracked-file edits
+**only inside this folder** — files anywhere else in the repo and any
+untracked files inside the folder are preserved.
+
+PowerShell (Windows):
+
+```powershell
+git checkout build-demo-final
+git checkout HEAD -- examples/bank_manager_agent_control/
+git pull --ff-only
+```
+
+bash (macOS / Linux):
+
+```bash
+git checkout build-demo-final
+git checkout HEAD -- examples/bank_manager_agent_control/
+git pull --ff-only
+```
+
+> If `git pull --ff-only` errors with "Not possible to fast-forward",
+> your local `build-demo-final` has diverged commits. On a demo-speaker
+> laptop the safe recovery is:
+> `git fetch && git reset --hard origin/build-demo-final`
+> &mdash; **this discards all local commits on the branch.** Do not run
+> this on a work laptop with unpushed changes.
+
 ### 1. Copy the prepared results into the viewer's working dir
 
 This populates `artifacts/results/bank-manager-agent-control/` from
@@ -139,23 +170,22 @@ cp -R examples/bank_manager_agent_control/results artifacts/results/bank-manager
 
 ### 2. Start the viewer (in its own terminal)
 
-```bash
-cd viewer
-npm install        # one-time, ~1-2 min
-```
-
-PowerShell:
+PowerShell (Windows):
 
 ```powershell
+cd viewer
+npm install                          # one-time, ~1-2 min
 $env:VIEWER_EDIT_MODE = "1"
-npm run dev        # serves http://localhost:5173
+npm run dev                          # serves http://localhost:5173
 ```
 
 bash (macOS / Linux):
 
 ```bash
+cd viewer
+npm install                          # one-time, ~1-2 min
 export VIEWER_EDIT_MODE=1
-npm run dev        # serves http://localhost:5173
+npm run dev                          # serves http://localhost:5173
 ```
 
 Open <http://localhost:5173> and pick the suite

--- a/examples/bank_manager_agent_control/agent.py
+++ b/examples/bank_manager_agent_control/agent.py
@@ -18,12 +18,11 @@ ACS spec and SDKs.
 """
 from __future__ import annotations
 
-# 2 lines to instrument, then run the agent unchanged. Phoenix auto-discovers
-# LangChain, CrewAI, OpenAI, and MCP tool calls.
-try:
-    from phoenix.otel import register; register(auto_instrument=True)
-except ImportError:
-    pass  # phoenix-otel + openinference-* not installed; skip auto-trace
+# Auto-trace LangChain / OpenAI / MCP via OpenInference — lazy. Skips the
+# 30-50s `import phoenix.otel` cost when no Phoenix collector is reachable,
+# so interactive demos (e.g. unguarded_ui.py) start instantly. Run
+# `phoenix serve` first, or set PHOENIX_COLLECTOR_ENDPOINT, to see traces.
+from assert_ai import auto_trace; auto_trace()
 
 import asyncio
 import os

--- a/examples/bank_manager_agent_control/eval_guarded_acs.yaml
+++ b/examples/bank_manager_agent_control/eval_guarded_acs.yaml
@@ -1,5 +1,5 @@
 suite: bank-manager-agent-control
-run: variant-e-guarded-acs-n100
+run: variant-e-guarded-acs-n100-v2
 
 # Comparison config: same shared test_set as variant-a-unguarded-n100,
 # scored against the new Agent Control Specification (ACS) policy at

--- a/examples/bank_manager_agent_control/eval_unguarded.yaml
+++ b/examples/bank_manager_agent_control/eval_unguarded.yaml
@@ -1,5 +1,5 @@
 suite: bank-manager-agent-control
-run: variant-a-unguarded-n100
+run: variant-a-unguarded-n100-v2
 
 # Baseline (unguarded) config. Owns the full pipeline:
 # systematize → test_set → inference → judge. The produced taxonomy and

--- a/examples/bank_manager_agent_control/eval_unguarded_prompted.yaml
+++ b/examples/bank_manager_agent_control/eval_unguarded_prompted.yaml
@@ -1,5 +1,5 @@
 suite: bank-manager-agent-control
-run: variant-c-unguarded-prompted-n100
+run: variant-c-unguarded-prompted-n100-v2
 
 # Prompt-engineering intervention: same unguarded LangGraph agent as
 # variant-a-unguarded-n100, but with defensive safety directives appended

--- a/examples/change_control_agent/agent.py
+++ b/examples/change_control_agent/agent.py
@@ -34,15 +34,16 @@ try:
     from opentelemetry.sdk.trace import TracerProvider
 
     try:
-        from phoenix.otel import register
+        from assert_ai import auto_trace
 
-        register(
+        if not auto_trace(
             project_name=os.environ.get("PHOENIX_PROJECT_NAME", "change-control-agent"),
-            auto_instrument=True,
             verbose=False,
             protocol="http/protobuf",
             batch=True,
-        )
+        ):
+            if not isinstance(trace.get_tracer_provider(), TracerProvider):
+                trace.set_tracer_provider(TracerProvider())
     except Exception:
         if not isinstance(trace.get_tracer_provider(), TracerProvider):
             trace.set_tracer_provider(TracerProvider())

--- a/examples/incident_triage_agent/agent.py
+++ b/examples/incident_triage_agent/agent.py
@@ -29,15 +29,19 @@ from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 
 try:
-    from phoenix.otel import register
+    from assert_ai import auto_trace
 
-    register(
+    if not auto_trace(
         project_name=os.environ.get("PHOENIX_PROJECT_NAME", "incident-triage-agent"),
-        auto_instrument=True,
         verbose=False,
         protocol="http/protobuf",
         batch=True,
-    )
+    ):
+        _existing = trace.get_tracer_provider()
+        if not isinstance(_existing, TracerProvider):
+            _real = getattr(_existing, "_real_provider", None)
+            if not isinstance(_real, TracerProvider):
+                trace.set_tracer_provider(TracerProvider())
 except Exception:
     _existing = trace.get_tracer_provider()
     if not isinstance(_existing, TracerProvider):

--- a/examples/phoenix_auto_trace/travel_anthropic.py
+++ b/examples/phoenix_auto_trace/travel_anthropic.py
@@ -8,8 +8,8 @@ Traces captured: LLM calls, tool use blocks, token counts, latency.
 """
 
 # pip install openinference-instrumentation-anthropic arize-phoenix-otel
-from phoenix.otel import register
-register(auto_instrument=True)
+from assert_ai import auto_trace
+auto_trace()
 
 import json
 import anthropic

--- a/examples/phoenix_auto_trace/travel_autogen.py
+++ b/examples/phoenix_auto_trace/travel_autogen.py
@@ -10,8 +10,8 @@ Traces captured: agent messages, tool calls, LLM calls, team orchestration, toke
 from __future__ import annotations
 
 # pip install openinference-instrumentation-autogen-agentchat arize-phoenix-otel
-from phoenix.otel import register
-register(auto_instrument=True)
+from assert_ai import auto_trace
+auto_trace()
 
 import asyncio
 import os

--- a/examples/phoenix_auto_trace/travel_bedrock.py
+++ b/examples/phoenix_auto_trace/travel_bedrock.py
@@ -10,8 +10,8 @@ Traces captured: LLM calls, tool use, token counts, latency.
 from __future__ import annotations
 
 # pip install openinference-instrumentation-bedrock arize-phoenix-otel
-from phoenix.otel import register
-register(auto_instrument=True)
+from assert_ai import auto_trace
+auto_trace()
 
 import json
 import boto3

--- a/examples/phoenix_auto_trace/travel_crewai.py
+++ b/examples/phoenix_auto_trace/travel_crewai.py
@@ -14,8 +14,8 @@ from __future__ import annotations
 # 2 lines of instrumentation
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # pip install openinference-instrumentation-crewai arize-phoenix-otel
-from phoenix.otel import register  # noqa: E402
-register(auto_instrument=True)
+from assert_ai import auto_trace  # noqa: E402
+auto_trace()
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # Agent code — standard CrewAI

--- a/examples/phoenix_auto_trace/travel_dspy.py
+++ b/examples/phoenix_auto_trace/travel_dspy.py
@@ -13,8 +13,8 @@ from __future__ import annotations
 # 2 lines of instrumentation
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # pip install openinference-instrumentation-dspy arize-phoenix-otel
-from phoenix.otel import register  # noqa: E402
-register(auto_instrument=True)
+from assert_ai import auto_trace  # noqa: E402
+auto_trace()
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # Agent code — standard DSPy

--- a/examples/phoenix_auto_trace/travel_google_adk.py
+++ b/examples/phoenix_auto_trace/travel_google_adk.py
@@ -10,8 +10,8 @@ Traces captured: agent execution, LLM calls, tool invocations, sub-agent delegat
 from __future__ import annotations
 
 # pip install openinference-instrumentation-google-adk arize-phoenix-otel
-from phoenix.otel import register
-register(auto_instrument=True)
+from assert_ai import auto_trace
+auto_trace()
 
 from google.adk.agents import Agent
 from google.adk.tools import FunctionTool

--- a/examples/phoenix_auto_trace/travel_google_genai.py
+++ b/examples/phoenix_auto_trace/travel_google_genai.py
@@ -10,8 +10,8 @@ Traces captured: LLM calls, function calls, token counts, latency.
 from __future__ import annotations
 
 # pip install openinference-instrumentation-google-genai arize-phoenix-otel
-from phoenix.otel import register
-register(auto_instrument=True)
+from assert_ai import auto_trace
+auto_trace()
 
 import json
 from google import genai

--- a/examples/phoenix_auto_trace/travel_groq.py
+++ b/examples/phoenix_auto_trace/travel_groq.py
@@ -8,8 +8,8 @@ Traces captured: LLM calls, tool calls, token counts, latency.
 """
 
 # pip install openinference-instrumentation-groq arize-phoenix-otel
-from phoenix.otel import register
-register(auto_instrument=True)
+from assert_ai import auto_trace
+auto_trace()
 
 import json
 from groq import Groq

--- a/examples/phoenix_auto_trace/travel_haystack.py
+++ b/examples/phoenix_auto_trace/travel_haystack.py
@@ -10,8 +10,8 @@ Traces captured: pipeline runs, LLM calls, tool invocations, token counts, laten
 from __future__ import annotations
 
 # pip install openinference-instrumentation-haystack arize-phoenix-otel
-from phoenix.otel import register
-register(auto_instrument=True)
+from assert_ai import auto_trace
+auto_trace()
 
 import os
 

--- a/examples/phoenix_auto_trace/travel_instructor.py
+++ b/examples/phoenix_auto_trace/travel_instructor.py
@@ -10,8 +10,8 @@ Traces captured: LLM calls with structured output schemas, token counts, latency
 from __future__ import annotations
 
 # pip install openinference-instrumentation-instructor arize-phoenix-otel
-from phoenix.otel import register
-register(auto_instrument=True)
+from assert_ai import auto_trace
+auto_trace()
 
 import os
 

--- a/examples/phoenix_auto_trace/travel_langchain.py
+++ b/examples/phoenix_auto_trace/travel_langchain.py
@@ -17,8 +17,8 @@ from __future__ import annotations
 # 2 lines of instrumentation
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # pip install openinference-instrumentation-langchain arize-phoenix-otel
-from phoenix.otel import register  # noqa: E402
-register(auto_instrument=True)
+from assert_ai import auto_trace  # noqa: E402
+auto_trace()
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # Agent code — standard LangGraph

--- a/examples/phoenix_auto_trace/travel_litellm.py
+++ b/examples/phoenix_auto_trace/travel_litellm.py
@@ -8,8 +8,8 @@ Traces captured: LLM calls, tool calls, token counts, latency, model name.
 """
 
 # pip install openinference-instrumentation-litellm arize-phoenix-otel
-from phoenix.otel import register
-register(auto_instrument=True)
+from assert_ai import auto_trace
+auto_trace()
 
 import json
 import os

--- a/examples/phoenix_auto_trace/travel_llamaindex.py
+++ b/examples/phoenix_auto_trace/travel_llamaindex.py
@@ -14,8 +14,8 @@ from __future__ import annotations
 # 2 lines of instrumentation
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # pip install openinference-instrumentation-llama-index arize-phoenix-otel
-from phoenix.otel import register  # noqa: E402
-register(auto_instrument=True)
+from assert_ai import auto_trace  # noqa: E402
+auto_trace()
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # Agent code — standard LlamaIndex

--- a/examples/phoenix_auto_trace/travel_mistralai.py
+++ b/examples/phoenix_auto_trace/travel_mistralai.py
@@ -8,8 +8,8 @@ Traces captured: LLM calls, tool calls, token counts, latency.
 """
 
 # pip install openinference-instrumentation-mistralai arize-phoenix-otel
-from phoenix.otel import register
-register(auto_instrument=True)
+from assert_ai import auto_trace
+auto_trace()
 
 import json
 from mistralai import Mistral

--- a/examples/phoenix_auto_trace/travel_openai.py
+++ b/examples/phoenix_auto_trace/travel_openai.py
@@ -8,8 +8,8 @@ Traces captured: LLM calls, tool calls with args/results, token counts, latency.
 """
 
 # pip install openinference-instrumentation-openai arize-phoenix-otel
-from phoenix.otel import register
-register(auto_instrument=True)
+from assert_ai import auto_trace
+auto_trace()
 
 import json
 import os

--- a/examples/phoenix_auto_trace/travel_openai_agents.py
+++ b/examples/phoenix_auto_trace/travel_openai_agents.py
@@ -10,8 +10,8 @@ Traces captured: agent runs, handoffs, tool calls, LLM completions, token counts
 from __future__ import annotations
 
 # pip install openinference-instrumentation-openai-agents arize-phoenix-otel
-from phoenix.otel import register
-register(auto_instrument=True)
+from assert_ai import auto_trace
+auto_trace()
 
 import asyncio
 import os

--- a/examples/phoenix_auto_trace/travel_openai_router.py
+++ b/examples/phoenix_auto_trace/travel_openai_router.py
@@ -2,8 +2,8 @@
 # Licensed under the MIT License.
 
 """Travel planner — model-router (SWC endpoint, multi-model ensemble)."""
-from phoenix.otel import register
-register(auto_instrument=True)
+from assert_ai import auto_trace
+auto_trace()
 
 import json
 import os

--- a/examples/phoenix_auto_trace/travel_portkey.py
+++ b/examples/phoenix_auto_trace/travel_portkey.py
@@ -8,8 +8,8 @@ Traces captured: LLM calls, gateway routing, fallbacks, token counts, latency.
 """
 
 # pip install openinference-instrumentation-portkey arize-phoenix-otel
-from phoenix.otel import register
-register(auto_instrument=True)
+from assert_ai import auto_trace
+auto_trace()
 
 import json
 from portkey_ai import Portkey

--- a/examples/phoenix_auto_trace/travel_pydantic_ai.py
+++ b/examples/phoenix_auto_trace/travel_pydantic_ai.py
@@ -10,8 +10,8 @@ Traces captured: agent runs, tool calls, LLM calls, structured output, token cou
 from __future__ import annotations
 
 # pip install openinference-instrumentation-pydantic-ai arize-phoenix-otel
-from phoenix.otel import register
-register(auto_instrument=True)
+from assert_ai import auto_trace
+auto_trace()
 
 import os
 

--- a/examples/phoenix_auto_trace/travel_smolagents.py
+++ b/examples/phoenix_auto_trace/travel_smolagents.py
@@ -10,8 +10,8 @@ Traces captured: agent steps, tool calls, LLM calls, reasoning traces, token cou
 from __future__ import annotations
 
 # pip install openinference-instrumentation-smolagents arize-phoenix-otel
-from phoenix.otel import register
-register(auto_instrument=True)
+from assert_ai import auto_trace
+auto_trace()
 
 import os
 

--- a/examples/science_research_agent/agent.py
+++ b/examples/science_research_agent/agent.py
@@ -34,15 +34,16 @@ try:
     from opentelemetry.sdk.trace import TracerProvider
 
     try:
-        from phoenix.otel import register
+        from assert_ai import auto_trace
 
-        register(
+        if not auto_trace(
             project_name=os.environ.get("PHOENIX_PROJECT_NAME", "research-agent"),
-            auto_instrument=True,
             verbose=False,
             protocol="http/protobuf",
             batch=True,
-        )
+        ):
+            if not isinstance(trace.get_tracer_provider(), TracerProvider):
+                trace.set_tracer_provider(TracerProvider())
     except Exception:
         if not isinstance(trace.get_tracer_provider(), TracerProvider):
             trace.set_tracer_provider(TracerProvider())

--- a/examples/travel_planner_langgraph/auto_trace.py
+++ b/examples/travel_planner_langgraph/auto_trace.py
@@ -9,8 +9,9 @@ LangChain, LangGraph, OpenAI, and MCP tool calls.
 
 from __future__ import annotations
 
-# pip install openinference-instrumentation-langchain arize-phoenix-otel
-from phoenix.otel import register  # noqa: F401
-register(auto_instrument=True)
+# 1 line to instrument — lazy via assert_ai.auto_trace so importing this
+# module is fast when no Phoenix collector is running. See assert_ai/tracing.py.
+from assert_ai import auto_trace
+auto_trace()
 
 from examples.travel_planner_langgraph.agent import chat_sync  # noqa: E402

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1,0 +1,192 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for ``assert_ai.tracing.auto_trace`` lazy Phoenix wrapper.
+
+Validates the gate logic across all four decision branches without
+actually importing ``phoenix.otel`` (since that pulls in ~5000 modules
+and would dominate the test runtime on cold caches).
+"""
+from __future__ import annotations
+
+import socket
+import sys
+from typing import Any
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from assert_ai import tracing
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Strip all Phoenix-related env vars before each test."""
+    for var in (
+        "PHOENIX_DISABLE_AUTO_INSTRUMENT",
+        "PHOENIX_COLLECTOR_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_ENDPOINT",
+        "ASSERT_AUTO_TRACE_FORCE",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _fake_phoenix_module() -> Any:
+    """Build a fake ``phoenix.otel`` module exposing a ``register`` mock."""
+    mod = MagicMock()
+    mod.register = MagicMock()
+    return mod
+
+
+def _install_fake_phoenix(monkeypatch) -> MagicMock:
+    """Install a fake ``phoenix.otel`` in sys.modules; return its register mock."""
+    mod = _fake_phoenix_module()
+    monkeypatch.setitem(sys.modules, "phoenix.otel", mod)
+    return mod.register
+
+
+# ---------------------------------------------------------------------------
+# phoenix_collector_available() — pure gate logic
+# ---------------------------------------------------------------------------
+
+
+def test_gate_skips_when_explicitly_disabled(monkeypatch):
+    monkeypatch.setenv("PHOENIX_DISABLE_AUTO_INSTRUMENT", "1")
+    assert tracing.phoenix_collector_available() is False
+
+
+def test_gate_skips_when_disable_overrides_other_signals(monkeypatch):
+    # Even if a collector endpoint is set, explicit disable wins.
+    monkeypatch.setenv("PHOENIX_DISABLE_AUTO_INSTRUMENT", "1")
+    monkeypatch.setenv("PHOENIX_COLLECTOR_ENDPOINT", "http://example:6006")
+    assert tracing.phoenix_collector_available() is False
+
+
+def test_gate_fires_when_phoenix_endpoint_env_set(monkeypatch):
+    monkeypatch.setenv("PHOENIX_COLLECTOR_ENDPOINT", "http://collector:6006")
+    # Probe must not be called when env var explicitly opts in.
+    with patch.object(socket, "create_connection") as probe:
+        assert tracing.phoenix_collector_available() is True
+        probe.assert_not_called()
+
+
+def test_gate_fires_when_otel_endpoint_env_set(monkeypatch):
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://otel.example/v1/traces")
+    with patch.object(socket, "create_connection") as probe:
+        assert tracing.phoenix_collector_available() is True
+        probe.assert_not_called()
+
+
+def test_gate_fires_when_force_env_set(monkeypatch):
+    monkeypatch.setenv("ASSERT_AUTO_TRACE_FORCE", "1")
+    with patch.object(socket, "create_connection") as probe:
+        assert tracing.phoenix_collector_available() is True
+        probe.assert_not_called()
+
+
+def test_gate_fires_when_localhost_probe_succeeds():
+    """TCP probe succeeds -> collector is running."""
+    mock_sock = MagicMock()
+    mock_sock.__enter__ = MagicMock(return_value=mock_sock)
+    mock_sock.__exit__ = MagicMock(return_value=False)
+    with patch.object(socket, "create_connection", return_value=mock_sock) as probe:
+        assert tracing.phoenix_collector_available() is True
+        probe.assert_called_once_with(("localhost", 6006), timeout=0.1)
+
+
+def test_gate_skips_when_localhost_probe_refuses():
+    with patch.object(socket, "create_connection", side_effect=ConnectionRefusedError):
+        assert tracing.phoenix_collector_available() is False
+
+
+def test_gate_skips_when_localhost_probe_times_out():
+    with patch.object(socket, "create_connection", side_effect=TimeoutError):
+        assert tracing.phoenix_collector_available() is False
+
+
+def test_gate_skips_when_localhost_probe_oserror():
+    with patch.object(socket, "create_connection", side_effect=OSError("nope")):
+        assert tracing.phoenix_collector_available() is False
+
+
+def test_gate_custom_host_port():
+    with patch.object(socket, "create_connection", return_value=MagicMock(
+        __enter__=MagicMock(return_value=None), __exit__=MagicMock(return_value=False),
+    )) as probe:
+        assert tracing.phoenix_collector_available(host="phoenix.svc", port=4317) is True
+        probe.assert_called_once_with(("phoenix.svc", 4317), timeout=0.1)
+
+
+# ---------------------------------------------------------------------------
+# auto_trace() — calls into phoenix.otel.register when gate fires
+# ---------------------------------------------------------------------------
+
+
+def test_auto_trace_skips_when_gate_false_and_does_not_import_phoenix(monkeypatch):
+    monkeypatch.setenv("PHOENIX_DISABLE_AUTO_INSTRUMENT", "1")
+    # Sentinel: if phoenix.otel were imported, this fake would record it.
+    register = _install_fake_phoenix(monkeypatch)
+    assert tracing.auto_trace() is False
+    register.assert_not_called()
+
+
+def test_auto_trace_fires_when_endpoint_env_set(monkeypatch):
+    monkeypatch.setenv("PHOENIX_COLLECTOR_ENDPOINT", "http://collector:6006")
+    register = _install_fake_phoenix(monkeypatch)
+    assert tracing.auto_trace() is True
+    register.assert_called_once_with(auto_instrument=True)
+
+
+def test_auto_trace_forwards_kwargs(monkeypatch):
+    monkeypatch.setenv("PHOENIX_COLLECTOR_ENDPOINT", "http://collector:6006")
+    register = _install_fake_phoenix(monkeypatch)
+    assert tracing.auto_trace(
+        project_name="my-agent",
+        protocol="http/protobuf",
+        batch=True,
+        verbose=False,
+    ) is True
+    register.assert_called_once_with(
+        auto_instrument=True,
+        project_name="my-agent",
+        protocol="http/protobuf",
+        batch=True,
+        verbose=False,
+    )
+
+
+def test_auto_trace_auto_instrument_false(monkeypatch):
+    monkeypatch.setenv("PHOENIX_COLLECTOR_ENDPOINT", "http://collector:6006")
+    register = _install_fake_phoenix(monkeypatch)
+    assert tracing.auto_trace(auto_instrument=False) is True
+    register.assert_called_once_with(auto_instrument=False)
+
+
+def test_auto_trace_force_bypasses_gate(monkeypatch):
+    # No env vars set, probe would fail.
+    register = _install_fake_phoenix(monkeypatch)
+    with patch.object(socket, "create_connection", side_effect=ConnectionRefusedError):
+        assert tracing.auto_trace(force=True) is True
+    register.assert_called_once_with(auto_instrument=True)
+
+
+def test_auto_trace_returns_false_when_phoenix_not_installed(monkeypatch):
+    monkeypatch.setenv("PHOENIX_COLLECTOR_ENDPOINT", "http://collector:6006")
+    # Simulate phoenix.otel ImportError by inserting a finder that rejects it.
+    monkeypatch.setitem(sys.modules, "phoenix.otel", None)
+    assert tracing.auto_trace() is False
+
+
+def test_auto_trace_swallows_register_no_op_when_gate_false():
+    """Even with no monkey-patching at all, calling auto_trace() in a clean
+    environment with no collector listening should return False and not raise.
+    """
+    # No env vars (autouse fixture), no collector at :6006 in CI.
+    # This is the most realistic 'fresh demo laptop' scenario.
+    with patch.object(socket, "create_connection", side_effect=ConnectionRefusedError):
+        assert tracing.auto_trace() is False


### PR DESCRIPTION
## What changed since the first review

PR #219 originally inlined a 37-line gate into `bank_manager_agent_control/agent.py`. That fixed the 30–50s `import phoenix.otel` cold-start cost but defeated the "2 lines in every agent" pitch in our README — every user would have to copy-paste 37 lines into their own `agent.py`.

This rewrite extracts the gate into `assert_ai.tracing.auto_trace()` so user code becomes:

```python
from assert_ai import auto_trace
auto_trace()
```

…which keeps the install-time pitch honest *and* fixes the slow demo startup.

## Files changed (28 total)

| Surface | Files | What changed |
|---|---|---|
| Helper (new) | `assert_ai/tracing.py` | `auto_trace(**kwargs) -> bool` + `phoenix_collector_available()`. All gate logic lives here. |
| Re-export | `assert_ai/__init__.py` | `from assert_ai import auto_trace` works. |
| Tests (new) | `tests/test_tracing.py` | 17 tests covering every gate branch + kwarg forwarding + `ImportError` handling. |
| Example agents | `bank_manager_agent_control`, `incident_triage_agent`, `change_control_agent`, `science_research_agent` | Inline `register()` blocks replaced; preserved nested-try `TracerProvider` / `_NoopTrace` fallbacks. |
| Public API | `travel_planner_langgraph/auto_trace.py`, `azure_doc_qa/auto_trace.py` | File paths preserved (referenced from yaml configs, tests, website, README); bodies simplified. |
| Gallery | 20 `phoenix_auto_trace/travel_*.py` | Uniform 2-line swap. |

## Gate behavior (unchanged from PR #219)

| Signal | Action |
|---|---|
| `PHOENIX_DISABLE_AUTO_INSTRUMENT=1` | skip |
| `PHOENIX_COLLECTOR_ENDPOINT` set | init |
| `OTEL_EXPORTER_OTLP_ENDPOINT` set | init |
| `ASSERT_AUTO_TRACE_FORCE=1` | init (bypass probe) |
| else | 100 ms TCP probe `localhost:6006`; init iff a collector is listening |

All `phoenix.otel.register()` kwargs (`project_name`, `batch`, `protocol`, `verbose`, `headers`, …) forward through.

## Validation

- `pytest tests/test_tracing.py tests/test_hosted_trace_registration.py` → **20 passed in 0.83s**
- Cold-import smoke (subprocess, no collector) on `assert_ai.tracing`, `assert_ai`, `travel_anthropic`, `travel_openai`, `travel_litellm`, `travel_groq` → **zero `phoenix.*` modules** in `sys.modules` across all six. Down from ~487 `phoenix.*` modules + ~5000 transitive deps + 30–50s wall time.
- Full pytest run (excluding `tests/regression/`) → 1 pre-existing failure on `tests/test_no_p2m_references.py` (flags a "p2m" string in `bank_manager_agent_control/results/.../inference_set.jsonl:86` — a demo-data file). Confirmed unrelated by stashing this refactor and re-running on the bare base branch.

## Follow-ups (separate PR)

- Doc sweep: `README.md`, `examples/README.md`, `examples/phoenix_auto_trace/README.md`, `docs/targets/callable.md`, `docs/getting-started.md`, the per-example READMEs. Common transformation: `from phoenix.otel import register; register(auto_instrument=True)` → `from assert_ai import auto_trace; auto_trace()`.
