### PR TITLE
fix: centralize lazy auto tracing

### DIFF
--- a/assert_ai/auto_trace.py
+++ b/assert_ai/auto_trace.py
@@ -1,0 +1,127 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Lightweight OpenInference/Phoenix auto-tracing helper.
+
+Use ``from assert_ai import auto_trace; auto_trace.enable()`` before importing
+or constructing the target agent. By default, the helper installs any available
+OpenTelemetry/OpenInference instrumentors but avoids importing ``phoenix.otel``
+when no Phoenix/OTLP collector is configured or reachable. This keeps local
+CLI/demo startup fast while still allowing ASSERT's in-process collector to
+capture spans during traced eval runs.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import socket
+from importlib.metadata import entry_points
+
+log = logging.getLogger(__name__)
+
+_enabled = False
+_instrumentors_enabled = False
+
+
+def _can_connect(host: str, port: int, *, timeout: float) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def _collector_available(*, timeout: float = 0.1) -> bool:
+    """Detect whether Phoenix/OTLP export is explicitly configured or local."""
+    if os.environ.get("PHOENIX_DISABLE_AUTO_INSTRUMENT") == "1":
+        return False
+
+    for name in ("PHOENIX_COLLECTOR_ENDPOINT", "OTEL_EXPORTER_OTLP_ENDPOINT"):
+        if os.environ.get(name):
+            log.info("%s is set; enabling Phoenix export", name)
+            return True
+
+    if os.environ.get("ASSERT_EXPORT_TRACES", "").strip() == "1":
+        log.info("ASSERT_EXPORT_TRACES=1; enabling Phoenix export")
+        return True
+
+    ports: list[int] = []
+    grpc_port = os.environ.get("PHOENIX_GRPC_PORT", "")
+    if grpc_port.isnumeric():
+        ports.append(int(grpc_port))
+    ports.extend([4317, 6006])
+
+    seen: set[int] = set()
+    for port in ports:
+        if port in seen:
+            continue
+        seen.add(port)
+        if _can_connect("localhost", port, timeout=timeout):
+            return True
+    return False
+
+
+def _enable_entrypoint_instrumentors() -> None:
+    """Install available OpenTelemetry instrumentors without importing Phoenix."""
+    global _instrumentors_enabled
+    if _instrumentors_enabled:
+        return
+
+    for entry_point in entry_points().select(group="opentelemetry_instrumentor"):
+        if not entry_point.value.startswith("openinference.instrumentation."):
+            continue
+        try:
+            instrumentor_cls = entry_point.load()
+            instrumentor_cls().instrument()
+        except Exception:
+            log.debug("Failed to enable OpenInference instrumentor %s", entry_point.name, exc_info=True)
+    _instrumentors_enabled = True
+
+
+def enable(
+    *,
+    auto_instrument: bool = True,
+    timeout: float = 0.1,
+    export: bool | None = None,
+    **register_kwargs: object,
+) -> bool:
+    """Enable local OpenInference tracing and optional Phoenix export.
+
+    Returns ``True`` when either local instrumentors or Phoenix registration ran.
+    Missing or misconfigured optional tracing dependencies are non-fatal so
+    examples and demos can run without Phoenix installed.
+    """
+    global _enabled
+    if _enabled:
+        return True
+
+    if os.environ.get("PHOENIX_DISABLE_AUTO_INSTRUMENT") == "1":
+        log.info("PHOENIX_DISABLE_AUTO_INSTRUMENT=1; skipping auto-tracing")
+        return False
+
+    if auto_instrument:
+        _enable_entrypoint_instrumentors()
+
+    should_export = _collector_available(timeout=timeout) if export is None else export
+    if not should_export:
+        log.info("No Phoenix/OTLP collector detected; skipping Phoenix export")
+        _enabled = _instrumentors_enabled
+        return _enabled
+
+    try:
+        from phoenix.otel import register
+    except ImportError:
+        log.info("Phoenix tracing dependencies are not installed; skipping Phoenix export")
+        _enabled = _instrumentors_enabled
+        return _enabled
+
+    try:
+        register(auto_instrument=auto_instrument, **register_kwargs)
+    except Exception:
+        log.warning("Failed to enable Phoenix auto-tracing", exc_info=True)
+        _enabled = _instrumentors_enabled
+        return _enabled
+
+    _enabled = True
+    return True

--- a/assert_ai/core/otel_session.py
+++ b/assert_ai/core/otel_session.py
@@ -120,6 +120,10 @@ class OTelTracedSession:
 
         validate_callable_ref(self._callable_ref)
         module_path, func_name = self._callable_ref.rsplit(":", 1)
+        if self._live_otel:
+            from assert_ai import auto_trace
+
+            auto_trace.enable(export=False)
         # Suppress Phoenix/OTel banner output during module import.
         # Phoenix's register(verbose=True) prints a multi-line banner to
         # stdout when the target module calls register() at import time.

--- a/assert_ai/stages/inference.py
+++ b/assert_ai/stages/inference.py
@@ -104,13 +104,13 @@ def _ensure_hosted_trace_instrumentation() -> None:
     if _hosted_trace_registered:
         return
     try:
-        from phoenix.otel import register
+        from assert_ai import auto_trace
         from openinference.instrumentation.litellm import LiteLLMInstrumentor
 
-        register()
+        auto_trace.enable(auto_instrument=False, export=False)
         LiteLLMInstrumentor().instrument()
         _hosted_trace_registered = True
-        log.info("Enabled Phoenix LiteLLM instrumentation for hosted session tracing")
+        log.info("Enabled LiteLLM instrumentation for hosted session tracing")
     except ImportError:
         log.warning(
             "target.trace is set but tracing dependencies are not installed. "

--- a/docs/targets/README.md
+++ b/docs/targets/README.md
@@ -21,8 +21,8 @@ For any agent or multi-agent system you can invoke from Python — LangGraph, Cr
 For 33+ supported frameworks the instrumentation is two lines:
 
 ```python
-from phoenix.otel import register
-register(auto_instrument=True)
+from assert_ai import auto_trace
+auto_trace.enable()
 ```
 
 For unsupported frameworks or custom orchestration, emit your own OTel spans with the OpenTelemetry SDK; `target.trace` reads the same span data either way.

--- a/docs/targets/callable.md
+++ b/docs/targets/callable.md
@@ -4,7 +4,7 @@ Use the callable target for any agent or multi-agent system with a Python entry 
 
 The callable target has two integration paths:
 
-- **Recommended (happy path):** OTel-traced agent — two-line auto-instrumentation across 33 supported frameworks. The judge cites tool calls, routing decisions, model calls, and latency as evidence.
+- **Recommended (happy path):** OTel-traced agent — central auto-instrumentation helper across supported OpenInference frameworks. The judge cites tool calls, routing decisions, model calls, and latency as evidence.
 - **Customization:** for unsupported frameworks (emit your own OTel spans) or for cases where instrumentation is impossible or unnecessary (plain callable / HTTP endpoint, no traces).
 
 ## What the judge sees, by integration path
@@ -27,13 +27,13 @@ Pick the path that exposes enough internals for the judge to score what matters.
 
 When your agent emits OpenTelemetry spans, the judge can cite tool arguments, routing decisions, model calls, and latency as evidence — not just the final response. This is the integration shape every flagship example uses.
 
-For 33 supported frameworks (OpenAI Agents SDK, LangChain/LangGraph, CrewAI, DSPy, LlamaIndex, AutoGen, MAF, Pydantic AI, Smolagents, Instructor, Haystack, …), instrumentation is **two lines** at the top of your callable module:
+For 33 supported frameworks (OpenAI Agents SDK, LangChain/LangGraph, CrewAI, DSPy, LlamaIndex, AutoGen, MAF, Pydantic AI, Smolagents, Instructor, Haystack, …), instrumentation is a small helper call at the top of your callable module:
 
 ```python
 # e.g. examples/travel_planner_langgraph/auto_trace.py
-from phoenix.otel import register
+from assert_ai import auto_trace
 
-register(auto_instrument=True)  # picks up any installed openinference-instrumentation-* package
+auto_trace.enable()  # installs available OpenInference instrumentors without starting Phoenix
 
 def chat_sync(message: str, history: list[dict[str, str]] | None = None) -> str:
     return run_my_agent(message, history)

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@ Runnable configs and sample agents for ASSERT.
 
 Start with the LangGraph travel planner. It is the flagship example because it exercises the real agent path on top of the universal `target.callable` integration: spec-driven test generation, inference outputs (conversations or agent actions), OTel-traced execution, and judge evidence. Phoenix/OpenInference auto-instrumentation captures the agent's OpenTelemetry spans so the judge cites tool calls, routing, and intermediate decisions in every verdict.
 
-> **Any agent works.** `target.callable` accepts any agent or multi-agent system you can invoke from a Python function — frameworks (LangGraph, CrewAI, AutoGen, OpenAI Agents SDK, DSPy, LlamaIndex, …), custom orchestration, REST clients, or thin wrappers around hosted models. The recommended integration adds two lines (`from phoenix.otel import register; register(auto_instrument=True)`) so the judge can score tool use and routing, not just the final response.
+> **Any agent works.** `target.callable` accepts any agent or multi-agent system you can invoke from a Python function — frameworks (LangGraph, CrewAI, AutoGen, OpenAI Agents SDK, DSPy, LlamaIndex, …), custom orchestration, REST clients, or thin wrappers around hosted models. The recommended integration adds the central helper (`from assert_ai import auto_trace; auto_trace.enable()`) so the judge can score tool use and routing, not just the final response.
 
 ## First run
 
@@ -39,7 +39,7 @@ See the [CLI reference](../docs/reference/cli.md#design-a-config-interactively) 
 | Goal | Example | Notes |
 |---|---|---|
 | Evaluate any agent or multi-agent system (recommended) | `travel_planner_langgraph/eval_config.yaml` | Canonical example. Uses `target.callable` with `target.trace.backend: phoenix` so the judge sees tool calls and routing. |
-| Understand framework instrumentation breadth | `phoenix_auto_trace/README.md` | Same travel-planner idea across multiple framework auto-instrumentation paths. |
+| Understand framework instrumentation breadth | `phoenix_auto_trace/README.md` | Same travel-planner idea across multiple framework auto-instrumentation paths using `assert_ai.auto_trace`. |
 | Run a simple hosted-model eval | `prompt_agents/health_assistant.yaml` | Most simple example: a single LLM target with a system prompt. |
 | Evaluate a Prompt Agent with planned tools but no backend | `prompt_agents/health_assistant_simulated_tools.yaml` | Uses a fixed tool schema and simulated tool responses. |
 | Evaluate a hosted target with Python tool functions | `prompt_agents/health_assistant_sandbox.yaml` | Requires Docker. Use when you want actual tool execution around a hosted model. |

--- a/examples/azure_doc_qa/auto_trace.py
+++ b/examples/azure_doc_qa/auto_trace.py
@@ -1,16 +1,16 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-"""Phoenix OTel auto-instrumentation for the Azure Doc QA agent.
+"""OpenInference auto-instrumentation for the Azure Doc QA agent.
 
-2 lines to instrument, then run the agent unchanged. Phoenix auto-discovers
-LangChain, LangGraph, OpenAI, and MCP tool calls.
+Central helper installs available OpenInference instrumentors without starting
+Phoenix unless a collector is configured or reachable.
 """
 
 from __future__ import annotations
 
 # pip install openinference-instrumentation-langchain arize-phoenix-otel
-from phoenix.otel import register  # noqa: F401
-register(auto_instrument=True)
+from assert_ai import auto_trace  # noqa: F401
+auto_trace.enable()
 
 from examples.azure_doc_qa.agent import chat_sync  # noqa: E402

--- a/examples/change_control_agent/agent.py
+++ b/examples/change_control_agent/agent.py
@@ -34,9 +34,9 @@ try:
     from opentelemetry.sdk.trace import TracerProvider
 
     try:
-        from phoenix.otel import register
+        from assert_ai import auto_trace
 
-        register(
+        auto_trace.enable(
             project_name=os.environ.get("PHOENIX_PROJECT_NAME", "change-control-agent"),
             auto_instrument=True,
             verbose=False,

--- a/examples/incident_triage_agent/agent.py
+++ b/examples/incident_triage_agent/agent.py
@@ -29,9 +29,9 @@ from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 
 try:
-    from phoenix.otel import register
+    from assert_ai import auto_trace
 
-    register(
+    auto_trace.enable(
         project_name=os.environ.get("PHOENIX_PROJECT_NAME", "incident-triage-agent"),
         auto_instrument=True,
         verbose=False,

--- a/examples/phoenix_auto_trace/README.md
+++ b/examples/phoenix_auto_trace/README.md
@@ -1,6 +1,6 @@
 # Phoenix Auto-Trace Gallery — Same Scenario, 33 Frameworks
 
-This is a **multi-framework instrumentation gallery**, not a single-agent example. It shows how one Phoenix/OpenInference setup (typically 2 lines: install the instrumentor, call `register(auto_instrument=True)`) gives `target.callable` + `target.trace` OpenTelemetry visibility across supported frameworks — without per-framework integration work in ASSERT itself.
+This is a **multi-framework instrumentation gallery**, not a single-agent example. It shows how the `assert_ai.auto_trace` helper gives `target.callable` + `target.trace` OpenTelemetry visibility across supported frameworks — without per-framework integration work in ASSERT itself.
 
 All runnable demos implement the **same travel planner** with 5 mock tools:
 
@@ -65,7 +65,7 @@ Additional runnable variants: `travel_langgraph.py` (LangGraph-specific target u
 | `openinference-instrumentation-agentspec` | AgentSpec |
 | `openinference-instrumentation-vertexai` | VertexAI |
 
-**Total: 33 auto-instrumented frameworks** in OpenInference. This gallery includes 19 per-framework demos plus the runnable variants above; the remaining instrumentors follow the same install + `register(auto_instrument=True)` pattern. For anything not in OpenInference, you can still emit spans via the OpenTelemetry SDK with `@tracer.start_as_current_span`.
+**Total: 33 auto-instrumented frameworks** in OpenInference. This gallery includes 19 per-framework demos plus the runnable variants above; the remaining instrumentors follow the same install + `auto_trace.enable()` pattern. For anything not in OpenInference, you can still emit spans via the OpenTelemetry SDK with `@tracer.start_as_current_span`.
 
 ---
 

--- a/examples/phoenix_auto_trace/travel_anthropic.py
+++ b/examples/phoenix_auto_trace/travel_anthropic.py
@@ -3,13 +3,13 @@
 
 """Travel planner — Anthropic Claude (native tool use).
 
-Instrumentation: 2 lines. Agent code: standard Anthropic SDK.
+Instrumentation: central helper call. Agent code: standard Anthropic SDK.
 Traces captured: LLM calls, tool use blocks, token counts, latency.
 """
 
-# pip install openinference-instrumentation-anthropic arize-phoenix-otel
-from phoenix.otel import register
-register(auto_instrument=True)
+# Optional Phoenix export: pip install openinference-instrumentation-anthropic arize-phoenix-otel
+from assert_ai import auto_trace
+auto_trace.enable()
 
 import json
 import anthropic

--- a/examples/phoenix_auto_trace/travel_autogen.py
+++ b/examples/phoenix_auto_trace/travel_autogen.py
@@ -3,15 +3,15 @@
 
 """Travel planner — AutoGen AgentChat (multi-agent conversation).
 
-Instrumentation: 2 lines. Agent code: standard AutoGen AgentChat.
+Instrumentation: central helper call. Agent code: standard AutoGen AgentChat.
 Traces captured: agent messages, tool calls, LLM calls, team orchestration, token counts.
 """
 
 from __future__ import annotations
 
-# pip install openinference-instrumentation-autogen-agentchat arize-phoenix-otel
-from phoenix.otel import register
-register(auto_instrument=True)
+# Optional Phoenix export: pip install openinference-instrumentation-autogen-agentchat arize-phoenix-otel
+from assert_ai import auto_trace
+auto_trace.enable()
 
 import asyncio
 import os

--- a/examples/phoenix_auto_trace/travel_bedrock.py
+++ b/examples/phoenix_auto_trace/travel_bedrock.py
@@ -3,15 +3,15 @@
 
 """Travel planner — AWS Bedrock (Anthropic Claude on AWS).
 
-Instrumentation: 2 lines. Agent code: standard Bedrock via boto3.
+Instrumentation: central helper call. Agent code: standard Bedrock via boto3.
 Traces captured: LLM calls, tool use, token counts, latency.
 """
 
 from __future__ import annotations
 
-# pip install openinference-instrumentation-bedrock arize-phoenix-otel
-from phoenix.otel import register
-register(auto_instrument=True)
+# Optional Phoenix export: pip install openinference-instrumentation-bedrock arize-phoenix-otel
+from assert_ai import auto_trace
+auto_trace.enable()
 
 import json
 import boto3

--- a/examples/phoenix_auto_trace/travel_crewai.py
+++ b/examples/phoenix_auto_trace/travel_crewai.py
@@ -3,7 +3,7 @@
 
 """Travel planner — CrewAI (multi-agent crew).
 
-Instrumentation: 2 lines. Agent code: standard CrewAI.
+Instrumentation: central helper call. Agent code: standard CrewAI.
 Traces captured: agent delegations, LLM calls per agent, tool invocations,
 crew execution flow, token counts.
 """
@@ -11,11 +11,11 @@ crew execution flow, token counts.
 from __future__ import annotations
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-# 2 lines of instrumentation
+# Central helper instrumentation
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-# pip install openinference-instrumentation-crewai arize-phoenix-otel
-from phoenix.otel import register  # noqa: E402
-register(auto_instrument=True)
+# Optional Phoenix export: pip install openinference-instrumentation-crewai arize-phoenix-otel
+from assert_ai import auto_trace  # noqa: E402
+auto_trace.enable()
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # Agent code — standard CrewAI

--- a/examples/phoenix_auto_trace/travel_dspy.py
+++ b/examples/phoenix_auto_trace/travel_dspy.py
@@ -3,18 +3,18 @@
 
 """Travel planner — DSPy (declarative signatures).
 
-Instrumentation: 2 lines. Agent code: standard DSPy.
+Instrumentation: central helper call. Agent code: standard DSPy.
 Traces captured: module calls, LLM calls with signatures, optimization steps.
 """
 
 from __future__ import annotations
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-# 2 lines of instrumentation
+# Central helper instrumentation
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-# pip install openinference-instrumentation-dspy arize-phoenix-otel
-from phoenix.otel import register  # noqa: E402
-register(auto_instrument=True)
+# Optional Phoenix export: pip install openinference-instrumentation-dspy arize-phoenix-otel
+from assert_ai import auto_trace  # noqa: E402
+auto_trace.enable()
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # Agent code — standard DSPy

--- a/examples/phoenix_auto_trace/travel_google_adk.py
+++ b/examples/phoenix_auto_trace/travel_google_adk.py
@@ -3,15 +3,15 @@
 
 """Travel planner — Google ADK (Agent Development Kit).
 
-Instrumentation: 2 lines. Agent code: standard Google ADK.
+Instrumentation: central helper call. Agent code: standard Google ADK.
 Traces captured: agent execution, LLM calls, tool invocations, sub-agent delegations.
 """
 
 from __future__ import annotations
 
-# pip install openinference-instrumentation-google-adk arize-phoenix-otel
-from phoenix.otel import register
-register(auto_instrument=True)
+# Optional Phoenix export: pip install openinference-instrumentation-google-adk arize-phoenix-otel
+from assert_ai import auto_trace
+auto_trace.enable()
 
 from google.adk.agents import Agent
 from google.adk.tools import FunctionTool

--- a/examples/phoenix_auto_trace/travel_google_genai.py
+++ b/examples/phoenix_auto_trace/travel_google_genai.py
@@ -3,15 +3,15 @@
 
 """Travel planner — Google GenAI (Gemini).
 
-Instrumentation: 2 lines. Agent code: standard google-genai SDK.
+Instrumentation: central helper call. Agent code: standard google-genai SDK.
 Traces captured: LLM calls, function calls, token counts, latency.
 """
 
 from __future__ import annotations
 
-# pip install openinference-instrumentation-google-genai arize-phoenix-otel
-from phoenix.otel import register
-register(auto_instrument=True)
+# Optional Phoenix export: pip install openinference-instrumentation-google-genai arize-phoenix-otel
+from assert_ai import auto_trace
+auto_trace.enable()
 
 import json
 from google import genai

--- a/examples/phoenix_auto_trace/travel_groq.py
+++ b/examples/phoenix_auto_trace/travel_groq.py
@@ -3,13 +3,13 @@
 
 """Travel planner — Groq (fast inference).
 
-Instrumentation: 2 lines. Agent code: standard Groq SDK (OpenAI-compatible).
+Instrumentation: central helper call. Agent code: standard Groq SDK (OpenAI-compatible).
 Traces captured: LLM calls, tool calls, token counts, latency.
 """
 
-# pip install openinference-instrumentation-groq arize-phoenix-otel
-from phoenix.otel import register
-register(auto_instrument=True)
+# Optional Phoenix export: pip install openinference-instrumentation-groq arize-phoenix-otel
+from assert_ai import auto_trace
+auto_trace.enable()
 
 import json
 from groq import Groq

--- a/examples/phoenix_auto_trace/travel_haystack.py
+++ b/examples/phoenix_auto_trace/travel_haystack.py
@@ -3,15 +3,15 @@
 
 """Travel planner — Haystack (pipeline with tool-calling loop).
 
-Instrumentation: 2 lines. Agent code: standard Haystack 2.x.
+Instrumentation: central helper call. Agent code: standard Haystack 2.x.
 Traces captured: pipeline runs, LLM calls, tool invocations, token counts, latency.
 """
 
 from __future__ import annotations
 
-# pip install openinference-instrumentation-haystack arize-phoenix-otel
-from phoenix.otel import register
-register(auto_instrument=True)
+# Optional Phoenix export: pip install openinference-instrumentation-haystack arize-phoenix-otel
+from assert_ai import auto_trace
+auto_trace.enable()
 
 import os
 

--- a/examples/phoenix_auto_trace/travel_instructor.py
+++ b/examples/phoenix_auto_trace/travel_instructor.py
@@ -3,15 +3,15 @@
 
 """Travel planner — Instructor (structured LLM output via Pydantic).
 
-Instrumentation: 2 lines. Agent code: Instructor-patched OpenAI client.
+Instrumentation: central helper call. Agent code: Instructor-patched OpenAI client.
 Traces captured: LLM calls with structured output schemas, token counts, latency.
 """
 
 from __future__ import annotations
 
-# pip install openinference-instrumentation-instructor arize-phoenix-otel
-from phoenix.otel import register
-register(auto_instrument=True)
+# Optional Phoenix export: pip install openinference-instrumentation-instructor arize-phoenix-otel
+from assert_ai import auto_trace
+auto_trace.enable()
 
 import os
 

--- a/examples/phoenix_auto_trace/travel_langchain.py
+++ b/examples/phoenix_auto_trace/travel_langchain.py
@@ -3,7 +3,7 @@
 
 """Travel planner — LangChain/LangGraph (multi-node graph).
 
-Instrumentation: 2 lines. Agent code: standard LangGraph.
+Instrumentation: central helper call. Agent code: standard LangGraph.
 Traces captured: graph node executions, LLM calls per node, tool invocations,
 routing decisions, token counts, latency per node.
 
@@ -14,11 +14,11 @@ architecture, no MCP dependency, self-contained with simulated tools.
 from __future__ import annotations
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-# 2 lines of instrumentation
+# Central helper instrumentation
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-# pip install openinference-instrumentation-langchain arize-phoenix-otel
-from phoenix.otel import register  # noqa: E402
-register(auto_instrument=True)
+# Optional Phoenix export: pip install openinference-instrumentation-langchain arize-phoenix-otel
+from assert_ai import auto_trace  # noqa: E402
+auto_trace.enable()
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # Agent code — standard LangGraph

--- a/examples/phoenix_auto_trace/travel_litellm.py
+++ b/examples/phoenix_auto_trace/travel_litellm.py
@@ -3,13 +3,13 @@
 
 """Travel planner — LiteLLM (provider-agnostic).
 
-Instrumentation: 2 lines. Agent code: LiteLLM completion with tools.
+Instrumentation: central helper call. Agent code: LiteLLM completion with tools.
 Traces captured: LLM calls, tool calls, token counts, latency, model name.
 """
 
-# pip install openinference-instrumentation-litellm arize-phoenix-otel
-from phoenix.otel import register
-register(auto_instrument=True)
+# Optional Phoenix export: pip install openinference-instrumentation-litellm arize-phoenix-otel
+from assert_ai import auto_trace
+auto_trace.enable()
 
 import json
 import os

--- a/examples/phoenix_auto_trace/travel_llamaindex.py
+++ b/examples/phoenix_auto_trace/travel_llamaindex.py
@@ -3,7 +3,7 @@
 
 """Travel planner — LlamaIndex (ReAct agent).
 
-Instrumentation: 2 lines. Agent code: standard LlamaIndex.
+Instrumentation: central helper call. Agent code: standard LlamaIndex.
 Traces captured: LLM calls, tool invocations,
 response synthesis, token counts.
 """
@@ -11,11 +11,11 @@ response synthesis, token counts.
 from __future__ import annotations
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-# 2 lines of instrumentation
+# Central helper instrumentation
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-# pip install openinference-instrumentation-llama-index arize-phoenix-otel
-from phoenix.otel import register  # noqa: E402
-register(auto_instrument=True)
+# Optional Phoenix export: pip install openinference-instrumentation-llama-index arize-phoenix-otel
+from assert_ai import auto_trace  # noqa: E402
+auto_trace.enable()
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # Agent code — standard LlamaIndex

--- a/examples/phoenix_auto_trace/travel_mistralai.py
+++ b/examples/phoenix_auto_trace/travel_mistralai.py
@@ -3,13 +3,13 @@
 
 """Travel planner — MistralAI.
 
-Instrumentation: 2 lines. Agent code: standard Mistral SDK.
+Instrumentation: central helper call. Agent code: standard Mistral SDK.
 Traces captured: LLM calls, tool calls, token counts, latency.
 """
 
-# pip install openinference-instrumentation-mistralai arize-phoenix-otel
-from phoenix.otel import register
-register(auto_instrument=True)
+# Optional Phoenix export: pip install openinference-instrumentation-mistralai arize-phoenix-otel
+from assert_ai import auto_trace
+auto_trace.enable()
 
 import json
 from mistralai import Mistral

--- a/examples/phoenix_auto_trace/travel_openai.py
+++ b/examples/phoenix_auto_trace/travel_openai.py
@@ -3,13 +3,13 @@
 
 """Travel planner — OpenAI direct (function calling).
 
-Instrumentation: 2 lines. Agent code: standard OpenAI SDK.
+Instrumentation: central helper call. Agent code: standard OpenAI SDK.
 Traces captured: LLM calls, tool calls with args/results, token counts, latency.
 """
 
-# pip install openinference-instrumentation-openai arize-phoenix-otel
-from phoenix.otel import register
-register(auto_instrument=True)
+# Optional Phoenix export: pip install openinference-instrumentation-openai arize-phoenix-otel
+from assert_ai import auto_trace
+auto_trace.enable()
 
 import json
 import os

--- a/examples/phoenix_auto_trace/travel_openai_agents.py
+++ b/examples/phoenix_auto_trace/travel_openai_agents.py
@@ -3,15 +3,15 @@
 
 """Travel planner — OpenAI Agents SDK (multi-agent orchestration).
 
-Instrumentation: 2 lines. Agent code: standard openai-agents SDK.
+Instrumentation: central helper call. Agent code: standard openai-agents SDK.
 Traces captured: agent runs, handoffs, tool calls, LLM completions, token counts.
 """
 
 from __future__ import annotations
 
-# pip install openinference-instrumentation-openai-agents arize-phoenix-otel
-from phoenix.otel import register
-register(auto_instrument=True)
+# Optional Phoenix export: pip install openinference-instrumentation-openai-agents arize-phoenix-otel
+from assert_ai import auto_trace
+auto_trace.enable()
 
 import asyncio
 import os

--- a/examples/phoenix_auto_trace/travel_openai_router.py
+++ b/examples/phoenix_auto_trace/travel_openai_router.py
@@ -2,8 +2,8 @@
 # Licensed under the MIT License.
 
 """Travel planner — model-router (SWC endpoint, multi-model ensemble)."""
-from phoenix.otel import register
-register(auto_instrument=True)
+from assert_ai import auto_trace
+auto_trace.enable()
 
 import json
 import os

--- a/examples/phoenix_auto_trace/travel_portkey.py
+++ b/examples/phoenix_auto_trace/travel_portkey.py
@@ -3,13 +3,13 @@
 
 """Travel planner — Portkey AI Gateway.
 
-Instrumentation: 2 lines. Agent code: Portkey SDK (OpenAI-compatible).
+Instrumentation: central helper call. Agent code: Portkey SDK (OpenAI-compatible).
 Traces captured: LLM calls, gateway routing, fallbacks, token counts, latency.
 """
 
-# pip install openinference-instrumentation-portkey arize-phoenix-otel
-from phoenix.otel import register
-register(auto_instrument=True)
+# Optional Phoenix export: pip install openinference-instrumentation-portkey arize-phoenix-otel
+from assert_ai import auto_trace
+auto_trace.enable()
 
 import json
 from portkey_ai import Portkey

--- a/examples/phoenix_auto_trace/travel_pydantic_ai.py
+++ b/examples/phoenix_auto_trace/travel_pydantic_ai.py
@@ -3,15 +3,15 @@
 
 """Travel planner — PydanticAI (agent framework with typed tools).
 
-Instrumentation: 2 lines. Agent code: standard PydanticAI.
+Instrumentation: central helper call. Agent code: standard PydanticAI.
 Traces captured: agent runs, tool calls, LLM calls, structured output, token counts.
 """
 
 from __future__ import annotations
 
-# pip install openinference-instrumentation-pydantic-ai arize-phoenix-otel
-from phoenix.otel import register
-register(auto_instrument=True)
+# Optional Phoenix export: pip install openinference-instrumentation-pydantic-ai arize-phoenix-otel
+from assert_ai import auto_trace
+auto_trace.enable()
 
 import os
 

--- a/examples/phoenix_auto_trace/travel_smolagents.py
+++ b/examples/phoenix_auto_trace/travel_smolagents.py
@@ -3,15 +3,15 @@
 
 """Travel planner — smolagents (HuggingFace tool-calling agent).
 
-Instrumentation: 2 lines. Agent code: standard smolagents.
+Instrumentation: central helper call. Agent code: standard smolagents.
 Traces captured: agent steps, tool calls, LLM calls, reasoning traces, token counts.
 """
 
 from __future__ import annotations
 
-# pip install openinference-instrumentation-smolagents arize-phoenix-otel
-from phoenix.otel import register
-register(auto_instrument=True)
+# Optional Phoenix export: pip install openinference-instrumentation-smolagents arize-phoenix-otel
+from assert_ai import auto_trace
+auto_trace.enable()
 
 import os
 

--- a/examples/science_research_agent/agent.py
+++ b/examples/science_research_agent/agent.py
@@ -34,9 +34,9 @@ try:
     from opentelemetry.sdk.trace import TracerProvider
 
     try:
-        from phoenix.otel import register
+        from assert_ai import auto_trace
 
-        register(
+        auto_trace.enable(
             project_name=os.environ.get("PHOENIX_PROJECT_NAME", "research-agent"),
             auto_instrument=True,
             verbose=False,

--- a/examples/travel_planner_langgraph/README.md
+++ b/examples/travel_planner_langgraph/README.md
@@ -13,7 +13,7 @@ generated test case
 assert-ai inference loop
       |
       v
-auto_trace.register(auto_instrument=True) -> chat_sync(message)
+auto_trace.enable() -> chat_sync(message)
       |
       v
 intent_classifier -- no book_trip/destination --> clarification --> END

--- a/examples/travel_planner_langgraph/auto_trace.py
+++ b/examples/travel_planner_langgraph/auto_trace.py
@@ -1,16 +1,16 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-"""Phoenix OTel auto-instrumentation for the LangGraph travel planner.
+"""OpenInference auto-instrumentation for the LangGraph travel planner.
 
-2 lines to instrument, then run the agent unchanged. Phoenix auto-discovers
-LangChain, LangGraph, OpenAI, and MCP tool calls.
+Central helper installs available OpenInference instrumentors without starting
+Phoenix unless a collector is configured or reachable.
 """
 
 from __future__ import annotations
 
 # pip install openinference-instrumentation-langchain arize-phoenix-otel
-from phoenix.otel import register  # noqa: F401
-register(auto_instrument=True)
+from assert_ai import auto_trace  # noqa: F401
+auto_trace.enable()
 
 from examples.travel_planner_langgraph.agent import chat_sync  # noqa: E402

--- a/examples/travel_planner_neurosan/README.md
+++ b/examples/travel_planner_neurosan/README.md
@@ -7,8 +7,7 @@ This is the NeurOSan-pattern variant of the travel-planner agent. The flagship [
 
 ## Why this matters
 
-The `phoenix_auto_trace/` demos show the happy path: Phoenix auto-discovers frameworks
-and instruments them with 2 lines. But what about custom orchestrators, in-house
+The `phoenix_auto_trace/` demos show the happy path: the central `assert_ai.auto_trace` helper installs available framework instrumentors. But what about custom orchestrators, in-house
 frameworks, or agents that Phoenix doesn't auto-instrument?
 
 This demo proves the general case: if your code emits OpenTelemetry spans following

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ examples = [
   "pydantic-ai>=0.8.1",
   "smolagents>=1.22.0",
   # Framework-specific OpenInference instrumentors used by the
-  # examples/phoenix_auto_trace/* demos. `phoenix.otel.register(auto_instrument=True)`
+  # examples/phoenix_auto_trace/* demos. `assert_ai.auto_trace.enable()`
   # auto-loads every installed `openinference-instrumentation-*` package and a
   # single version mismatch crashes the whole call, so the upper bounds below
   # match the framework versions pinned above. The crewai instrumentor pin is

--- a/tests/test_auto_trace.py
+++ b/tests/test_auto_trace.py
@@ -1,0 +1,90 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for assert_ai.auto_trace helper."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+class AutoTraceTest(unittest.TestCase):
+    def setUp(self) -> None:
+        sys.modules.pop("assert_ai.auto_trace", None)
+        self.auto_trace = importlib.import_module("assert_ai.auto_trace")
+        self.auto_trace._enabled = False
+        self.auto_trace._instrumentors_enabled = False
+
+    def tearDown(self) -> None:
+        self.auto_trace._enabled = False
+        self.auto_trace._instrumentors_enabled = False
+
+    def test_skips_phoenix_import_when_no_collector_is_available(self) -> None:
+        mock_instrumentor = MagicMock()
+        entry_point = MagicMock()
+        entry_point.name = "openai"
+        entry_point.value = "openinference.instrumentation.openai:OpenAIInstrumentor"
+        entry_point.load.return_value = MagicMock(return_value=mock_instrumentor)
+        entry_points_result = MagicMock()
+        entry_points_result.select.return_value = [entry_point]
+
+        with patch.dict("sys.modules", {"phoenix.otel": MagicMock()}, clear=False), \
+             patch.dict("os.environ", {}, clear=True), \
+             patch.object(self.auto_trace, "entry_points", return_value=entry_points_result), \
+             patch.object(self.auto_trace.socket, "create_connection", side_effect=OSError):
+            self.assertTrue(self.auto_trace.enable())
+
+        self.assertTrue(self.auto_trace._enabled)
+        mock_instrumentor.instrument.assert_called_once()
+        self.assertNotIn("phoenix.otel", sys.modules)
+
+    def test_registers_when_explicit_endpoint_is_configured(self) -> None:
+        mock_register = MagicMock()
+        with patch.dict("sys.modules", {"phoenix.otel": MagicMock(register=mock_register)}, clear=False), \
+             patch.dict("os.environ", {"PHOENIX_COLLECTOR_ENDPOINT": "http://localhost:6006"}, clear=True), \
+             patch.object(self.auto_trace, "_enable_entrypoint_instrumentors"), \
+             patch.object(self.auto_trace.socket, "create_connection", side_effect=AssertionError("probe should be skipped")):
+            self.assertTrue(self.auto_trace.enable())
+
+        mock_register.assert_called_once_with(auto_instrument=True)
+        self.assertTrue(self.auto_trace._enabled)
+
+    def test_disable_env_overrides_explicit_endpoint(self) -> None:
+        mock_register = MagicMock()
+        with patch.dict("sys.modules", {"phoenix.otel": MagicMock(register=mock_register)}, clear=False), \
+             patch.dict("os.environ", {
+                 "PHOENIX_DISABLE_AUTO_INSTRUMENT": "1",
+                 "PHOENIX_COLLECTOR_ENDPOINT": "http://localhost:6006",
+             }, clear=True):
+            self.assertFalse(self.auto_trace.enable())
+
+        mock_register.assert_not_called()
+        self.assertFalse(self.auto_trace._enabled)
+
+    def test_probes_default_otlp_and_phoenix_ports(self) -> None:
+        mock_register = MagicMock()
+        calls: list[tuple[tuple[str, int], float | None]] = []
+
+        def fake_create_connection(address: tuple[str, int], timeout: float | None = None):
+            calls.append((address, timeout))
+            if address == ("localhost", 4317):
+                raise OSError("no grpc collector")
+            connection = MagicMock()
+            connection.__enter__.return_value = connection
+            return connection
+
+        with patch.dict("sys.modules", {"phoenix.otel": MagicMock(register=mock_register)}, clear=False), \
+             patch.dict("os.environ", {}, clear=True), \
+             patch.object(self.auto_trace, "_enable_entrypoint_instrumentors"), \
+             patch.object(self.auto_trace.socket, "create_connection", side_effect=fake_create_connection):
+            self.assertTrue(self.auto_trace.enable())
+
+        self.assertEqual(calls, [(("localhost", 4317), 0.1), (("localhost", 6006), 0.1)])
+        mock_register.assert_called_once_with(auto_instrument=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hosted_trace_registration.py
+++ b/tests/test_hosted_trace_registration.py
@@ -6,12 +6,12 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
+import assert_ai
 import assert_ai.stages.inference as inference_mod
 
 
 class HostedTraceRegistrationTest(unittest.TestCase):
     def setUp(self) -> None:
-        # Reset the module-level flag before each test.
         inference_mod._hosted_trace_registered = False
 
     def tearDown(self) -> None:
@@ -19,27 +19,30 @@ class HostedTraceRegistrationTest(unittest.TestCase):
 
     @patch("assert_ai.stages.inference.log")
     def test_registers_once_on_success(self, mock_log: MagicMock) -> None:
-        mock_register = MagicMock()
+        mock_auto_trace = MagicMock()
         mock_instrumentor = MagicMock()
         mock_instrumentor_cls = MagicMock(return_value=mock_instrumentor)
 
-        with patch.dict("sys.modules", {
-            "phoenix.otel": MagicMock(register=mock_register),
-            "openinference.instrumentation.litellm": MagicMock(LiteLLMInstrumentor=mock_instrumentor_cls),
-            "openinference": MagicMock(),
-            "openinference.instrumentation": MagicMock(),
-        }):
+        with patch.object(assert_ai, "auto_trace", mock_auto_trace, create=True), patch.dict(
+            "sys.modules",
+            {
+                "openinference.instrumentation.litellm": MagicMock(
+                    LiteLLMInstrumentor=mock_instrumentor_cls
+                ),
+                "openinference": MagicMock(),
+                "openinference.instrumentation": MagicMock(),
+            },
+        ):
             inference_mod._ensure_hosted_trace_instrumentation()
 
         self.assertTrue(inference_mod._hosted_trace_registered)
-        mock_register.assert_called_once()
+        mock_auto_trace.enable.assert_called_once_with(auto_instrument=False, export=False)
         mock_instrumentor.instrument.assert_called_once()
 
-        # Second call is a no-op.
-        mock_register.reset_mock()
+        mock_auto_trace.enable.reset_mock()
         mock_instrumentor.instrument.reset_mock()
         inference_mod._ensure_hosted_trace_instrumentation()
-        mock_register.assert_not_called()
+        mock_auto_trace.enable.assert_not_called()
         mock_instrumentor.instrument.assert_not_called()
 
     @patch("assert_ai.stages.inference.log")
@@ -52,14 +55,17 @@ class HostedTraceRegistrationTest(unittest.TestCase):
 
     @patch("assert_ai.stages.inference.log")
     def test_flag_stays_false_on_runtime_error(self, mock_log: MagicMock) -> None:
-        mock_register = MagicMock(side_effect=RuntimeError("config error"))
+        mock_auto_trace = MagicMock()
+        mock_auto_trace.enable.side_effect = RuntimeError("config error")
 
-        with patch.dict("sys.modules", {
-            "phoenix.otel": MagicMock(register=mock_register),
-            "openinference.instrumentation.litellm": MagicMock(LiteLLMInstrumentor=MagicMock()),
-            "openinference": MagicMock(),
-            "openinference.instrumentation": MagicMock(),
-        }):
+        with patch.object(assert_ai, "auto_trace", mock_auto_trace, create=True), patch.dict(
+            "sys.modules",
+            {
+                "openinference.instrumentation.litellm": MagicMock(LiteLLMInstrumentor=MagicMock()),
+                "openinference": MagicMock(),
+                "openinference.instrumentation": MagicMock(),
+            },
+        ):
             inference_mod._ensure_hosted_trace_instrumentation()
 
         self.assertFalse(inference_mod._hosted_trace_registered)


### PR DESCRIPTION
## Summary
- Add a central `assert_ai.auto_trace` helper that installs available OpenInference instrumentors without importing Phoenix unless export is configured/reachable
- Use the helper from traced callable/hosted runtime paths so ASSERT can collect local spans without starting Phoenix export
- Replace direct `phoenix.otel.register(auto_instrument=True)` calls across examples and docs with the central helper

## Why
Importing `phoenix.otel` can pull in the Phoenix UI stack and make clean demo/CLI startup extremely slow. The helper keeps no-collector runs fast while preserving local trace capture for ASSERT's in-process collector.

## Validation
- `python3.11 -m pytest tests/test_auto_trace.py tests/test_hosted_trace_registration.py -q` -> 7 passed
- `python3.11 -m compileall -q assert_ai examples/phoenix_auto_trace examples/travel_planner_langgraph examples/azure_doc_qa examples/incident_triage_agent examples/science_research_agent examples/change_control_agent examples/travel_planner_neurosan` -> passed
- No stale direct `from phoenix.otel import register` call sites remain outside `assert_ai/auto_trace.py`
- No-collector smoke: `auto_trace.enable()` returned true from local instrumentors and did not load any `phoenix.*` modules
