### PR TITLE
test: fix viewer Node harness env import

### DIFF
--- a/tests/test_viewer_server_artifacts.py
+++ b/tests/test_viewer_server_artifacts.py
@@ -39,6 +39,7 @@ class ViewerServerArtifactsTest(unittest.TestCase):
 
         data_source = (
             DATA_SRC.read_text(encoding="utf-8")
+            .replace("import { env } from '$env/dynamic/private';", "const env = process.env;")
             .replace("./config.js", "./config.ts")
             .replace("./dimensions.js", "./dimensions.ts")
             .replace("./artifacts.js", "./artifacts.ts")


### PR DESCRIPTION
## Summary
- rewrites SvelteKit's `$env/dynamic/private` import in the standalone viewer Node test harness
- maps it to `const env = process.env;` so `data.ts` can run outside SvelteKit in Tier 1 unit tests
- keeps production viewer code unchanged

## Validation
- `npm ci --prefix viewer`
- `python3.11 -m pytest tests/test_viewer_server_artifacts.py::ViewerServerArtifactsTest::test_completed_run_page_data_preserves_pipeline_manifest_fields -q`
