### PR TITLE
docs(bank-manager): viewer restart instructions + shell-label sweep

### DIFF
--- a/examples/bank_manager_agent_control/README.md
+++ b/examples/bank_manager_agent_control/README.md
@@ -274,7 +274,7 @@ Run all commands from the repository root.
 
 ### 1. Python 3.11+ venv and ASSERT
 
-PowerShell:
+PowerShell (Windows):
 
 ```powershell
 python -m venv .venv
@@ -283,7 +283,7 @@ python -m pip install --upgrade pip
 python -m pip install -e ".[otel,langgraph,examples]"
 ```
 
-bash:
+bash (macOS / Linux):
 
 ```bash
 python -m venv .venv
@@ -306,9 +306,13 @@ needed -- you only need a C linker).
 
 ### 3. OPA (Open Policy Agent) on PATH
 
+PowerShell (Windows):
+
 ```powershell
 winget install open-policy-agent.opa
 ```
+
+bash (macOS / Linux):
 
 ```bash
 brew install opa                                    # macOS
@@ -320,13 +324,13 @@ Compare tab in the chat UI.
 
 ### 4. `.env` with Azure credentials
 
-PowerShell:
+PowerShell (Windows):
 
 ```powershell
 if (-not (Test-Path .env)) { Copy-Item .env.example .env }
 ```
 
-bash:
+bash (macOS / Linux):
 
 ```bash
 [[ -f .env ]] || cp .env.example .env

--- a/examples/bank_manager_agent_control/README.md
+++ b/examples/bank_manager_agent_control/README.md
@@ -223,6 +223,46 @@ static reader and needs neither.
 
 Stop each service with Ctrl+C in its terminal.
 
+### Restarting the viewer (if it hangs or behaves erratically)
+
+The SvelteKit dev server occasionally wedges -- blank pages, stale
+suite list after `git pull`, "compare" tab not updating, or Ctrl+C
+not actually freeing port 5173. Hard-restart it like this:
+
+PowerShell (Windows):
+
+```powershell
+# From any terminal: kill anything holding the viewer port
+Get-NetTCPConnection -LocalPort 5173 -ErrorAction SilentlyContinue |
+    Select-Object -ExpandProperty OwningProcess -Unique |
+    ForEach-Object { Stop-Process -Id $_ -Force -ErrorAction SilentlyContinue }
+
+# Then in the viewer terminal, restart cleanly
+cd viewer
+Remove-Item -Recurse -Force .svelte-kit -ErrorAction SilentlyContinue
+$env:VIEWER_EDIT_MODE = "1"
+npm run dev
+```
+
+bash (macOS / Linux):
+
+```bash
+# From any terminal: kill anything holding the viewer port
+lsof -ti :5173 | xargs -r kill -9
+
+# Then in the viewer terminal, restart cleanly
+cd viewer
+rm -rf .svelte-kit
+export VIEWER_EDIT_MODE=1
+npm run dev
+```
+
+If the chat UI (port 8766) gets stuck the same way, swap `5173` for
+`8766` and re-run `python examples/bank_manager_agent_control/unguarded_ui.py`.
+
+A hard browser refresh (Ctrl+Shift+R / Cmd+Shift+R) clears most
+stale-state weirdness without a server restart.
+
 ## Set up to reproduce (Azure credentials required)
 
 This is the one-time install path. After step 4, **you are fully set


### PR DESCRIPTION
Tiny docs-only follow-up to #219. Two changes to the bank-manager README, both pure-text:

**1. Add a "Restarting the viewer (if it hangs or behaves erratically)" subsection** (`b196c40`, originally pushed to #219 after the squash-merge window so it didn't land). Covers the cases the demo speakers hit on the Windows backup laptop:

- Blank pages / stale suite list after git pull -> wipe .svelte-kit
- Ctrl+C did not actually free port 5173 -> cross-platform port-kill recipe (Get-NetTCPConnection on Windows; lsof on macOS/Linux) followed by clean npm run dev
- Same recipe noted for the chat UI on 8766
- Hard browser refresh (Ctrl+Shift+R) as the cheap first try

**2. Unify shell labels across all 7 dual-platform stanzas** (`aa1dc3c`). Four code blocks in "Set up to reproduce" used bare `PowerShell:` / `bash:` while the earlier "View the demo results locally" section used the explicit `PowerShell (Windows):` / `bash (macOS / Linux):` form. The OPA section had no labels at all. All 7 stanzas now use the explicit form.

No behavior change. Single-file diff (`examples/bank_manager_agent_control/README.md`).
