### PR TITLE
fix(docs site): rewrite repo-relative .md links so cross-references resolve

### DIFF
--- a/website/app/docs/[...slug]/page.tsx
+++ b/website/app/docs/[...slug]/page.tsx
@@ -53,7 +53,7 @@ export default async function DocPage({ params }: { params: Promise<Params> }) {
 						<h1 className="docs-title">{doc.title}</h1>
 						{doc.description && <p className="docs-lede">{doc.description}</p>}
 					</header>
-					<MarkdownContent source={doc.content} />
+					<MarkdownContent source={doc.content} relativePath={doc.relativePath} />
 				</article>
 			</main>
 			<OnThisPage headings={headings} />

--- a/website/app/docs/_components/MarkdownContent.tsx
+++ b/website/app/docs/_components/MarkdownContent.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { AnchorHTMLAttributes } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
@@ -11,18 +12,131 @@ import "highlight.js/styles/github-dark.css";
 // must be rewritten to URLs that resolve under the site basePath.
 const BASE_PATH = "/ASSERT";
 
+// GitHub blob URL used when a markdown link escapes the docs/ tree
+// (e.g. `../examples/README.md`). Matches the "GitHub repo" link in
+// app/page.tsx and TopNav.tsx so the source-of-truth repo is consistent.
+const GITHUB_BLOB_BASE =
+	process.env.NEXT_PUBLIC_DOCS_GITHUB_BLOB_BASE ??
+	"https://github.com/microsoft/ASSERT/blob/main";
+
 function rewriteAssetPaths(source: string): string {
 	// Matches `./assets/` or any depth of `../assets/` after a quote or paren
 	return source.replace(/(["'(])(?:\.\.\/)+assets\//g, `$1${BASE_PATH}/assets/`)
 		.replace(/(["'(])\.\/assets\//g, `$1${BASE_PATH}/assets/`);
 }
 
-export default function MarkdownContent({ source }: { source: string }) {
+// Resolve a POSIX-style relative path against a base directory. Unlike
+// `node:path.resolve`, an ascent (`..`) above the base is preserved in the
+// output (as a leading `..` segment) so callers can detect that the link
+// escaped the docs tree.
+function resolveRelativePath(baseDir: string, target: string): string {
+	const segments: string[] = [];
+	const all = [...baseDir.split("/"), ...target.split("/")];
+	for (const segment of all) {
+		if (segment === "" || segment === ".") continue;
+		if (segment === "..") {
+			if (segments.length > 0 && segments[segments.length - 1] !== "..") {
+				segments.pop();
+			} else {
+				segments.push("..");
+			}
+			continue;
+		}
+		segments.push(segment);
+	}
+	return segments.join("/");
+}
+
+// Split `path.md#anchor?query` into pieces so we can rewrite just the path part.
+function splitLinkHref(href: string): { path: string; suffix: string } {
+	const hashIdx = href.indexOf("#");
+	const queryIdx = href.indexOf("?");
+	const cutAt = [hashIdx, queryIdx].filter((i) => i >= 0).sort((a, b) => a - b)[0] ?? -1;
+	if (cutAt === -1) return { path: href, suffix: "" };
+	return { path: href.slice(0, cutAt), suffix: href.slice(cutAt) };
+}
+
+// Is this an "external-ish" link we should leave alone?
+function isExternalHref(href: string): boolean {
+	return (
+		href.startsWith("http://") ||
+		href.startsWith("https://") ||
+		href.startsWith("//") ||
+		href.startsWith("mailto:") ||
+		href.startsWith("tel:") ||
+		href.startsWith("#") ||
+		href.startsWith("/")
+	);
+}
+
+// Convert a doc-relative markdown link into a site URL.
+//
+// `currentRelativePath` is the source doc's path relative to the docs root
+// (e.g. "targets/README.md" or "getting-started.md"). Top-level docs use "".
+//
+// Returns null if the href should be left untouched.
+function rewriteMarkdownLink(
+	href: string,
+	currentRelativePath: string,
+): string | null {
+	if (!href || isExternalHref(href)) return null;
+	const { path: rawPath, suffix } = splitLinkHref(href);
+	if (!/\.(md|mdx)$/i.test(rawPath)) return null;
+
+	// Normalize Windows-style separators just in case (the data layer already
+	// does this, but be defensive: a bad currentRelativePath here would produce
+	// flattened URLs that 404).
+	const normalizedCurrent = currentRelativePath.replace(/\\/g, "/");
+
+	// Source doc's directory relative to docs/ root.
+	const lastSlash = normalizedCurrent.lastIndexOf("/");
+	const baseDir = lastSlash >= 0 ? normalizedCurrent.slice(0, lastSlash) : "";
+
+	const resolved = resolveRelativePath(baseDir, rawPath);
+
+	// Anything that climbed above the docs/ root (e.g. ../examples/README.md)
+	// is repo content we do not publish on the docs site. Send those to GitHub
+	// so the link is at least live and points at the canonical source.
+	if (resolved.startsWith("../") || resolved === "..") {
+		const fromRepoRoot = resolveRelativePath(
+			"docs/" + baseDir,
+			rawPath,
+		);
+		return `${GITHUB_BLOB_BASE}/${fromRepoRoot}${suffix}`;
+	}
+
+	// Strip extension, lowercase the slug to match how docs.ts slugs files.
+	const noExt = resolved.replace(/\.(md|mdx)$/i, "").toLowerCase();
+
+	// Top-level README is the docs index. Nested READMEs render as their own
+	// `/readme/` page (see app/docs/[...slug]/page.tsx and docs.ts).
+	if (noExt === "readme") return `${BASE_PATH}/docs/${suffix}`;
+
+	return `${BASE_PATH}/docs/${noExt}/${suffix}`;
+}
+
+type MarkdownContentProps = {
+	source: string;
+	// Source file's path relative to the docs root, e.g. "targets/README.md"
+	// or "getting-started.md". Empty string for the top-level docs index.
+	relativePath?: string;
+};
+
+export default function MarkdownContent({ source, relativePath = "" }: MarkdownContentProps) {
+	const anchorRenderer = ({ href, children, ...rest }: AnchorHTMLAttributes<HTMLAnchorElement>) => {
+		const rewritten = href ? rewriteMarkdownLink(href, relativePath) : null;
+		return (
+			<a href={rewritten ?? href} {...rest}>
+				{children}
+			</a>
+		);
+	};
 	return (
 		<div className="docs-prose">
 			<ReactMarkdown
 				remarkPlugins={[remarkGfm]}
 				rehypePlugins={[rehypeRaw, rehypeSlug, rehypeHighlight]}
+				components={{ a: anchorRenderer }}
 			>
 				{rewriteAssetPaths(source)}
 			</ReactMarkdown>

--- a/website/app/docs/_lib/docs.ts
+++ b/website/app/docs/_lib/docs.ts
@@ -105,7 +105,7 @@ export function getAllDocs(): Doc[] {
 			title,
 			description,
 			href: "/docs/" + slug.join("/"),
-			relativePath: rel,
+			relativePath: rel.split(path.sep).join("/"),
 			content: stripped,
 		});
 	}
@@ -181,6 +181,10 @@ export function getDocsNav(): { group: string | null; items: DocMeta[] }[] {
 	}));
 }
 
+// Path within docs/ that the sidebar uses for `arr.push({ ..., relativePath })`
+// is set in getAllDocs above; getDocsNav copies the same field. Ensure POSIX
+// separator for cross-platform consistency.
+
 export type Heading = { id: string; text: string; level: 2 };
 
 /**
@@ -224,7 +228,7 @@ export function getDocGroupLabel(doc: DocMeta): string | null {
  * Returns the parsed README.md from the docs root, used to render the /docs
  * landing page. Returns null if README.md does not exist.
  */
-export function getDocsIndex(): { title: string; description?: string; content: string } | null {
+export function getDocsIndex(): { title: string; description?: string; content: string; relativePath: string } | null {
 	const candidates = ["README.md", "readme.md", "README.mdx", "readme.mdx"];
 	for (const name of candidates) {
 		const full = path.join(DOCS_DIR, name);
@@ -236,7 +240,7 @@ export function getDocsIndex(): { title: string; description?: string; content: 
 			titleFromContent(content, "ASSERT Documentation");
 		const description = typeof data.description === "string" ? data.description : undefined;
 		const stripped = content.replace(/^\s*#\s+.+\r?\n+/, "");
-		return { title, description, content: stripped };
+		return { title, description, content: stripped, relativePath: name };
 	}
 	return null;
 }

--- a/website/app/docs/page.tsx
+++ b/website/app/docs/page.tsx
@@ -12,6 +12,7 @@ export default function DocsIndex() {
 	const title = index?.title ?? "ASSERT Documentation";
 	const description = index?.description;
 	const content = index?.content ?? "";
+	const relativePath = index?.relativePath ?? "README.md";
 	const headings = getHeadings(content);
 	return (
 		<div className="docs-layout has-toc">
@@ -22,7 +23,7 @@ export default function DocsIndex() {
 						<h1 className="docs-title">{title}</h1>
 						{description && <p className="docs-lede">{description}</p>}
 					</header>
-					<MarkdownContent source={content} />
+					<MarkdownContent source={content} relativePath={relativePath} />
 				</article>
 			</main>
 			<OnThisPage headings={headings} />


### PR DESCRIPTION
The docs site at https://responsibleai.github.io/ASSERT/ has a systemic broken-link problem: every relative `.md` link in `docs/` 404s when rendered. Example surfaced by Chang at launch prep:

> https://responsibleai.github.io/ASSERT/docs/targets/readme/ shows the snippet with `→ See Callable Target.` — clicking goes to `/docs/targets/readme/callable.md` → 404.

The source markdown writes `[Callable Target](callable.md)` which is correct for a file-system view (Jake's PR #220 / my PR #224 both rely on this). But `MarkdownContent.tsx` passes the literal href through, and the browser resolves `callable.md` against the current page URL (`/docs/targets/readme/`) — giving `/docs/targets/readme/callable.md` instead of `/docs/targets/callable/`.

## Surface area

About **30 cross-doc links** across `docs/`, including (audit grep in PR description below):

- `docs/README.md` — 15 links (every section index card)
- `docs/concepts.md` — 5 links (the "Next" footer block)
- `docs/getting-started.md` — 4 links (where-to-go-next)
- `docs/targets/README.md` — 5 (the link the user spotted)
- `docs/config/schema.md`, `docs/cli/overview.md`, `docs/guides/*.md` — the rest

## Fix

Add a custom `<a>` renderer to `MarkdownContent` that resolves any `.md` / `.mdx` link against the source doc''s `relativePath` and rewrites it to the site URL:

| Source link | From doc | Becomes |
|---|---|---|
| `callable.md` | `targets/README.md` | `/ASSERT/docs/targets/callable/` |
| `../config/schema.md` | `guides/create-evaluation.md` | `/ASSERT/docs/config/schema/` |
| `callable.md#anchor` | (any) | `/ASSERT/docs/targets/callable/#anchor` |
| `README.md` (top-level) | (any) | `/ASSERT/docs/` |
| `../examples/README.md` | `docs/README.md` | `https://github.com/microsoft/ASSERT/blob/main/examples/README.md` |

Last row: links that escape the `docs/` tree are repo content not published on the docs site, so they go to the canonical GitHub blob URL instead of 404''ing under `/docs/`. Org matches the "GitHub repo" link already used in `app/page.tsx` and `TopNav.tsx` (`microsoft/ASSERT`); overridable at build time via `NEXT_PUBLIC_DOCS_GITHUB_BLOB_BASE`.

Also normalizes `path.relative()` to POSIX in `getAllDocs` so the Windows backslash separator doesn''t bypass the directory parsing in the rewriter (would otherwise emit flattened URLs like `/docs/callable/`).

## Validation

Built the static export locally with the rewriter and grep''d every generated HTML file:

```
=== any .md hrefs left site-wide ===
  docs\index.html: https://github.com/microsoft/ASSERT/blob/main/examples/README.md
```

Only the intentional GitHub escape URL remains; all in-site cross-refs resolve to working slash-terminated paths.

Spot checks of rewritten hrefs on `/docs/targets/readme/`, `/docs/`, `/docs/concepts/`, and `/docs/config/schema/` all match expected URLs.

## Out of scope

- `docs/getting-started.md` and `docs/README.md` content fixes (helper-paragraph + shell-label sweep) ship in #224, the auto_trace sweep PR.
- The fact that #224 has not merged yet is why the live snippet still shows the old `phoenix.otel` two-liner — content is correct on `main` once #224 merges.
