### PR TITLE
fix: repair broken links and remove missing logo asset

### DIFF
--- a/docs/targets/callable.md
+++ b/docs/targets/callable.md
@@ -129,7 +129,7 @@ Return types and what the judge sees:
 | Return type | Judge sees |
 |---|---|
 | `str`, or `dict` with `text` / `content` | final response text only |
-| Any object with a `.choices` attribute — [`litellm.ModelResponse`](https://github.com/BerriAI/litellm), OpenAI's [`ChatCompletion`](https://platform.openai.com/docs/api-reference/chat/object), etc. — or a [`assert_ai.core.model_client.ModelResponse`](../../assert_ai/core/model_client.py) returned directly | final response text **plus** final tool calls, token usage, and model name (the `.choices` form is normalized to `assert_ai.core.model_client.ModelResponse` internally) |
+| Any object with a `.choices` attribute — [`litellm.ModelResponse`](https://github.com/BerriAI/litellm), OpenAI's [`ChatCompletion`](https://platform.openai.com/docs/api-reference/chat/object), etc. — or a [`assert_ai.core.model_client.ModelResponse`](https://github.com/microsoft/ASSERT/blob/main/assert_ai/core/model_client.py) returned directly | final response text **plus** final tool calls, token usage, and model name (the `.choices` form is normalized to `assert_ai.core.model_client.ModelResponse` internally) |
 
 #### HTTP endpoint (`target.endpoint`)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -32,7 +32,7 @@ assert-ai init --model azure/gpt-5.4-mini
 assert-ai init --model azure/gpt-5.4-mini --from examples/travel_planner_langgraph/eval_config.yaml
 ```
 
-See the [CLI reference](../docs/reference/cli.md#design-a-config-interactively) for all options.
+See the [CLI reference](../docs/cli/commands.md#init) for all options.
 
 ## Which example to start with
 
@@ -44,7 +44,7 @@ See the [CLI reference](../docs/reference/cli.md#design-a-config-interactively) 
 | Evaluate a Prompt Agent with planned tools but no backend | `prompt_agents/health_assistant_simulated_tools.yaml` | Uses a fixed tool schema and simulated tool responses. |
 | Evaluate a hosted target with Python tool functions | `prompt_agents/health_assistant_sandbox.yaml` | Requires Docker. Use when you want actual tool execution around a hosted model. |
 | Evaluate a science research agent with real retrieval tools | `science_research_agent/eval_config.yaml` | Callable-agent example ported from Omni. Uses `web_search`, `fetch_url`, and `file_search`. Run `python -m pip install -e ".[examples]"`, set `TAVILY_API_KEY` for web search, then `assert-ai run --config examples/science_research_agent/eval_config.yaml`. |
-| See runtime + eval close the loop on a real workflow | `incident_triage_agent/eval_config_baseline.yaml` + `eval_config_naive_prompt.yaml` + `eval_config_guarded.yaml` + `eval_config_guarded_gepa.yaml` | Joint [AgentControlSpecification](https://github.com/responsibleai/AgentControlSpecification) + ASSERT demo. SRE incident-triage agent run across a 4-variant matrix (baseline weak prompt → naïve DO-NOT prompt → ACS gates → ACS + GEPA-optimized prompt) over a 4-axis failure-mode taxonomy to prove the runtime+eval loop and surface the security/overrefusal trade-off. See [`incident_triage_agent/README.md`](incident_triage_agent/README.md) and [`docs/case-study-incident-triage-joint.md`](../docs/case-study-incident-triage-joint.md). |
+| See runtime + eval close the loop on a real workflow | `incident_triage_agent/eval_config_baseline.yaml` + `eval_config_naive_prompt.yaml` + `eval_config_guarded.yaml` + `eval_config_guarded_gepa.yaml` | Joint [AgentControlSpecification](https://github.com/responsibleai/AgentControlSpecification) + ASSERT demo. SRE incident-triage agent run across a 4-variant matrix (baseline weak prompt → naïve DO-NOT prompt → ACS gates → ACS + GEPA-optimized prompt) over a 4-axis failure-mode taxonomy to prove the runtime+eval loop and surface the security/overrefusal trade-off. See [`incident_triage_agent/README.md`](incident_triage_agent/README.md). |
 
 ## Layout
 

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -1,6 +1,6 @@
 # Agents
 
-This directory holds tool modules and tool schemas used by the example pipeline configs in [`../pipes/`](../pipes/). The flagship customer integration path is `target.callable` — see [`../travel_planner_langgraph/`](../travel_planner_langgraph/).
+This directory holds tool modules and tool schemas used by the Prompt Agent example configs in [`../prompt_agents/`](../prompt_agents/). The flagship customer integration path is `target.callable` — see [`../travel_planner_langgraph/`](../travel_planner_langgraph/).
 
 ASSERT supports three ways to give a target access to tools or external systems.
 
@@ -52,4 +52,4 @@ The `health_assistant.py` module requires Docker locally. On first use, Docker m
 
 The `examples.agents.openclaw` connector also requires Docker with Compose support. Each inference conversation gets its own Compose project and container. On first use, Docker Compose builds the image from `openclaw/Dockerfile`, which pulls `node:24-bookworm` and installs `openclaw@latest`. The container reads `AZURE_API_KEY` and `AZURE_API_BASE` from the host environment at startup to configure OpenClaw. See [openclaw/README.md](openclaw/README.md) for the Docker-specific setup.
 
-See [pipes/](../pipes/) for complete configs that use each pattern.
+See [`../prompt_agents/`](../prompt_agents/) for complete configs that use each pattern.

--- a/examples/incident_triage_agent/README.md
+++ b/examples/incident_triage_agent/README.md
@@ -1,6 +1,6 @@
 # Incident-triage agent — ACS efficacy demo (A → C demo path)
 
-This example builds on the [responsibleai/AgentControlSpecification](https://github.com/responsibleai/AgentShield)
+This example builds on the [responsibleai/AgentControlSpecification](https://github.com/responsibleai/AgentControlSpecification)
 incident-triage reference shape and turns it into a **4-variant ASSERT eval**
 that measures ACS efficacy on a second vertical (the canonical bank-manager
 demo lives in [PR #88](https://github.com/microsoft/ASSERT/pull/88)).

--- a/examples/prompt_agents/README.md
+++ b/examples/prompt_agents/README.md
@@ -13,10 +13,10 @@ The five configs exercise different Prompt Agent options around the same failure
 | Config | Target shape | What it demonstrates |
 |---|---|---|
 | [`health_assistant.yaml`](health_assistant.yaml) | Hosted model + system prompt | Smallest smoke test: no tools, just the model behavior and judge loop. |
-| [`health_assistant_simulated_tools.yaml`](health_assistant_simulated_tools.yaml) | Hosted model + fixed toolset + simulator | Tool schemas from [`health_assistant_tools.yaml`](health_assistant_tools.yaml); an LLM simulator returns tool results. |
-| [`health_assistant_sandbox.yaml`](health_assistant_sandbox.yaml) | Hosted model + Python tool module | Real tool functions from [`health_assistant.py`](health_assistant.py), executed in a Docker-backed sandbox per conversation. |
+| [`health_assistant_simulated_tools.yaml`](health_assistant_simulated_tools.yaml) | Hosted model + fixed toolset + simulator | Tool schemas from [`health_assistant_tools.yaml`](../agents/health_assistant_tools.yaml); an LLM simulator returns tool results. |
+| [`health_assistant_sandbox.yaml`](health_assistant_sandbox.yaml) | Hosted model + Python tool module | Real tool functions from [`health_assistant.py`](../agents/health_assistant.py), executed in a Docker-backed sandbox per conversation. |
 | [`health_assistant_generated_tools.yaml`](health_assistant_generated_tools.yaml) | Hosted model + per-test-case tools + simulator | Each generated test case carries its own tool definitions; the simulator returns plausible results. |
-| [`health_assistant_external.yaml`](health_assistant_external.yaml) | External connector | Advanced/legacy connector path through [`openclaw/`](openclaw/), with the external agent owning the conversation. |
+| [`health_assistant_external.yaml`](health_assistant_external.yaml) | External connector | Advanced/legacy connector path through [`openclaw/`](../agents/openclaw/), with the external agent owning the conversation. |
 
 ## Value-add
 
@@ -59,7 +59,7 @@ Run any config with `assert-ai`:
 | Generated tools | `assert-ai run --config examples/prompt_agents/health_assistant_generated_tools.yaml` |
 | External connector | `assert-ai run --config examples/prompt_agents/health_assistant_external.yaml` |
 
-**Docker prerequisite:** [`health_assistant_sandbox.yaml`](health_assistant_sandbox.yaml) and [`health_assistant_external.yaml`](health_assistant_external.yaml) start containers per conversation. Keep Docker Desktop running before invoking them. The sandbox variant may pull `python:3.11-bookworm`; the external connector builds an OpenClaw image from [`openclaw/Dockerfile`](openclaw/Dockerfile).
+**Docker prerequisite:** [`health_assistant_sandbox.yaml`](health_assistant_sandbox.yaml) and [`health_assistant_external.yaml`](health_assistant_external.yaml) start containers per conversation. Keep Docker Desktop running before invoking them. The sandbox variant may pull `python:3.11-bookworm`; the external connector builds an OpenClaw image from [`openclaw/Dockerfile`](../agents/openclaw/Dockerfile).
 
 ### Files
 

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -74,7 +74,6 @@ const frameworkLogos: { src: string; alt: string }[] = [
 	{ src: "DSPy logo.png", alt: "DSPy" },
 	{ src: "llamalndexlogo.png", alt: "LlamaIndex" },
 	{ src: "autogen logo.png", alt: "AutoGen / MAF" },
-	{ src: "anthropic-logo.svg", alt: "Anthropic" },
 	{ src: "nvidia-logo.webp", alt: "NVIDIA" },
 	{ src: "vertex-ai-logo.png", alt: "Vertex AI" },
 	// Add more logos here — drop the file into public/icons/ and add an entry.


### PR DESCRIPTION
P0 launch-blocking link fixes surfaced by tonight's launch-readiness audit.

## P0 (site-breaking)

- `website/app/page.tsx` — remove `anthropic-logo.svg` entry. The asset was never added to `website/public/icons/`, so the rendered `/ASSERT/icons/anthropic-logo.svg` was 404 in production (appeared twice on the landing page).
- `docs/targets/callable.md` — rewrite source-code link from relative `../../assert_ai/core/model_client.py` to an absolute `github.com/microsoft/ASSERT/blob/main/...` URL. The docs-site markdown rewriter (`MarkdownContent.tsx`) only rewrites `.md` links, so this `.py` link was left as-is and 404'd on `/docs/targets/callable`.

## P1 (README cleanup)

- `examples/incident_triage_agent/README.md` — fix wrong URL. Link text said `responsibleai/AgentControlSpecification` but URL pointed at the nonexistent `responsibleai/AgentShield` repo (404).
- `examples/README.md` — redirect CLI reference link to `docs/cli/commands.md#init` (`docs/reference/` does not exist); drop the dangling reference to a nonexistent `docs/case-study-incident-triage-joint.md`.
- `examples/agents/README.md` — `../pipes/` is not a real directory; the tool modules are used by Prompt Agent configs in `../prompt_agents/`. Fixed two occurrences.
- `examples/prompt_agents/README.md` — prefix tool-asset links with `../agents/` since `health_assistant.py`, `health_assistant_tools.yaml`, and `openclaw/` live in `examples/agents/`. Fixed 4 occurrences.

## Not changed (verified safe)

OpenAI documentation URLs in `docs/targets/callable.md` (`platform.openai.com/docs/api-reference/chat/{create,object}`) return `301` to `developers.openai.com/api/reference/resources/chat` which resolves to `200` in browsers. The audit agent's curl didn't follow redirects so these were initially flagged P0 — they work fine for end users. Left untouched to keep the diff small for launch.

## Validation

- Diff: 6 files, +10 / −11
- `git diff --stat` confirmed scope (no unintended changes)
- Source-of-truth check: ran `Get-ChildItem` on every referenced directory and file to confirm the rewritten paths actually exist before committing

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
