### PR TITLE
fix(web): explicit cursor:pointer on .nav-btn

### DIFF
--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -213,6 +213,7 @@ p { margin: 0; }
   border: 1px solid var(--borderColor-default);
   color: #fff;
   background: transparent;
+  cursor: pointer;
   transition: background-color 120ms ease, border-color 120ms ease;
 }
 .nav-btn-secondary:hover {


### PR DESCRIPTION
## What

One-line CSS: add `cursor: pointer` to `.nav-btn`.

## Why

Top-nav buttons (`Documentation`, `Read the blog`, `Get started`) relied on the browser's `a:any-link` default to render the pointer cursor on hover. With `display: inline-flex` on the anchor and nested spans inside `.nav-btn-shine` (`shine-border` + `shine-label`), that browser default did not apply consistently across browsers.

User-reported repro: hovering `Read the blog` on any `/docs/*` sub-page shows the default arrow cursor, making the button look unclickable even though the click works.

## Verification

- HTML for the anchor is correct: `<a href="https://commandline.microsoft.com/assert-written-intent-executable-evals/" target="_blank" rel="noopener noreferrer" class="nav-btn nav-btn-secondary">Read the blog</a>`
- URL returns 200 OK (real published blog post)
- Existing `.nav-btn-secondary:hover` styles are unaffected
- No other site rule sets `cursor` on `a` or `.nav-btn` (verified via `grep cursor website/app/globals.css`)

Diff: 1 file, +1 / −0.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
