### PR TITLE
chore: add CODEOWNERS for auto-review-routing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,36 @@
+# Code owners for responsibleai/ASSERT
+#
+# Rules:
+# - GitHub uses the LAST matching pattern as the effective code owners list.
+# - Listed owners are alternatives — any ONE of them satisfies the required review.
+# - Branch protection on `main` should be set to "Require review from Code Owners"
+#   so reviewers are auto-requested when a PR opens.
+#
+# Pecking order (per maintainer agreement):
+#   - UI / viewer        → Aaron
+#   - Website / doc site → Sooyeon, Minsoo
+#   - Core code & examples → Chang, Yeming, Jake, Aaron
+#   - CI / workflows     → Yeming, Jake
+#   - Documentation      → Chang, Minsoo, Jake
+#   - Catch-all fallback → Chang (only when no specific rule matches)
+
+# ---- Catch-all (most general; specific rules below override) ----
+*                                @changliu2
+
+# ---- Documentation (any .md anywhere; docs/ tree) ----
+*.md                             @changliu2 @minthigpen @jakepresent
+docs/                            @changliu2 @minthigpen @jakepresent
+
+# ---- UI / viewer ----
+viewer/                          @AaronAspinwall123
+
+# ---- Website / doc site ----
+website/                         @sooyeonni @minthigpen
+
+# ---- Core code, examples, prompts ----
+assert_ai/                       @changliu2 @tangym @jakepresent @AaronAspinwall123
+examples/                        @changliu2 @tangym @jakepresent @AaronAspinwall123
+prompts/                         @changliu2 @tangym @jakepresent @AaronAspinwall123
+
+# ---- CI / workflows ----
+.github/workflows/               @tangym @jakepresent

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,7 +22,7 @@
 docs/                            @changliu2 @minthigpen @jakepresent
 
 # ---- UI / viewer ----
-viewer/                          @AaronAspinwall123
+viewer/                          @AaronAspinwall123 @minthigpen
 
 # ---- Website / doc site ----
 website/                         @sooyeonni @minthigpen

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,7 +10,7 @@
 #   - UI / viewer        → Aaron
 #   - Website / doc site → Sooyeon, Minsoo
 #   - Core code & examples → Chang, Yeming, Jake, Aaron
-#   - CI / workflows     → Yeming, Jake
+#   - CI / workflows     → Yeming, Jake, Chang
 #   - Documentation      → Chang, Minsoo, Jake
 #   - Catch-all fallback → Chang (only when no specific rule matches)
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,4 +33,4 @@ examples/                        @changliu2 @tangym @jakepresent @AaronAspinwall
 prompts/                         @changliu2 @tangym @jakepresent @AaronAspinwall123
 
 # ---- CI / workflows ----
-.github/workflows/               @tangym @jakepresent
+.github/workflows/               @tangym @jakepresent @changliu2

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,7 +22,7 @@
 docs/                            @changliu2 @minthigpen @jakepresent
 
 # ---- UI / viewer ----
-viewer/                          @AaronAspinwall123 @minthigpen
+viewer/                          @AaronAspinwall123 @minthigpen @sooyeonni
 
 # ---- Website / doc site ----
 website/                         @sooyeonni @minthigpen


### PR DESCRIPTION
## What

Adds `.github/CODEOWNERS` to auto-route PR reviews to the right maintainers at PR-open time. Permanently fixes the routing-latency problem that left PR #214 sitting ~67h with zero reviewers requested.

## Mapping (any one listed = sufficient review)

| Path | Owners |
|---|---|
| `viewer/` | @AaronAspinwall123 @minthigpen @sooyeonni |
| `website/` | @sooyeonni @minthigpen |
| `assert_ai/`, `examples/`, `prompts/` | @changliu2 @tangym @jakepresent @AaronAspinwall123 |
| `.github/workflows/` | @tangym @jakepresent @changliu2 |
| `*.md`, `docs/` | @changliu2 @minthigpen @jakepresent |
| `*` (catch-all) | @changliu2 |

Order in the file uses last-match-wins precedence: most general first, specific overrides below.

## ⚠️ Required follow-up (manual, you do)

After merge, in repo Settings -> Branches -> `main` protection rule, enable:
- **Require review from Code Owners**

Without this, the auto-assignment doesn't trigger.

## What this does NOT do (intentionally)

- Does not change the agent team's permissions. Agents still observation-only in VACATION MODE.
- Does not auto-approve anything. Approval stays 100% human.
- Does not give Chang less work; it gives the OTHER owners a chance to take work BEFORE it falls to Chang. The dev-maintainer agent spec update (separate PR) will codify the routing logic: when Chang is one of N co-owners, prefer to ping the others first.

## Validation

- All listed handles confirmed via `gh api repos/responsibleai/ASSERT/collaborators`
- `@sooyeonni` has `maintain` permission (valid for CODEOWNERS)
- `@AaronAspinwall123` is outside collaborator with admin (valid)
- File parses (37 lines, no syntax errors)

## Related

- Fixes routing root cause behind sitting-PRs (e.g. #211 / #214)
- Follow-up PR will update `AGENTS.md`, `.github/agents/dev-maintainer.md`, and the dev-loop schedule to enable `[Vacation-mode] post audit-only comments + auto-ping co-owners` for the 3-week absence period

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>