### PR TITLE
docs: credit Bloom as prior art + add third-party license notice

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -45,9 +45,9 @@ references:
     year: 2025
     url: "https://github.com/safety-research/bloom"
     notes: >-
-      ASSERT's staged evaluation pipeline is modeled on Bloom's design; adapted
-      material is used under the MIT License (Copyright (c) 2025 Safety
-      Research). See THIRD_PARTY_NOTICES.md.
+      ASSERT's staged evaluation pipeline is modeled on Bloom's design. Bloom's
+      MIT license notice is retained in THIRD_PARTY_NOTICES.md as good-faith
+      attribution.
     authors:
       - family-names: Gupta
         given-names: Isha

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,30 +14,6 @@ repository-code: "https://github.com/responsibleai/ASSERT"
 url: "https://github.com/responsibleai/ASSERT"
 license: MIT
 references:
-  - type: software
-    title: "Bloom: an open source tool for automated behavioral evaluations"
-    year: 2025
-    url: "https://github.com/safety-research/bloom"
-    notes: >-
-      ASSERT's automated behavioral-evaluation pipeline was adapted from Bloom
-      (MIT, Copyright (c) 2025 Safety Research). See THIRD_PARTY_NOTICES.md.
-    authors:
-      - family-names: Gupta
-        given-names: Isha
-      - family-names: Fronsdal
-        given-names: Kai
-      - family-names: Sheshadri
-        given-names: Abhay
-      - family-names: Michala
-        given-names: Jonathan
-      - family-names: Tay
-        given-names: Jacqueline
-      - family-names: Wang
-        given-names: Rowan
-      - family-names: Bowman
-        given-names: "Samuel R."
-      - family-names: Price
-        given-names: Sara
   - type: article
     title: "AI-Assisted Systematization for Evaluating GenAI Systems"
     year: 2026
@@ -64,3 +40,28 @@ references:
         given-names: Solon
       - family-names: Wallach
         given-names: Hanna
+  - type: software
+    title: "Bloom: an open source tool for automated behavioral evaluations"
+    year: 2025
+    url: "https://github.com/safety-research/bloom"
+    notes: >-
+      ASSERT's staged evaluation pipeline is modeled on Bloom's design; adapted
+      material is used under the MIT License (Copyright (c) 2025 Safety
+      Research). See THIRD_PARTY_NOTICES.md.
+    authors:
+      - family-names: Gupta
+        given-names: Isha
+      - family-names: Fronsdal
+        given-names: Kai
+      - family-names: Sheshadri
+        given-names: Abhay
+      - family-names: Michala
+        given-names: Jonathan
+      - family-names: Tay
+        given-names: Jacqueline
+      - family-names: Wang
+        given-names: Rowan
+      - family-names: Bowman
+        given-names: "Samuel R."
+      - family-names: Price
+        given-names: Sara

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,40 @@
+cff-version: 1.2.0
+message: >-
+  If you use ASSERT, please cite it as below. Please also consider citing the
+  prior work it builds on (see the references section).
+title: "ASSERT: Adaptive Spec-driven Scoring for Evaluation and Regression Testing"
+abstract: >-
+  ASSERT is an open-source framework for turning natural-language behavior
+  specifications into executable evaluations for AI models, applications, and
+  agents.
+type: software
+authors:
+  - name: "Microsoft Responsible AI"
+repository-code: "https://github.com/responsibleai/ASSERT"
+url: "https://github.com/responsibleai/ASSERT"
+license: MIT
+references:
+  - type: software
+    title: "Bloom: an open source tool for automated behavioral evaluations"
+    year: 2025
+    url: "https://github.com/safety-research/bloom"
+    notes: >-
+      ASSERT's automated behavioral-evaluation pipeline was adapted from Bloom
+      (MIT, Copyright (c) 2025 Safety Research). See THIRD_PARTY_NOTICES.md.
+    authors:
+      - family-names: Gupta
+        given-names: Isha
+      - family-names: Fronsdal
+        given-names: Kai
+      - family-names: Sheshadri
+        given-names: Abhay
+      - family-names: Michala
+        given-names: Jonathan
+      - family-names: Tay
+        given-names: Jacqueline
+      - family-names: Wang
+        given-names: Rowan
+      - family-names: Bowman
+        given-names: "Samuel R."
+      - family-names: Price
+        given-names: Sara

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -38,3 +38,29 @@ references:
         given-names: "Samuel R."
       - family-names: Price
         given-names: Sara
+  - type: article
+    title: "AI-Assisted Systematization for Evaluating GenAI Systems"
+    year: 2026
+    month: 5
+    url: "https://www.microsoft.com/en-us/research/publication/ai-assisted-systematization-for-evaluating-genai-systems/"
+    notes: >-
+      ASSERT's concept-systematization stage follows this work.
+    authors:
+      - family-names: Agarwal
+        given-names: Dhruv
+      - family-names: Sheng
+        given-names: Emily
+      - family-names: Atalla
+        given-names: Chad
+      - family-names: Garcia-Gathright
+        given-names: Jean
+      - family-names: Mozannar
+        given-names: Hussein
+      - family-names: Washington
+        given-names: Hannah
+      - family-names: Chouldechova
+        given-names: Alexandra
+      - family-names: Barocas
+        given-names: Solon
+      - family-names: Wallach
+        given-names: Hanna

--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ assert-ai run --config examples/travel_planner_langgraph/eval_config.yaml
         </tr>
 </table>
 
+## Acknowledgments
+
+ASSERT's automated behavioral-evaluation pipeline builds on and adapts the design of **[Bloom](https://github.com/safety-research/bloom)**, an open-source framework for automated behavioral evaluations from the Anthropic alignment team (released under the Safety Research organization, MIT licensed), and the broader line of work it belongs to, including [Petri](https://github.com/safety-research/petri). The concept-systematization stage additionally follows [Agarwal et al. (2026)](https://arxiv.org/abs/2605.26001).
+
+Adapted third-party material and the corresponding license notices are documented in [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md). If you use ASSERT in research, please also consider citing Bloom (see [`CITATION.cff`](CITATION.cff)).
+
 ## Trademarks
 
 This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft trademarks or logos is subject to and must follow [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks). Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship. Any use of third-party trademarks or logos is subject to those third party's policies.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ assert-ai run --config examples/travel_planner_langgraph/eval_config.yaml
 
 ## Acknowledgments
 
-ASSERT's automated behavioral-evaluation pipeline builds on and adapts the design of **[Bloom](https://github.com/safety-research/bloom)**, an open-source framework for automated behavioral evaluations from the Anthropic alignment team (released under the Safety Research organization, MIT licensed), and the broader line of work it belongs to, including [Petri](https://github.com/safety-research/petri). The concept-systematization stage additionally follows [Agarwal et al. (2026)](https://arxiv.org/abs/2605.26001).
+ASSERT's automated behavioral-evaluation pipeline builds on and adapts the design of **[Bloom](https://github.com/safety-research/bloom)**, an open-source framework for automated behavioral evaluations from the Anthropic alignment team (released under the Safety Research organization, MIT licensed), and the broader line of work it belongs to, including [Petri](https://github.com/safety-research/petri). The concept-systematization stage additionally follows [Agarwal et al. (2026)](https://www.microsoft.com/en-us/research/publication/ai-assisted-systematization-for-evaluating-genai-systems/).
 
 Adapted third-party material and the corresponding license notices are documented in [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md). If you use ASSERT in research, please also consider citing Bloom (see [`CITATION.cff`](CITATION.cff)).
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ ASSERT's automated behavioral-evaluation pipeline builds on and adapts the desig
 
 Adapted third-party material and the corresponding license notices are documented in [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md). If you use ASSERT in research, please also consider citing Bloom (see [`CITATION.cff`](CITATION.cff)).
 
+### Team and contributors
+
+ASSERT was built by the Microsoft Responsible AI organization.
+
+- **Product:** Mehrnoosh Sameki, Minsoo Thigpen, Chang Liu, Abby Palia, Hanna Kim
+- **Science:** Riccardo Fogliato, Emily Sheng, Alex Dow, Meera Chander, Alex Chouldechova, Sharman Tan, Xiawei Wang, Ahmed Magooda, Mayank Gupta, Jean Garcia-Gathright, Chad Atalla, Dan Vann, Hanna Wallach, Hannah Washington, Meredith Rodden, Nadine Frey, Melissa Kirkwood, Nick Pangakis, Ali Azad, Ahmed Elghory Ghoneim, Shushan Arakleyan
+- **Engineering:** Mohamed Elmergawi, Jake Present, Aaron Aspinwall, Yeming Tang
+- **Design:** Sooyeon Hwang, Becky Haruyama
+- **Special thanks:** Roni Burd, Mohammad A, Heba Elfardy, Sandeep Atluri, Sydney Lister, Ram Shankar Siva Kumar, Andrew Gully
+
 ## Trademarks
 
 This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft trademarks or logos is subject to and must follow [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks). Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship. Any use of third-party trademarks or logos is subject to those third party's policies.

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ assert-ai run --config examples/travel_planner_langgraph/eval_config.yaml
 
 ## Acknowledgments
 
-ASSERT's automated behavioral-evaluation pipeline builds on and adapts the design of **[Bloom](https://github.com/safety-research/bloom)**, an open-source framework for automated behavioral evaluations from the Anthropic alignment team (released under the Safety Research organization, MIT licensed), and the broader line of work it belongs to, including [Petri](https://github.com/safety-research/petri). The concept-systematization stage additionally follows [Agarwal et al. (2026)](https://www.microsoft.com/en-us/research/publication/ai-assisted-systematization-for-evaluating-genai-systems/).
+ASSERT's core method is **AI-assisted systematization** — turning a broad, contested behavior concept into an explicit, measurable specification — following **[Agarwal et al. (2026), *AI-Assisted Systematization for Evaluating GenAI Systems*](https://www.microsoft.com/en-us/research/publication/ai-assisted-systematization-for-evaluating-genai-systems/)** from Microsoft Research. The staged pipeline that turns that specification into generated scenarios, runs them against a target, and judges the results is modeled in spirit on the design of **[Bloom](https://github.com/safety-research/bloom)** and **[Petri](https://github.com/safety-research/petri)**, open-source behavioral-evaluation frameworks from the Anthropic alignment team (Safety Research, MIT licensed).
 
-Adapted third-party material and the corresponding license notices are documented in [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md). If you use ASSERT in research, please also consider citing Bloom (see [`CITATION.cff`](CITATION.cff)).
+Adapted third-party material and the corresponding license notices are documented in [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md). If you use ASSERT in research, please also cite Agarwal et al. (2026) and Bloom (see [`CITATION.cff`](CITATION.cff)).
 
 ### Team and contributors
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,20 +1,22 @@
 # Third-Party Notices
 
-ASSERT incorporates and adapts material from the third-party open-source
-projects listed below. We are grateful to their authors and maintainers. The
-original copyright and license notices are reproduced here as required by their
-licenses.
+ASSERT builds on and credits the third-party open-source work listed below. We
+are grateful to their authors and maintainers, and reproduce their original
+copyright and license notices here as good-faith attribution.
 
 ---
 
 ## Bloom
 
-ASSERT's automated behavioral-evaluation pipeline — its staged
-"generate scenarios, run them against a target, and judge the results against a
-specified behavior" design, along with parts of the associated configuration
-schema and prompt design — was adapted from **Bloom**, an open-source framework
-for automated behavioral evaluations of LLMs originally developed by the
-Anthropic alignment team and released under the "Safety Research" organization.
+ASSERT's automated behavioral-evaluation pipeline — its staged design of
+generating scenarios from a specified behavior, running them against a target,
+and judging the results — is **modeled on the design of Bloom**, an open-source
+framework for automated behavioral evaluations of LLMs originally developed by
+the Anthropic alignment team and released under the "Safety Research"
+organization. ASSERT's own implementation (code, prompts, and configuration
+schema) is independently written; this notice is provided as good-faith
+attribution to the project whose design ASSERT follows, and to retain Bloom's
+license notice.
 
 - **Project:** Bloom — Automated Behavioral Evaluations for LLMs
 - **Source:** https://github.com/safety-research/bloom

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,59 @@
+# Third-Party Notices
+
+ASSERT incorporates and adapts material from the third-party open-source
+projects listed below. We are grateful to their authors and maintainers. The
+original copyright and license notices are reproduced here as required by their
+licenses.
+
+---
+
+## Bloom
+
+ASSERT's automated behavioral-evaluation pipeline — its staged
+"generate scenarios, run them against a target, and judge the results against a
+specified behavior" design, along with parts of the associated configuration
+schema and prompt design — was adapted from **Bloom**, an open-source framework
+for automated behavioral evaluations of LLMs originally developed by the
+Anthropic alignment team and released under the "Safety Research" organization.
+
+- **Project:** Bloom — Automated Behavioral Evaluations for LLMs
+- **Source:** https://github.com/safety-research/bloom
+  (now developed and maintained by Meridian Labs at
+  https://meridianlabs-ai.github.io/petri_bloom/)
+- **License:** MIT
+
+```
+MIT License
+
+Copyright (c) 2025 Safety Research
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+If you use ASSERT's behavioral-evaluation pipeline in research, please also cite
+Bloom:
+
+```bibtex
+@misc{bloom2025,
+  title  = {Bloom: an open source tool for automated behavioral evaluations},
+  author = {Gupta, Isha and Fronsdal, Kai and Sheshadri, Abhay and Michala, Jonathan and Tay, Jacqueline and Wang, Rowan and Bowman, Samuel R. and Price, Sara},
+  year   = {2025},
+  url    = {https://github.com/safety-research/bloom},
+}
+```


### PR DESCRIPTION
## What

ASSERT's automated behavioral-evaluation pipeline is **modeled on the design of [Bloom](https://github.com/safety-research/bloom)** (MIT, Anthropic alignment team / Safety Research), and its concept-systematization stage follows **[Agarwal et al. (2026)](https://www.microsoft.com/en-us/research/publication/ai-assisted-systematization-for-evaluating-genai-systems/)** (Microsoft Research). This adds the attribution that was missing.

## Overlap analysis (why the wording is "modeled on," not "adapted code")

A side-by-side diff of the shipped Bloom source vs ASSERT found **no verbatim reuse**:
- Prompt/schema/data text: **~0% shared 8-grams** (longest common run 17-23 chars of common phrasing).
- Python implementation: **0.0-0.7% shared 40-char windows**, all boilerplate / library-call patterns.
- Config keys: **8 generic shared** (model, temperature, max_tokens, target, behavior, name, description, max_turns).

The overlap is **design/method/architecture** (the four-stage generate -> run -> judge pipeline) — not protected expression. We credit Bloom and retain its MIT notice as **good-faith attribution**.

## Changes

- **THIRD_PARTY_NOTICES.md** (new) — credits Bloom, reproduces its MIT copyright + permission notice as good-faith attribution; notes Bloom's new home at Meridian Labs.
- **README.md** — Acknowledgments section: leads with MSR systematization (Agarwal et al.), credits Bloom/Petri for the pipeline design, and lists the full ASSERT team (mirrors the public launch blog).
- **CITATION.cff** (new) — ASSERT citation + references for Agarwal et al. (2026) and Bloom.

## Scope notes

- Docs/legal artifacts only. No code or behavior changes.
- CITATION.cff \uthors\ is org-level ("Microsoft Responsible AI") for now; to sync to the paper's author list once finalized.
- Recommend a brief CELA / OSS-compliance glance at the attribution wording before merge (flagship RAI release publicly crediting an MIT, Anthropic-adjacent project). Per the diff, retaining Bloom's MIT notice is good-faith courtesy rather than strictly required.

## Follow-ups (not in this PR)

- Add a Bloom + Petri acknowledgment to the launch blog (aka.ms/assert).
- Ensure the incoming paper cites Bloom (and Petri) in Related Work.