### PR TITLE
feat(otel): map OTel GenAI (gen_ai.*) semconv spans to ASSERT event rows

### DIFF
--- a/assert_ai/core/otel.py
+++ b/assert_ai/core/otel.py
@@ -43,6 +43,40 @@ _TOOL_NAME_KEY = "tool.name"
 _LANGGRAPH_NODE_KEY = "langgraph.node"
 
 
+# OTel GenAI semantic conventions (gen_ai.*)
+# https://opentelemetry.io/docs/specs/semconv/gen-ai/
+# These are the newer, increasingly-standard semconv emitted by a growing
+# number of agent runtimes. They coexist with the OpenInference keys above:
+# a span is treated as gen_ai-flavored only when it carries
+# ``gen_ai.operation.name`` and does NOT carry ``openinference.span.kind``.
+
+_GENAI_OPERATION_KEY = "gen_ai.operation.name"
+_GENAI_REQUEST_MODEL_KEY = "gen_ai.request.model"
+_GENAI_RESPONSE_MODEL_KEY = "gen_ai.response.model"
+_GENAI_INPUT_TOKENS_KEY = "gen_ai.usage.input_tokens"
+_GENAI_OUTPUT_TOKENS_KEY = "gen_ai.usage.output_tokens"
+_GENAI_OUTPUT_MESSAGES_KEY = "gen_ai.output.messages"
+_GENAI_TOOL_NAME_KEY = "gen_ai.tool.name"
+_GENAI_TOOL_CALL_ID_KEY = "gen_ai.tool.call.id"
+_GENAI_TOOL_CALL_ARGS_KEY = "gen_ai.tool.call.arguments"
+_GENAI_TOOL_CALL_RESULT_KEY = "gen_ai.tool.call.result"
+_GENAI_AGENT_NAME_KEY = "gen_ai.agent.name"
+
+# Well-known gen_ai.operation.name values, classified by ASSERT event shape.
+_GENAI_LLM_OPERATIONS = frozenset({"chat", "text_completion", "generate_content"})
+_GENAI_TOOL_OPERATIONS = frozenset({"execute_tool"})
+
+# Span-event names that carry message/choice content (event-carried content).
+_GENAI_CHOICE_EVENT = "gen_ai.choice"
+_GENAI_ASSISTANT_MESSAGE_EVENT = "gen_ai.assistant.message"
+
+# Optional vendor enrichment (graceful add-on, never required). When present,
+# these provide higher-fidelity content than the generic gen_ai.* fields.
+_OPENCLAW_TOOL_INPUT_KEY = "openclaw.content.tool_input"
+_OPENCLAW_TOOL_OUTPUT_KEY = "openclaw.content.tool_output"
+_OPENCLAW_OUTPUT_MESSAGES_KEY = "openclaw.content.output_messages"
+
+
 @dataclass
 class OTelSpan:
     """Minimal representation of an OpenTelemetry span."""
@@ -55,10 +89,28 @@ class OTelSpan:
     end_time_ns: int
     attributes: dict[str, Any] = field(default_factory=dict)
     status: str = "OK"
+    events: list[dict[str, Any]] = field(default_factory=list)
 
     @property
     def latency_ms(self) -> float:
         return (self.end_time_ns - self.start_time_ns) / 1_000_000
+
+    @property
+    def is_gen_ai(self) -> bool:
+        """True when this span uses OTel GenAI semconv (and not OpenInference).
+
+        OpenInference takes precedence when both are present so the existing
+        path is never regressed.
+        """
+        return (
+            _GENAI_OPERATION_KEY in self.attributes
+            and _SPAN_KIND_KEY not in self.attributes
+        )
+
+    @property
+    def operation(self) -> str | None:
+        """The ``gen_ai.operation.name`` value, if any (e.g. ``chat``)."""
+        return self.attributes.get(_GENAI_OPERATION_KEY)
 
 
 def parse_otel_traces(
@@ -116,6 +168,7 @@ def _parse_otlp_json(path: Path) -> list[OTelSpan]:
         for scope_span in resource_span.get("scopeSpans", []):
             for raw in scope_span.get("spans", []):
                 attrs = _flatten_attributes(raw.get("attributes", []))
+                events = _parse_span_events(raw.get("events", []))
                 spans.append(OTelSpan(
                     trace_id=raw.get("traceId", ""),
                     span_id=raw.get("spanId", ""),
@@ -126,8 +179,26 @@ def _parse_otlp_json(path: Path) -> list[OTelSpan]:
                     end_time_ns=int(raw.get("endTimeUnixNano", 0)),
                     attributes=attrs,
                     status=raw.get("status", {}).get("code", "OK"),
+                    events=events,
                 ))
     return spans
+
+
+def _parse_span_events(raw_events: list[dict]) -> list[dict[str, Any]]:
+    """Parse the OTLP span ``events`` array into ``{name, attributes}`` dicts.
+
+    The OTel GenAI semconv carries a lot of message/choice content in span
+    events (``gen_ai.choice``, ``gen_ai.assistant.message``, etc.) rather than
+    span attributes, so the parser must preserve them. OpenInference traces
+    have no span events, so this is a no-op for the existing path.
+    """
+    events: list[dict[str, Any]] = []
+    for raw_event in raw_events:
+        events.append({
+            "name": raw_event.get("name", ""),
+            "attributes": _flatten_attributes(raw_event.get("attributes", [])),
+        })
+    return events
 
 
 def _flatten_attributes(attrs: list[dict]) -> dict[str, Any]:
@@ -189,6 +260,24 @@ def _spans_to_events(
     llm_call_count = 0
 
     for span in spans:
+        if span.is_gen_ai:
+            # OTel GenAI semconv span — handled by its own mapper so the
+            # OpenInference branches below stay byte-for-byte unchanged.
+            span_events, contribution = _gen_ai_span_to_events(span)
+            events.extend(span_events)
+            total_input_tokens += contribution["input_tokens"]
+            total_output_tokens += contribution["output_tokens"]
+            total_latency_ms += contribution["latency_ms"]
+            if contribution["is_llm_call"]:
+                llm_call_count += 1
+            node_name = contribution["node"]
+            if node_name and node_name not in nodes_visited:
+                nodes_visited.append(node_name)
+            tool_name = contribution["tool_name"]
+            if tool_name and tool_name not in tools_called:
+                tools_called.append(tool_name)
+            continue
+
         if span.kind == "LLM":
             output_text = span.attributes.get(_OUTPUT_VALUE_KEY, "")
             model = span.attributes.get(_LLM_MODEL_KEY, "")
@@ -288,7 +377,243 @@ def _spans_to_events(
     return events, aggregate
 
 
-# ── Span validation ───────────────────────────────────────────────
+# ── GenAI (gen_ai.*) semconv mapping ──────────────────────────────
+#
+# These helpers mirror the OpenInference structure above but read the OTel
+# GenAI semantic conventions. They are dispatched from ``_spans_to_events``
+# only for spans where ``span.is_gen_ai`` is true, so the OpenInference path
+# is never touched. The headline behavior stands on generic ``gen_ai.*``
+# fields alone; ``openclaw.content.*`` is an optional enrichment layer that,
+# when present, supplies higher-fidelity content.
+
+
+def _gen_ai_span_to_events(
+    span: OTelSpan,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Map a single gen_ai.* span to ASSERT events + an aggregate contribution.
+
+    Returns ``(events, contribution)`` where ``contribution`` carries the
+    token/latency/node/tool deltas the caller folds into session aggregates.
+    """
+    operation = (span.operation or "").strip()
+    if operation in _GENAI_TOOL_OPERATIONS:
+        return _gen_ai_tool_span_to_events(span)
+    if operation in _GENAI_LLM_OPERATIONS:
+        return _gen_ai_llm_span_to_events(span)
+    # Unknown/other gen_ai operation (embeddings, invoke_agent, plan, ...).
+    # Degrade gracefully: keep the span visible in node history without
+    # inventing message or tool-call content.
+    return [], _gen_ai_contribution(node=span.attributes.get(_GENAI_AGENT_NAME_KEY, span.name))
+
+
+def _gen_ai_contribution(
+    *,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    latency_ms: float = 0.0,
+    is_llm_call: bool = False,
+    node: str | None = None,
+    tool_name: str | None = None,
+) -> dict[str, Any]:
+    """Build the aggregate-contribution dict consumed by ``_spans_to_events``."""
+    return {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "latency_ms": latency_ms,
+        "is_llm_call": is_llm_call,
+        "node": node,
+        "tool_name": tool_name,
+    }
+
+
+def _gen_ai_llm_span_to_events(
+    span: OTelSpan,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Map a gen_ai chat/completion span to an ``add_message`` event."""
+    attrs = span.attributes
+    # Prefer the response model (what actually answered) over the request model.
+    model = attrs.get(_GENAI_RESPONSE_MODEL_KEY) or attrs.get(_GENAI_REQUEST_MODEL_KEY, "")
+    input_tokens = attrs.get(_GENAI_INPUT_TOKENS_KEY, 0)
+    output_tokens = attrs.get(_GENAI_OUTPUT_TOKENS_KEY, 0)
+    node_name = attrs.get(_GENAI_AGENT_NAME_KEY, span.name)
+
+    output_text = _gen_ai_assistant_text(span)
+
+    events: list[dict[str, Any]] = []
+    if output_text:
+        events.append({
+            "view": ["target", "combined"],
+            "actor": "target",
+            "edit": {
+                "type": "add_message",
+                "message": {"role": "assistant", "content": output_text},
+            },
+            "raw": {
+                "_node": node_name,
+                "_model": model,
+                "_tokens": {"input": input_tokens, "output": output_tokens},
+                "_latency_ms": span.latency_ms,
+                "_semconv": "gen_ai",
+            },
+        })
+
+    contribution = _gen_ai_contribution(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        latency_ms=span.latency_ms,
+        is_llm_call=True,
+        node=node_name,
+    )
+    return events, contribution
+
+
+def _gen_ai_tool_span_to_events(
+    span: OTelSpan,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Map a gen_ai execute_tool span to a ``tool_call`` event."""
+    attrs = span.attributes
+    tool_name = attrs.get(_GENAI_TOOL_NAME_KEY, span.name)
+    tool_call_id = attrs.get(_GENAI_TOOL_CALL_ID_KEY)
+
+    # Optional openclaw enrichment wins for fidelity; fall back to generic
+    # gen_ai.tool.call.* when it is absent.
+    raw_args = attrs.get(_OPENCLAW_TOOL_INPUT_KEY)
+    if raw_args is None:
+        raw_args = attrs.get(_GENAI_TOOL_CALL_ARGS_KEY, "")
+    tool_args = _coerce_tool_args(raw_args)
+
+    tool_result = attrs.get(_OPENCLAW_TOOL_OUTPUT_KEY)
+    if tool_result is None:
+        tool_result = attrs.get(_GENAI_TOOL_CALL_RESULT_KEY, "")
+    tool_result = _coerce_tool_result(tool_result)
+
+    events = [{
+        "view": ["target", "combined"],
+        "actor": "tool",
+        "edit": {
+            "type": "tool_call",
+            "tool_name": tool_name,
+            "tool_args": tool_args,
+            "tool_result": tool_result,
+            "tool_call_id": tool_call_id,
+        },
+        "raw": {"_semconv": "gen_ai"},
+    }]
+
+    contribution = _gen_ai_contribution(
+        latency_ms=span.latency_ms,
+        tool_name=tool_name,
+    )
+    return events, contribution
+
+
+def _gen_ai_assistant_text(span: OTelSpan) -> str:
+    """Resolve assistant text from a gen_ai chat span.
+
+    Resolution order (highest fidelity first):
+      1. ``openclaw.content.output_messages`` (optional vendor enrichment)
+      2. ``gen_ai.output.messages`` span attribute (attribute-carried content)
+      3. ``gen_ai.choice`` / ``gen_ai.assistant.message`` span events
+         (event-carried content — where the spec puts most content)
+    """
+    enrichment = span.attributes.get(_OPENCLAW_OUTPUT_MESSAGES_KEY)
+    if enrichment:
+        text = _text_from_messages(enrichment)
+        if text:
+            return text
+
+    attr_messages = span.attributes.get(_GENAI_OUTPUT_MESSAGES_KEY)
+    if attr_messages:
+        text = _text_from_messages(attr_messages)
+        if text:
+            return text
+
+    return _text_from_span_events(span)
+
+
+def _text_from_messages(value: Any) -> str:
+    """Extract assistant text from a gen_ai messages structure.
+
+    Handles both the structured ``[{"role", "parts": [{"type": "text",
+    "content"}]}]`` shape and the simpler ``[{"role", "content"}]`` shape,
+    accepting either a parsed list or a JSON string.
+    """
+    messages = _maybe_load_json(value)
+    if isinstance(messages, str):
+        # Not JSON — treat the raw string as the content itself.
+        return messages
+    if isinstance(messages, dict):
+        messages = [messages]
+    if not isinstance(messages, list):
+        return ""
+
+    parts: list[str] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content")
+        if isinstance(content, str) and content:
+            parts.append(content)
+            continue
+        for part in message.get("parts", []) or []:
+            if isinstance(part, dict) and part.get("type") == "text":
+                text = part.get("content")
+                if isinstance(text, str) and text:
+                    parts.append(text)
+    return "\n".join(parts)
+
+
+def _text_from_span_events(span: OTelSpan) -> str:
+    """Extract assistant text from gen_ai.choice / gen_ai.assistant.message events."""
+    parts: list[str] = []
+    for event in span.events:
+        name = event.get("name", "")
+        event_attrs = event.get("attributes", {})
+        if name == _GENAI_CHOICE_EVENT:
+            message = _maybe_load_json(event_attrs.get("message", ""))
+            if isinstance(message, dict):
+                content = message.get("content")
+                if isinstance(content, str) and content:
+                    parts.append(content)
+        elif name == _GENAI_ASSISTANT_MESSAGE_EVENT:
+            content = event_attrs.get("content")
+            if isinstance(content, str) and content:
+                parts.append(content)
+    return "\n".join(parts)
+
+
+def _coerce_tool_args(value: Any) -> dict[str, Any]:
+    """Coerce gen_ai tool-call arguments into a dict (mirrors OpenInference)."""
+    if isinstance(value, dict):
+        return value
+    if not value:
+        return {}
+    parsed = _maybe_load_json(value)
+    if isinstance(parsed, dict):
+        return parsed
+    return {"raw": value}
+
+
+def _coerce_tool_result(value: Any) -> str:
+    """Coerce a gen_ai tool-call result into a string for the event row."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, ensure_ascii=False)
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def _maybe_load_json(value: Any) -> Any:
+    """Best-effort JSON parse; return the original value when it is not JSON."""
+    if not isinstance(value, str):
+        return value
+    try:
+        return json.loads(value)
+    except (json.JSONDecodeError, ValueError):
+        return value
 
 
 @dataclass
@@ -311,6 +636,12 @@ def validate_spans(spans: list[OTelSpan]) -> SpanValidationResult:
     warnings: list[str] = []
 
     for span in spans:
+        if span.is_gen_ai:
+            # GenAI semconv span — validate against gen_ai.* recommendations
+            # rather than the OpenInference kind.
+            warnings.extend(_validate_gen_ai_span(span))
+            continue
+
         if span.kind == "UNKNOWN":
             warnings.append(f"span {span.span_id}: missing {_SPAN_KIND_KEY}")
 
@@ -334,6 +665,34 @@ def validate_spans(spans: list[OTelSpan]) -> SpanValidationResult:
         missing_attributes=[],
         warnings=warnings,
     )
+
+
+def _validate_gen_ai_span(span: OTelSpan) -> list[str]:
+    """Informational checks for an OTel GenAI semconv span.
+
+    Mirrors the OpenInference checks (warns, never drops), but keyed on
+    gen_ai.* attributes so gen_ai spans are never flagged as missing the
+    OpenInference ``openinference.span.kind``.
+    """
+    warnings: list[str] = []
+    operation = (span.operation or "").strip()
+
+    if operation in _GENAI_LLM_OPERATIONS:
+        if not (
+            span.attributes.get(_GENAI_RESPONSE_MODEL_KEY)
+            or span.attributes.get(_GENAI_REQUEST_MODEL_KEY)
+        ):
+            warnings.append(f"span {span.span_id}: missing {_GENAI_REQUEST_MODEL_KEY}")
+        if (
+            not span.attributes.get(_GENAI_INPUT_TOKENS_KEY)
+            and not span.attributes.get(_GENAI_OUTPUT_TOKENS_KEY)
+        ):
+            warnings.append(f"span {span.span_id}: missing token counts")
+    elif operation in _GENAI_TOOL_OPERATIONS:
+        if not span.attributes.get(_GENAI_TOOL_NAME_KEY):
+            warnings.append(f"span {span.span_id}: missing {_GENAI_TOOL_NAME_KEY}")
+
+    return warnings
 
 
 # ── Trace compression ────────────────────────────────────────────

--- a/tests/fixtures/gen_ai_openclaw_enrichment_traces.json
+++ b/tests/fixtures/gen_ai_openclaw_enrichment_traces.json
@@ -1,0 +1,49 @@
+{
+  "resourceSpans": [
+    {
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "genai_oc_trace_01",
+              "spanId": "ocspan_01",
+              "name": "chat gpt-4o",
+              "startTimeUnixNano": 1000000000,
+              "endTimeUnixNano": 2240000000,
+              "attributes": [
+                {"key": "gen_ai.operation.name", "value": {"stringValue": "chat"}},
+                {"key": "gen_ai.system", "value": {"stringValue": "openclaw"}},
+                {"key": "session.id", "value": {"stringValue": "sess_oc_trip"}},
+                {"key": "gen_ai.request.model", "value": {"stringValue": "gpt-4o"}},
+                {"key": "gen_ai.response.model", "value": {"stringValue": "gpt-4o-2024-08-06"}},
+                {"key": "gen_ai.usage.input_tokens", "value": {"intValue": "120"}},
+                {"key": "gen_ai.usage.output_tokens", "value": {"intValue": "64"}},
+                {"key": "gen_ai.output.messages", "value": {"stringValue": "[{\"role\": \"assistant\", \"parts\": [{\"type\": \"text\", \"content\": \"GENERIC short answer\"}], \"finish_reason\": \"stop\"}]"}},
+                {"key": "openclaw.content.input_messages", "value": {"stringValue": "[{\"role\": \"user\", \"content\": \"Plan a Tokyo trip with full detail\"}]"}},
+                {"key": "openclaw.content.output_messages", "value": {"stringValue": "[{\"role\": \"assistant\", \"content\": \"OPENCLAW full fidelity Tokyo itinerary: ANA $1180 + Granbell 7 nights $1015 = $2195.\"}]"}}
+              ]
+            },
+            {
+              "traceId": "genai_oc_trace_01",
+              "spanId": "ocspan_02",
+              "parentSpanId": "ocspan_01",
+              "name": "execute_tool search_hotels",
+              "startTimeUnixNano": 2300000000,
+              "endTimeUnixNano": 3500000000,
+              "attributes": [
+                {"key": "gen_ai.operation.name", "value": {"stringValue": "execute_tool"}},
+                {"key": "session.id", "value": {"stringValue": "sess_oc_trip"}},
+                {"key": "gen_ai.tool.name", "value": {"stringValue": "search_hotels"}},
+                {"key": "gen_ai.tool.call.id", "value": {"stringValue": "call_hotels_001"}},
+                {"key": "gen_ai.tool.call.arguments", "value": {"stringValue": "{\"city\": \"Tokyo\"}"}},
+                {"key": "gen_ai.tool.call.result", "value": {"stringValue": "[truncated]"}},
+                {"key": "openclaw.content.tool_input", "value": {"stringValue": "{\"city\": \"Tokyo\", \"max_price_per_night\": 250, \"checkin\": \"2025-07-10\"}"}},
+                {"key": "openclaw.content.tool_output", "value": {"stringValue": "[{\"name\": \"Shinjuku Granbell\", \"price_per_night\": 145, \"rating\": 4.5}]"}}
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/gen_ai_otel_traces.json
+++ b/tests/fixtures/gen_ai_otel_traces.json
@@ -1,0 +1,85 @@
+{
+  "resourceSpans": [
+    {
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "genai_trace_01",
+              "spanId": "gspan_01",
+              "name": "chat gpt-4o",
+              "startTimeUnixNano": 1000000000,
+              "endTimeUnixNano": 2240000000,
+              "attributes": [
+                {"key": "gen_ai.operation.name", "value": {"stringValue": "chat"}},
+                {"key": "gen_ai.system", "value": {"stringValue": "openai"}},
+                {"key": "gen_ai.provider.name", "value": {"stringValue": "openai"}},
+                {"key": "session.id", "value": {"stringValue": "sess_genai_trip"}},
+                {"key": "gen_ai.request.model", "value": {"stringValue": "gpt-4o"}},
+                {"key": "gen_ai.response.model", "value": {"stringValue": "gpt-4o-2024-08-06"}},
+                {"key": "gen_ai.usage.input_tokens", "value": {"intValue": "85"}},
+                {"key": "gen_ai.usage.output_tokens", "value": {"intValue": "42"}}
+              ],
+              "events": [
+                {
+                  "timeUnixNano": 1100000000,
+                  "name": "gen_ai.user.message",
+                  "attributes": [
+                    {"key": "gen_ai.system", "value": {"stringValue": "openai"}},
+                    {"key": "content", "value": {"stringValue": "Book me a week in Tokyo in July for under $3000"}},
+                    {"key": "role", "value": {"stringValue": "user"}}
+                  ]
+                },
+                {
+                  "timeUnixNano": 2200000000,
+                  "name": "gen_ai.choice",
+                  "attributes": [
+                    {"key": "gen_ai.system", "value": {"stringValue": "openai"}},
+                    {"key": "finish_reason", "value": {"stringValue": "stop"}},
+                    {"key": "index", "value": {"intValue": "0"}},
+                    {"key": "message", "value": {"stringValue": "{\"role\":\"assistant\",\"content\":\"{\\\"intent\\\": \\\"book_trip\\\", \\\"destination\\\": \\\"Tokyo\\\"}\"}"}}
+                  ]
+                }
+              ]
+            },
+            {
+              "traceId": "genai_trace_01",
+              "spanId": "gspan_02",
+              "parentSpanId": "gspan_01",
+              "name": "execute_tool search_flights",
+              "startTimeUnixNano": 2300000000,
+              "endTimeUnixNano": 3500000000,
+              "attributes": [
+                {"key": "gen_ai.operation.name", "value": {"stringValue": "execute_tool"}},
+                {"key": "session.id", "value": {"stringValue": "sess_genai_trip"}},
+                {"key": "gen_ai.tool.name", "value": {"stringValue": "search_flights"}},
+                {"key": "gen_ai.tool.type", "value": {"stringValue": "function"}},
+                {"key": "gen_ai.tool.call.id", "value": {"stringValue": "call_flights_001"}},
+                {"key": "gen_ai.tool.call.arguments", "value": {"stringValue": "{\"destination\": \"NRT\", \"max_price\": 1500}"}},
+                {"key": "gen_ai.tool.call.result", "value": {"stringValue": "[{\"airline\": \"ANA\", \"price\": 1180}]"}}
+              ]
+            },
+            {
+              "traceId": "genai_trace_01",
+              "spanId": "gspan_03",
+              "parentSpanId": "gspan_01",
+              "name": "chat gpt-4o",
+              "startTimeUnixNano": 3600000000,
+              "endTimeUnixNano": 5700000000,
+              "attributes": [
+                {"key": "gen_ai.operation.name", "value": {"stringValue": "chat"}},
+                {"key": "gen_ai.system", "value": {"stringValue": "openai"}},
+                {"key": "session.id", "value": {"stringValue": "sess_genai_trip"}},
+                {"key": "gen_ai.request.model", "value": {"stringValue": "gpt-4o"}},
+                {"key": "gen_ai.response.model", "value": {"stringValue": "gpt-4o-2024-08-06"}},
+                {"key": "gen_ai.usage.input_tokens", "value": {"intValue": "210"}},
+                {"key": "gen_ai.usage.output_tokens", "value": {"intValue": "95"}},
+                {"key": "gen_ai.output.messages", "value": {"stringValue": "[{\"role\": \"assistant\", \"parts\": [{\"type\": \"text\", \"content\": \"Here is your optimized Tokyo itinerary: ANA flight $1180 + Granbell 7 nights $1015 = $2195 total.\"}], \"finish_reason\": \"stop\"}]"}}
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_otel_gen_ai.py
+++ b/tests/test_otel_gen_ai.py
@@ -1,0 +1,235 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for OTel GenAI semantic-convention (``gen_ai.*``) span parsing.
+
+These cover the newer OpenTelemetry GenAI semconv that a growing number of
+agent runtimes emit, in addition to the existing OpenInference conventions.
+The parser must map ``gen_ai.*`` spans into the same ASSERT inference-row
+shape (``{metadata, events, raw}`` with ``tool_call`` / ``add_message``
+events) without regressing the OpenInference path.
+
+Spec references (authoritative, not memory):
+- https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/
+- gen-ai-events (gen_ai.choice / gen_ai.assistant.message / gen_ai.tool.message)
+
+The ``gen_ai.*`` headline must stand on generic semconv alone; the
+``openclaw.content.*`` vendor attributes are an optional enrichment layer
+for content fidelity, never a requirement.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from assert_ai.core.otel import parse_otel_traces
+
+FIXTURES = Path(__file__).parent / "fixtures"
+GENAI_TRACES = FIXTURES / "gen_ai_otel_traces.json"
+GENAI_OPENCLAW_TRACES = FIXTURES / "gen_ai_openclaw_enrichment_traces.json"
+OPENINFERENCE_TRACES = FIXTURES / "sample_otel_traces.json"
+
+
+def _write_temp_otlp(payload: dict) -> Path:
+    """Dump an OTLP-JSON payload to a temp file and return its path."""
+    tmp = tempfile.NamedTemporaryFile(
+        mode="w", suffix=".json", delete=False, encoding="utf-8"
+    )
+    json.dump(payload, tmp)
+    tmp.flush()
+    tmp.close()
+    return Path(tmp.name)
+
+
+# ── Headline: generic gen_ai.* spans (no vendor enrichment) ──────────
+
+
+class TestGenAiParser(unittest.TestCase):
+    """gen_ai.* spans map into ASSERT event rows on generic semconv alone."""
+
+    def setUp(self):
+        self.rows = parse_otel_traces(GENAI_TRACES, group_by="session.id")
+
+    def test_groups_into_single_session(self):
+        self.assertEqual(len(self.rows), 1)
+        self.assertEqual(self.rows[0]["metadata"]["session_id"], "sess_genai_trip")
+
+    def test_row_schema_unchanged(self):
+        row = self.rows[0]
+        self.assertIn("metadata", row)
+        self.assertIn("events", row)
+        self.assertIn("raw", row)
+        self.assertEqual(row["metadata"]["type"], "otel_import")
+        self.assertEqual(row["metadata"]["runtime_mode"], "otel_traced")
+
+    def test_event_counts(self):
+        """Two chat spans -> 2 assistant messages; one execute_tool -> 1 tool call."""
+        events = self.rows[0]["events"]
+        target_events = [e for e in events if e["actor"] == "target"]
+        tool_events = [e for e in events if e["actor"] == "tool"]
+        self.assertEqual(len(target_events), 2)
+        self.assertEqual(len(tool_events), 1)
+
+    def test_event_carried_choice_content(self):
+        """First chat span's assistant text comes from a gen_ai.choice span EVENT."""
+        target_events = [e for e in self.rows[0]["events"] if e["actor"] == "target"]
+        first = target_events[0]
+        self.assertEqual(first["edit"]["type"], "add_message")
+        self.assertEqual(first["edit"]["message"]["role"], "assistant")
+        self.assertEqual(
+            first["edit"]["message"]["content"],
+            '{"intent": "book_trip", "destination": "Tokyo"}',
+        )
+
+    def test_attribute_carried_output_messages_content(self):
+        """Second chat span's text comes from the gen_ai.output.messages ATTRIBUTE."""
+        target_events = [e for e in self.rows[0]["events"] if e["actor"] == "target"]
+        second = target_events[1]
+        self.assertIn("optimized Tokyo itinerary", second["edit"]["message"]["content"])
+
+    def test_llm_metadata_model_and_tokens(self):
+        target_events = [e for e in self.rows[0]["events"] if e["actor"] == "target"]
+        first = target_events[0]
+        # response.model is preferred over request.model.
+        self.assertEqual(first["raw"]["_model"], "gpt-4o-2024-08-06")
+        self.assertEqual(first["raw"]["_tokens"]["input"], 85)
+        self.assertEqual(first["raw"]["_tokens"]["output"], 42)
+
+    def test_tool_call_mapping(self):
+        tool_events = [e for e in self.rows[0]["events"] if e["actor"] == "tool"]
+        tool = tool_events[0]
+        self.assertEqual(tool["edit"]["type"], "tool_call")
+        self.assertEqual(tool["edit"]["tool_name"], "search_flights")
+        self.assertEqual(tool["edit"]["tool_args"]["destination"], "NRT")
+        self.assertEqual(tool["edit"]["tool_args"]["max_price"], 1500)
+        self.assertIn("ANA", tool["edit"]["tool_result"])
+
+    def test_tool_call_id_preserved(self):
+        """gen_ai.tool.call.id is carried on the tool_call edit (viewer reads it)."""
+        tool_events = [e for e in self.rows[0]["events"] if e["actor"] == "tool"]
+        self.assertEqual(tool_events[0]["edit"]["tool_call_id"], "call_flights_001")
+
+    def test_aggregate_metadata(self):
+        agg = self.rows[0]["raw"]
+        self.assertEqual(agg["llm_call_count"], 2)
+        self.assertEqual(agg["total_tokens"]["input"], 85 + 210)
+        self.assertEqual(agg["total_tokens"]["output"], 42 + 95)
+        self.assertIn("search_flights", agg["tools_called"])
+
+
+# ── Optional openclaw.* enrichment layer (content fidelity add-on) ───
+
+
+class TestGenAiOpenClawEnrichment(unittest.TestCase):
+    """openclaw.content.* enriches content fidelity but is never required."""
+
+    def setUp(self):
+        self.rows = parse_otel_traces(GENAI_OPENCLAW_TRACES, group_by="session.id")
+
+    def test_enrichment_output_messages_win_over_generic(self):
+        target_events = [e for e in self.rows[0]["events"] if e["actor"] == "target"]
+        content = target_events[0]["edit"]["message"]["content"]
+        self.assertIn("OPENCLAW full fidelity", content)
+        self.assertNotIn("GENERIC short answer", content)
+
+    def test_enrichment_tool_input_output_win_over_generic(self):
+        tool_events = [e for e in self.rows[0]["events"] if e["actor"] == "tool"]
+        tool = tool_events[0]
+        # Generic gen_ai.tool.call.arguments only had {"city": "Tokyo"};
+        # the openclaw enrichment carries the full argument object.
+        self.assertEqual(tool["edit"]["tool_args"]["max_price_per_night"], 250)
+        self.assertIn("Granbell", tool["edit"]["tool_result"])
+        self.assertNotIn("[truncated]", tool["edit"]["tool_result"])
+
+
+# ── Graceful degradation when optional gen_ai fields are absent ──────
+
+
+class TestGenAiGracefulDegradation(unittest.TestCase):
+    """Missing optional gen_ai fields must not crash or drop the span."""
+
+    def test_chat_span_without_content_or_usage(self):
+        payload = {
+            "resourceSpans": [{"scopeSpans": [{"spans": [{
+                "traceId": "t_min",
+                "spanId": "s_min",
+                "name": "chat gpt-4o",
+                "startTimeUnixNano": 1000000000,
+                "endTimeUnixNano": 1100000000,
+                "attributes": [
+                    {"key": "gen_ai.operation.name", "value": {"stringValue": "chat"}},
+                    {"key": "gen_ai.request.model", "value": {"stringValue": "gpt-4o"}},
+                    {"key": "session.id", "value": {"stringValue": "sess_min"}},
+                ],
+            }]}]}]
+        }
+        path = _write_temp_otlp(payload)
+        rows = parse_otel_traces(path, group_by="session.id")
+        self.assertEqual(len(rows), 1)
+        # Counted as an LLM call even though it emitted no message content.
+        self.assertEqual(rows[0]["raw"]["llm_call_count"], 1)
+
+    def test_execute_tool_span_with_only_name(self):
+        payload = {
+            "resourceSpans": [{"scopeSpans": [{"spans": [{
+                "traceId": "t_tool",
+                "spanId": "s_tool",
+                "name": "execute_tool lookup",
+                "startTimeUnixNano": 1000000000,
+                "endTimeUnixNano": 1100000000,
+                "attributes": [
+                    {"key": "gen_ai.operation.name", "value": {"stringValue": "execute_tool"}},
+                    {"key": "gen_ai.tool.name", "value": {"stringValue": "lookup"}},
+                    {"key": "session.id", "value": {"stringValue": "sess_tool"}},
+                ],
+            }]}]}]
+        }
+        path = _write_temp_otlp(payload)
+        rows = parse_otel_traces(path, group_by="session.id")
+        tool_events = [e for e in rows[0]["events"] if e["actor"] == "tool"]
+        self.assertEqual(len(tool_events), 1)
+        self.assertEqual(tool_events[0]["edit"]["tool_name"], "lookup")
+        self.assertEqual(tool_events[0]["edit"]["tool_args"], {})
+        self.assertEqual(tool_events[0]["edit"]["tool_result"], "")
+        self.assertIsNone(tool_events[0]["edit"]["tool_call_id"])
+
+
+# ── Span validation treats gen_ai spans as first-class ──────────────
+
+
+class TestGenAiSpanValidation(unittest.TestCase):
+    """validate_spans must not flag gen_ai spans as missing the OpenInference kind."""
+
+    def test_gen_ai_span_not_flagged_unknown(self):
+        from assert_ai.core.otel import _parse_otlp_json, validate_spans
+
+        spans = _parse_otlp_json(GENAI_TRACES)
+        result = validate_spans(spans)
+        self.assertFalse(
+            any("openinference.span.kind" in w for w in result.warnings),
+            f"gen_ai spans should not warn about OpenInference kind: {result.warnings}",
+        )
+
+
+# ── Coexistence: OpenInference path must remain unchanged ────────────
+
+
+class TestOpenInferenceStillParses(unittest.TestCase):
+    """Adding gen_ai support must not regress OpenInference parsing."""
+
+    def test_openinference_sample_unchanged(self):
+        rows = parse_otel_traces(OPENINFERENCE_TRACES, group_by="session.id")
+        session_ids = {r["metadata"]["session_id"] for r in rows}
+        self.assertEqual(session_ids, {"sess_tokyo_trip", "sess_paris_trip"})
+        tokyo = next(r for r in rows if r["metadata"]["session_id"] == "sess_tokyo_trip")
+        target_events = [e for e in tokyo["events"] if e["actor"] == "target"]
+        tool_events = [e for e in tokyo["events"] if e["actor"] == "tool"]
+        self.assertEqual(len(target_events), 3)
+        self.assertEqual(len(tool_events), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

ASSERT's OTel trace parser (`assert_ai/core/otel.py`) previously understood only **OpenInference** semantic conventions (`openinference.span.kind`, `tool.name`, `input.value`). Any agent runtime that emits the newer, increasingly-standard **OTel GenAI semantic conventions** (`gen_ai.*`) had its spans classified `UNKNOWN` and its tool calls dropped on import.

This PR adds `gen_ai.*` mapping into ASSERT's existing inference-row shape, expanding native traced-target reach to every agent on that standard. It's a clean, parser-only improvement and is valuable on its own.

## The gap

`_spans_to_events` keys entirely off `openinference.span.kind`. A `gen_ai`-emitting span has no such attribute, so it fell through to the `UNKNOWN` branch: no `tool_call` rows, no model/usage metadata, and message content (which the GenAI spec often puts in **span events** like `gen_ai.choice`) was never even parsed, since `_parse_otlp_json` only read span *attributes*.

## The fix

A standalone `gen_ai.*` path, dispatched only for spans where `OTelSpan.is_gen_ai` is true (carries `gen_ai.operation.name` and not `openinference.span.kind`). It maps into the **same** `{metadata, events, raw}` rows with `tool_call` / `add_message` events — no new shape invented.

- **Span kind from `gen_ai.operation.name`:** `chat` / `text_completion` / `generate_content` → assistant `add_message`; `execute_tool` → `tool_call`.
- **Model / usage metadata:** `gen_ai.request.model` / `gen_ai.response.model` (response preferred), `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens`.
- **Attribute- and event-carried content:** reads `gen_ai.output.messages` (attribute) and, since the spec puts a lot of content in span events, also `gen_ai.choice` / `gen_ai.assistant.message` span events. The OTLP span `events` array is now parsed (it was previously discarded).
- **Tool calls:** `gen_ai.tool.name`, `gen_ai.tool.call.arguments`, `gen_ai.tool.call.result`, and `gen_ai.tool.call.id` (carried on the `tool_call` edit — the viewer read-model already consumes `tool_call_id`).
- **Graceful degradation** when optional fields are absent (no content, no usage, tool name only, etc.).
- **Validation:** `validate_spans` now checks `gen_ai` spans against `gen_ai.*` recommendations instead of flagging them as missing the OpenInference kind.

### Optional vendor enrichment (`openclaw.content.*`)

When a span also carries `openclaw.content.tool_input` / `tool_output` / `output_messages`, those are used as a higher-fidelity content layer. This is a **graceful add-on, never a requirement** — the headline behavior and every generic test stand on `gen_ai.*` alone. This was surfaced while investigating sandboxed-agent evals (OpenClaw ships an OTel exporter that emits `gen_ai.*` + `openclaw.*`).

## Coexistence / no regression

OpenInference spans parse exactly as before — the existing branches are untouched and OpenInference takes precedence when both markers are present. The pre-existing OTel test suite passes unchanged.

## Scope

- **In:** `gen_ai.*` span → ASSERT event-row mapping, plus an optional `openclaw.content.*` enrichment layer.
- **Out / not touched:** any sandbox / RAMPART / local-agent code, host-side OTLP collector/receiver work, and exporter-config or container-networking changes. **This PR is parser-only and has no sandbox dependency.** Those remain separate follow-ups.

## Tests (TDD)

New `tests/test_otel_gen_ai.py` with realistic `gen_ai.*` OTLP-JSON fixtures authored from the [OTel GenAI spec](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/):

- `tests/fixtures/gen_ai_otel_traces.json` — a `chat` span with usage and an event-carried `gen_ai.choice`, an `execute_tool` span, and a second `chat` span using the attribute-carried `gen_ai.output.messages`.
- `tests/fixtures/gen_ai_openclaw_enrichment_traces.json` — the same generic `gen_ai.*` spans plus `openclaw.content.*`, asserting the enrichment wins for fidelity while generic parsing still holds.

Coverage: span grouping, row schema, event counts, event- vs attribute-carried content, model/token metadata, tool-call mapping + call id, aggregate metadata, graceful degradation, span validation, the optional enrichment layer, and an explicit OpenInference-coexistence test.

### Local validation

```
pytest tests/test_otel_gen_ai.py -q            # 15 passed
pytest tests/test_framework_agnostic.py -q     # 110 passed, 1 skipped (existing OTel suite, unchanged)
```
Full OTel module + all `core.otel` / viewer-read-model consumers: 236 passed, 1 skipped, 0 failures.
