### PR TITLE
Docs UX enhancements: copy buttons and content search to docs

### DIFF
--- a/website/app/docs/_components/DocsSidebar.tsx
+++ b/website/app/docs/_components/DocsSidebar.tsx
@@ -1,7 +1,8 @@
-import { getDocsNav } from "../_lib/docs";
+import { getDocsNav, getDocsSearchIndex } from "../_lib/docs";
 import DocsSidebarClient from "./DocsSidebarClient";
 
 export default function DocsSidebar({ activeHref }: { activeHref?: string }) {
 	const nav = getDocsNav();
-	return <DocsSidebarClient nav={nav} activeHref={activeHref} />;
+	const searchIndex = getDocsSearchIndex();
+	return <DocsSidebarClient nav={nav} searchIndex={searchIndex} activeHref={activeHref} />;
 }

--- a/website/app/docs/_components/DocsSidebarClient.tsx
+++ b/website/app/docs/_components/DocsSidebarClient.tsx
@@ -1,34 +1,108 @@
 "use client";
 
 import Link from "next/link";
-import { useMemo, useState } from "react";
-import type { DocMeta } from "../_lib/docs";
+import { useMemo, useState, type ReactNode } from "react";
+import type { DocMeta, DocSearchEntry } from "../_lib/docs";
 
 type NavGroup = { group: string | null; items: DocMeta[] };
 
+type SearchResult = {
+	href: string;
+	title: string;
+	group: string | null;
+	snippet: ReactNode;
+};
+
+const SNIPPET_BEFORE = 40;
+const SNIPPET_AFTER = 120;
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// Wrap occurrences of the query within text in <mark> for highlighting.
+function highlight(text: string, query: string): ReactNode {
+	if (!query) return text;
+	const re = new RegExp(escapeRegExp(query), "gi");
+	const parts: ReactNode[] = [];
+	let lastIndex = 0;
+	let match: RegExpExecArray | null;
+	let key = 0;
+	while ((match = re.exec(text)) !== null) {
+		if (match.index > lastIndex) parts.push(text.slice(lastIndex, match.index));
+		parts.push(
+			<mark key={key++} className="docs-search-hl">
+				{match[0]}
+			</mark>,
+		);
+		lastIndex = match.index + match[0].length;
+		if (match.index === re.lastIndex) re.lastIndex++;
+	}
+	if (lastIndex < text.length) parts.push(text.slice(lastIndex));
+	return parts;
+}
+
+function buildResult(entry: DocSearchEntry, q: string): SearchResult | null {
+	const haystack = entry.text;
+	const lower = haystack.toLowerCase();
+	const titleMatch = entry.title.toLowerCase().includes(q);
+	const idx = lower.indexOf(q);
+
+	// No match anywhere in title or body -> not a result.
+	if (idx === -1 && !titleMatch) return null;
+
+	// Deep-link to the nearest heading preceding the body match.
+	let href = entry.href;
+	let snippetText = "";
+	if (idx !== -1) {
+		let heading = null as (typeof entry.headings)[number] | null;
+		for (const h of entry.headings) {
+			if (h.offset <= idx) heading = h;
+			else break;
+		}
+		if (heading) href = `${entry.href}#${heading.id}`;
+
+		const start = Math.max(0, idx - SNIPPET_BEFORE);
+		const end = Math.min(haystack.length, idx + q.length + SNIPPET_AFTER);
+		snippetText =
+			(start > 0 ? "\u2026" : "") +
+			haystack.slice(start, end).trim() +
+			(end < haystack.length ? "\u2026" : "");
+	} else {
+		// Title-only match: show the opening of the body as context.
+		snippetText = haystack.slice(0, SNIPPET_AFTER).trim() + (haystack.length > SNIPPET_AFTER ? "\u2026" : "");
+	}
+
+	return {
+		href,
+		title: entry.title,
+		group: entry.group,
+		snippet: highlight(snippetText, q),
+	};
+}
+
 export default function DocsSidebar({
 	nav,
+	searchIndex,
 	activeHref,
 }: {
 	nav: NavGroup[];
+	searchIndex: DocSearchEntry[];
 	activeHref?: string;
 }) {
 	const [query, setQuery] = useState("");
 
-	const filtered = useMemo<NavGroup[]>(() => {
-		const q = query.trim().toLowerCase();
-		if (!q) return nav;
-		return nav
-			.map((g) => ({
-				group: g.group,
-				items: g.items.filter(
-					(item) =>
-						item.title.toLowerCase().includes(q) ||
-						(item.description ?? "").toLowerCase().includes(q),
-				),
-			}))
-			.filter((g) => g.items.length > 0);
-	}, [nav, query]);
+	const q = query.trim().toLowerCase();
+
+	const results = useMemo<SearchResult[]>(() => {
+		if (!q) return [];
+		const out: SearchResult[] = [];
+		for (const entry of searchIndex) {
+			const r = buildResult(entry, q);
+			if (r) out.push(r);
+		}
+		return out;
+	}, [searchIndex, q]);
 
 	return (
 		<aside className="docs-sidebar">
@@ -59,44 +133,62 @@ export default function DocsSidebar({
 					/>
 				</div>
 
-				{filtered.map((group, gi) => (
-					<div key={group.group ?? `g-${gi}`} className="docs-sidebar-group">
-						{group.group && (
-							<div className="docs-sidebar-group-title">{group.group}</div>
-						)}
-						<ul className="docs-sidebar-list">
-							{/* Place the docs index link at the top of the first untitled
-							    group so it shares the same row rhythm as the other top-level items. */}
-							{gi === 0 && !group.group && !query.trim() && (
-								<li>
-									<Link
-										href="/docs"
-										className={`docs-sidebar-link${
-											activeHref === "/docs" ? " is-active" : ""
-										}`}
-									>
-										ASSERT Documentation
-									</Link>
-								</li>
-							)}
-							{group.items.map((item) => (
-								<li key={item.href}>
-									<Link
-										href={item.href}
-										className={`docs-sidebar-link${
-											activeHref === item.href ? " is-active" : ""
-										}`}
-									>
-										{item.title}
+				{q ? (
+					results.length > 0 ? (
+						<ul className="docs-search-results">
+							{results.map((r, i) => (
+								<li key={`${r.href}-${i}`}>
+									<Link href={r.href} className="docs-search-result">
+										<span className="docs-search-result-title">
+											{r.group && (
+												<span className="docs-search-result-group">{r.group} · </span>
+											)}
+											{r.title}
+										</span>
+										<span className="docs-search-result-snippet">{r.snippet}</span>
 									</Link>
 								</li>
 							))}
 						</ul>
-					</div>
-				))}
-
-				{filtered.length === 0 && (
-					<p className="docs-search-empty">No matches.</p>
+					) : (
+						<p className="docs-search-empty">No matches.</p>
+					)
+				) : (
+					nav.map((group, gi) => (
+						<div key={group.group ?? `g-${gi}`} className="docs-sidebar-group">
+							{group.group && (
+								<div className="docs-sidebar-group-title">{group.group}</div>
+							)}
+							<ul className="docs-sidebar-list">
+								{/* Place the docs index link at the top of the first untitled
+								    group so it shares the same row rhythm as the other top-level items. */}
+								{gi === 0 && !group.group && (
+									<li>
+										<Link
+											href="/docs"
+											className={`docs-sidebar-link${
+												activeHref === "/docs" ? " is-active" : ""
+											}`}
+										>
+											ASSERT Documentation
+										</Link>
+									</li>
+								)}
+								{group.items.map((item) => (
+									<li key={item.href}>
+										<Link
+											href={item.href}
+											className={`docs-sidebar-link${
+												activeHref === item.href ? " is-active" : ""
+											}`}
+										>
+											{item.title}
+										</Link>
+									</li>
+								))}
+							</ul>
+						</div>
+					))
 				)}
 			</div>
 		</aside>

--- a/website/app/docs/_components/MarkdownContent.tsx
+++ b/website/app/docs/_components/MarkdownContent.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import type { AnchorHTMLAttributes } from "react";
+import {
+	isValidElement,
+	useRef,
+	useState,
+	type AnchorHTMLAttributes,
+	type ComponentPropsWithoutRef,
+	type ReactNode,
+} from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
@@ -122,6 +129,82 @@ type MarkdownContentProps = {
 	relativePath?: string;
 };
 
+function CopyIcon() {
+	return (
+		<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+			<rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+			<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+		</svg>
+	);
+}
+
+function CheckIcon() {
+	return (
+		<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+			<path d="M20 6 9 17l-5-5" />
+		</svg>
+	);
+}
+
+// Languages whose blocks are illustrative (directory trees, plain output) and
+// should not show a copy button.
+const NON_COPYABLE_LANGUAGES = new Set(["text", "plaintext", "txt", "plain"]);
+
+function getCodeLanguage(children: ReactNode): string | null {
+	if (!isValidElement(children)) return null;
+	const className: string = (children.props as { className?: string })?.className ?? "";
+	const match = className.match(/language-([\w-]+)/);
+	return match ? match[1].toLowerCase() : null;
+}
+
+function CodeBlock({ children, ...props }: ComponentPropsWithoutRef<"pre">) {
+	const preRef = useRef<HTMLPreElement>(null);
+	const [copied, setCopied] = useState(false);
+
+	const language = getCodeLanguage(children);
+	const copyable = !language || !NON_COPYABLE_LANGUAGES.has(language);
+
+	async function handleCopy() {
+		const text = preRef.current?.innerText ?? "";
+		try {
+			await navigator.clipboard.writeText(text);
+		} catch {
+			// Fallback for browsers without the async clipboard API
+			const textarea = document.createElement("textarea");
+			textarea.value = text;
+			textarea.style.position = "fixed";
+			textarea.style.opacity = "0";
+			document.body.appendChild(textarea);
+			textarea.select();
+			document.execCommand("copy");
+			document.body.removeChild(textarea);
+		}
+		setCopied(true);
+		window.setTimeout(() => setCopied(false), 2000);
+	}
+
+	if (!copyable) {
+		return <pre {...props}>{children}</pre>;
+	}
+
+	return (
+		<div className="docs-code-block">
+			<button
+				type="button"
+				className="docs-copy-btn"
+				onClick={handleCopy}
+				aria-label="Copy to clipboard"
+				data-tooltip={copied ? "Copied!" : "Copy to Clipboard"}
+			>
+				{copied ? <CheckIcon /> : <CopyIcon />}
+			</button>
+			<pre ref={preRef} {...props}>
+				{children}
+			</pre>
+		</div>
+	);
+}
+
 export default function MarkdownContent({ source, relativePath = "" }: MarkdownContentProps) {
 	const anchorRenderer = ({ href, children, ...rest }: AnchorHTMLAttributes<HTMLAnchorElement>) => {
 		const rewritten = href ? rewriteMarkdownLink(href, relativePath) : null;
@@ -136,7 +219,7 @@ export default function MarkdownContent({ source, relativePath = "" }: MarkdownC
 			<ReactMarkdown
 				remarkPlugins={[remarkGfm]}
 				rehypePlugins={[rehypeRaw, rehypeSlug, rehypeHighlight]}
-				components={{ a: anchorRenderer }}
+				components={{ a: anchorRenderer, pre: CodeBlock }}
 			>
 				{rewriteAssetPaths(source)}
 			</ReactMarkdown>

--- a/website/app/docs/_lib/docs.ts
+++ b/website/app/docs/_lib/docs.ts
@@ -216,6 +216,85 @@ export function getHeadings(content: string): Heading[] {
 	return headings;
 }
 
+export type DocSearchHeading = { id: string; text: string; offset: number };
+export type DocSearchEntry = {
+	href: string;
+	title: string;
+	group: string | null;
+	description: string;
+	text: string; // plain-text body, used for matching and snippets
+	headings: DocSearchHeading[];
+};
+
+// Remove inline markdown so search matches and snippets read as plain prose.
+function stripInline(line: string): string {
+	return line
+		.replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1") // images -> alt text
+		.replace(/\[([^\]]+)\]\([^)]*\)/g, "$1") // links -> link text
+		.replace(/`([^`]+)`/g, "$1") // inline code
+		.replace(/[*_~]+/g, "") // emphasis markers
+		.replace(/^\s{0,3}>\s?/, "") // blockquote marker
+		.replace(/^\s*[-*+]\s+/, "") // unordered list marker
+		.replace(/^\s*\d+\.\s+/, "") // ordered list marker
+		.replace(/^\s*#{1,6}\s+/, "") // stray heading markers
+		.trim();
+}
+
+// Build a flat plain-text body plus heading offsets so the search UI can show a
+// snippet and deep-link to the nearest preceding section heading.
+function buildSearchable(content: string): { text: string; headings: DocSearchHeading[] } {
+	const slugger = new GithubSlugger();
+	const lines = content.split("\n");
+	const headings: DocSearchHeading[] = [];
+	let text = "";
+	let inFence = false;
+	for (const line of lines) {
+		if (/^\s*```/.test(line)) {
+			inFence = !inFence;
+			continue;
+		}
+		if (inFence) {
+			if (line.trim()) text += line + "\n";
+			continue;
+		}
+		const headingMatch = line.match(/^(#{1,6})\s+(.+?)\s*$/);
+		if (headingMatch) {
+			const headingText = headingMatch[2]
+				.replace(/`([^`]+)`/g, "$1")
+				.replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+				.replace(/[*_]+/g, "")
+				.trim();
+			headings.push({ id: slugger.slug(headingText), text: headingText, offset: text.length });
+			text += headingText + "\n";
+			continue;
+		}
+		const stripped = stripInline(line);
+		if (stripped) text += stripped + "\n";
+	}
+	return { text, headings };
+}
+
+/**
+ * Returns a per-page search index containing the page title, group, plain-text
+ * body, and heading offsets. Used by the docs sidebar to search full page
+ * content (not just nav titles) and deep-link to the matching section.
+ */
+export function getDocsSearchIndex(): DocSearchEntry[] {
+	const docs = getAllDocs();
+	return docs.map((doc) => {
+		const { text, headings } = buildSearchable(doc.content);
+		const group = doc.slug.length > 1 ? humanize(doc.slug[0]) : null;
+		return {
+			href: doc.href,
+			title: doc.title,
+			group,
+			description: doc.description ?? "",
+			text,
+			headings,
+		};
+	});
+}
+
 /**
  * For breadcrumbs: returns the group label ("Targets", "Reference", etc.) for a doc,
  * or null for top-level docs.

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -4012,6 +4012,53 @@ h3 {
   color: #6e7681;
 }
 
+/* Content-aware search results */
+.docs-search-results {
+  list-style: none;
+  margin: 8px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.docs-search-result {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 8px 12px;
+  border-radius: 6px;
+  text-decoration: none;
+  transition: background-color 120ms ease;
+}
+.docs-search-result:hover {
+  background: rgba(177, 185, 196, 0.08);
+}
+.docs-search-result-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #e6edf3;
+  line-height: 1.3;
+}
+.docs-search-result-group {
+  color: #8b949e;
+  font-weight: 500;
+}
+.docs-search-result-snippet {
+  font-size: 12px;
+  line-height: 1.45;
+  color: #8b949e;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.docs-search-hl {
+  background: rgba(175, 134, 245, 0.28);
+  color: #fff;
+  border-radius: 3px;
+  padding: 0 1px;
+}
+
 .docs-sidebar-group { display: flex; flex-direction: column; gap: 4px; }
 .docs-sidebar-group-title {
   font-size: 14px;
@@ -4274,6 +4321,67 @@ h3 {
   border-radius: 0;
   font-size: 13px;
   line-height: 1.5;
+}
+
+/* Code block with copy button */
+.docs-code-block {
+  position: relative;
+  margin: 16px 0;
+}
+.docs-code-block pre {
+  margin: 0;
+  padding-right: 52px;
+}
+.docs-copy-btn {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  color: #8b949e;
+  background: rgba(110, 118, 129, 0.12);
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  cursor: pointer;
+  opacity: 1;
+  transition: color 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+}
+.docs-copy-btn:hover {
+  color: #fff;
+  background: rgba(110, 118, 129, 0.25);
+  border-color: #58a6ff;
+}
+.docs-copy-btn:focus-visible {
+  outline: 2px solid #58a6ff;
+  outline-offset: 2px;
+}
+/* Tooltip on hover/focus */
+.docs-copy-btn::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  top: 50%;
+  right: calc(100% + 8px);
+  transform: translateY(-50%);
+  padding: 4px 8px;
+  font-size: 12px;
+  line-height: 1;
+  white-space: nowrap;
+  color: #fff;
+  background: #1c2128;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
+}
+.docs-copy-btn:hover::after,
+.docs-copy-btn:focus-visible::after {
+  opacity: 1;
 }
 .docs-prose table {
   display: block;


### PR DESCRIPTION
Docs UX enhancements:
- Copy button on every code block (always visible) with a 'Copy to Clipboard' tooltip and a 'Copied!' confirmation. Illustrative blocks (text/plaintext directory trees and plain output) are skipped.
- Sidebar search now searches doc *content*, not just nav titles, with highlighted snippets and deep-links to the nearest section heading.

Integrates cleanly with the existing markdown link-rewriting in MarkdownContent (a + pre renderers coexist).

## Summary

Adds copy-to-clipboard buttons on docs code blocks and upgrades the sidebar search to search doc content (not just nav titles).

## Motivation / linked issue

Improves docs usability: readers can copy commands in one click, and search now finds text anywhere in the docs with deep-links to the right section.

## Changes

- **Copy button** on every code block (always visible) with a "Copy to Clipboard" tooltip and a "Copied!" confirmation. Illustrative blocks (directory trees / plain `text` output) are intentionally skipped.
- **Content search** in the sidebar: searches full doc content, shows highlighted snippets, and deep-links to the nearest section heading.
- Both features integrate with the existing markdown link-rewriting (the `a` and `pre` renderers now coexist in `MarkdownContent`).

## Testing

- `npx next build` passes (26 static pages generated).
- Manual check at `localhost:3001/ASSERT/docs/getting-started/`: copy buttons render on command blocks, the illustrative artifacts-path block correctly has no button, and content search returns highlighted results with section deep-links.

## Checklist

- [x] Tests pass locally (`next build` / manual docs checks).
- [x] Docs updated if behavior or public API changed. <!-- N/A — docs site UX only -->
- [x] No secrets, credentials, or customer data committed.
- [x] No breaking change, or a `CHANGELOG.md` entry is included.