### PR TITLE
fix(docs): remove internal maintainer agent docs from public site

### DIFF
--- a/website/app/docs/_lib/docs.ts
+++ b/website/app/docs/_lib/docs.ts
@@ -39,6 +39,19 @@ function isMarkdownFile(filename: string): boolean {
 // Files (relative path, lowercased) that should NOT appear as their own doc
 // page. README is rendered as the docs index instead.
 const EXCLUDED_FILES = new Set(["readme.md", "readme.mdx"]);
+const EXCLUDED_PATH_PREFIXES = ["agents/"];
+
+function normalizeRelativePath(relativePath: string): string {
+	return relativePath.split(path.sep).join("/").toLowerCase();
+}
+
+function isExcludedDocPath(relativePath: string): boolean {
+	const normalized = normalizeRelativePath(relativePath);
+	return (
+		EXCLUDED_FILES.has(normalized) ||
+		EXCLUDED_PATH_PREFIXES.some((prefix) => normalized.startsWith(prefix))
+	);
+}
 
 function walk(dir: string, base: string = dir): string[] {
 	if (!fs.existsSync(dir)) return [];
@@ -50,7 +63,7 @@ function walk(dir: string, base: string = dir): string[] {
 			files.push(...walk(full, base));
 		} else if (entry.isFile() && isMarkdownFile(entry.name)) {
 			const rel = path.relative(base, full);
-			if (EXCLUDED_FILES.has(rel.toLowerCase())) continue;
+			if (isExcludedDocPath(rel)) continue;
 			files.push(rel);
 		}
 	}


### PR DESCRIPTION
## What this fixes

The public docs site (`responsibleai.github.io/ASSERT`) was publishing an **"Agents"** nav section — internal maintainer-assist tooling docs (`ASSERT Maintainer Assist System`, `Designer Inbox`, `Dev-maintainer Inbox`, `Agent Run Log`). These are maintainer-operations docs, not customer product, and should not appear on the customer-facing site.

## The change

Single, surgical fix in the docs-site loader (`website/app/docs/_lib/docs.ts`): extend the existing exclusion mechanism with an `agents/` path-prefix skip. Because both the sidebar/nav and the search index derive from the same `getAllDocs()` walk, this removes `docs/agents/**` from **routes, nav, and search** in one place.

- The maintainer docs **remain in the repo** (the repo is private; the leak surface was the rendered public site). Maintainers can still read/fork the pattern.
- No files moved or deleted, so `AGENTS.md` links into `docs/agents/...` stay valid.

## Verification

Built locally (`npm ci && npm run build`):
- `/docs/agents` route **gone**; "Maintainer Assist / Designer Inbox / Dev-maintainer / Agent Run Log / docs/agents" **absent** from the static export.
- Getting Started / Concepts / CLI / Config / Guides / Targets nav **all intact**.

## Reviewers

cc @sooyeonni @minthigpen — `website/` code owners. Flagging as **priority** (live customer-facing leak).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
