### PR TITLE
feat(azure-auth): native AAD support for azure_ai/* targets (Foundry hosted agents)

### DIFF
--- a/assert_ai/core/azure_auth.py
+++ b/assert_ai/core/azure_auth.py
@@ -38,6 +38,12 @@ Mode = Literal["key", "aad", "aad-fallback"]
 #: Standard scope for Azure OpenAI / Cognitive Services data-plane tokens.
 AZURE_OPENAI_SCOPE = "https://cognitiveservices.azure.com/.default"
 
+#: Scope for Azure AI Foundry data-plane tokens (Foundry projects, hosted
+#: agents, and other ``azure_ai/*`` LiteLLM routes). Distinct from the
+#: Cognitive Services scope above because the Foundry control plane sits
+#: behind a different audience.
+AZURE_FOUNDRY_SCOPE = "https://ai.azure.com/.default"
+
 #: Env var users set to force AAD even when ``AZURE_API_KEY`` is present.
 ENV_USE_AAD_FLAG = "ASSERT_AZURE_USE_AAD"
 
@@ -63,10 +69,17 @@ _FRIENDLY_CRED_LABELS: Mapping[str, str] = {
 
 # DefaultAzureCredential is expensive to construct repeatedly and
 # azure-identity already handles its own in-process token caching, so
-# the provider callable is built lazily once and reused for the
-# process lifetime.
-_CACHED_PROVIDER: Callable[[], str] | None = None
-_CACHE_POPULATED = False
+# provider callables are built lazily and reused for the process
+# lifetime. We key the cache on scope because Azure OpenAI and Azure AI
+# Foundry data planes accept tokens for different audiences; the
+# underlying ``DefaultAzureCredential`` is reused across scopes.
+_PROVIDER_CACHE: dict[str, Callable[[], str] | None] = {}
+_CACHED_CREDENTIAL: object | None = None
+#: True after the first import attempt for ``azure.identity`` has
+#: completed, regardless of whether it succeeded. Lets us short-circuit
+#: repeat imports without re-introducing per-scope ImportError costs.
+_IDENTITY_IMPORT_ATTEMPTED = False
+_IDENTITY_AVAILABLE = False
 
 
 def _is_truthy(value: str | None) -> bool:
@@ -90,20 +103,37 @@ def resolve_azure_auth_mode(env: Mapping[str, str] | None = None) -> Mode:
     return "aad-fallback"
 
 
-def get_azure_token_provider() -> Callable[[], str] | None:
-    """Return a cached bearer-token callable for Azure OpenAI, or ``None``.
+def get_azure_token_provider(
+    scope: str = AZURE_OPENAI_SCOPE,
+) -> Callable[[], str] | None:
+    """Return a cached bearer-token callable for ``scope``, or ``None``.
 
     Returns ``None`` (without raising) when ``azure-identity`` is not
     installed. Callers should treat ``None`` as "AAD requested but
     optional dependency missing" and surface an actionable install hint.
 
+    The default scope (:data:`AZURE_OPENAI_SCOPE`) covers ``azure/*``
+    LiteLLM models. Pass :data:`AZURE_FOUNDRY_SCOPE` for ``azure_ai/*``
+    routes (Foundry hosted agents, embeddings, chat). Each scope gets
+    its own cached provider; all providers share a single
+    ``DefaultAzureCredential`` instance so adding a second scope does
+    not pay for a second credential-chain probe.
+
     Honors ``AZURE_CLIENT_ID`` natively via ``DefaultAzureCredential``
     so users can select a specific user-assigned managed identity
     without passing anything to ASSERT.
     """
-    global _CACHED_PROVIDER, _CACHE_POPULATED
-    if _CACHE_POPULATED:
-        return _CACHED_PROVIDER
+    global _CACHED_CREDENTIAL, _IDENTITY_IMPORT_ATTEMPTED, _IDENTITY_AVAILABLE
+
+    if scope in _PROVIDER_CACHE:
+        return _PROVIDER_CACHE[scope]
+
+    if _IDENTITY_IMPORT_ATTEMPTED and not _IDENTITY_AVAILABLE:
+        # A prior call already discovered the dep is missing; don't
+        # re-pay the ImportError or re-log the install hint for every
+        # additional scope a caller asks about.
+        _PROVIDER_CACHE[scope] = None
+        return None
 
     try:
         from azure.identity import (  # type: ignore[import-not-found]
@@ -115,19 +145,25 @@ def get_azure_token_provider() -> Callable[[], str] | None:
             "azure-identity is not installed; AAD auth unavailable. "
             "Install with: pip install 'assert-ai[azure-aad]'"
         )
-        _CACHE_POPULATED = True
+        _IDENTITY_IMPORT_ATTEMPTED = True
+        _IDENTITY_AVAILABLE = False
+        _PROVIDER_CACHE[scope] = None
         return None
 
-    # Skip the interactive flows so CI / non-interactive shells fail
-    # fast instead of hanging on a browser prompt.
-    credential = DefaultAzureCredential(
-        exclude_interactive_browser_credential=True,
-        exclude_visual_studio_code_credential=True,
-    )
-    raw_provider = get_bearer_token_provider(credential, AZURE_OPENAI_SCOPE)
-    _CACHED_PROVIDER = _wrap_provider_with_provenance_log(credential, raw_provider)
-    _CACHE_POPULATED = True
-    return _CACHED_PROVIDER
+    _IDENTITY_IMPORT_ATTEMPTED = True
+    _IDENTITY_AVAILABLE = True
+
+    if _CACHED_CREDENTIAL is None:
+        # Skip the interactive flows so CI / non-interactive shells fail
+        # fast instead of hanging on a browser prompt.
+        _CACHED_CREDENTIAL = DefaultAzureCredential(
+            exclude_interactive_browser_credential=True,
+            exclude_visual_studio_code_credential=True,
+        )
+    raw_provider = get_bearer_token_provider(_CACHED_CREDENTIAL, scope)
+    provider = _wrap_provider_with_provenance_log(_CACHED_CREDENTIAL, raw_provider)
+    _PROVIDER_CACHE[scope] = provider
+    return provider
 
 
 def _wrap_provider_with_provenance_log(
@@ -262,10 +298,12 @@ def log_resolved_azure_auth_mode() -> None:
 
 
 def _reset_cache_for_tests() -> None:
-    """Clear the cached provider — for tests only."""
-    global _CACHED_PROVIDER, _CACHE_POPULATED
-    _CACHED_PROVIDER = None
-    _CACHE_POPULATED = False
+    """Clear the cached providers and credential — for tests only."""
+    global _CACHED_CREDENTIAL, _IDENTITY_IMPORT_ATTEMPTED, _IDENTITY_AVAILABLE
+    _PROVIDER_CACHE.clear()
+    _CACHED_CREDENTIAL = None
+    _IDENTITY_IMPORT_ATTEMPTED = False
+    _IDENTITY_AVAILABLE = False
 
 
 def _reset_auth_mode_cache_for_tests() -> None:

--- a/assert_ai/core/azure_auth.py
+++ b/assert_ai/core/azure_auth.py
@@ -82,23 +82,49 @@ _IDENTITY_IMPORT_ATTEMPTED = False
 _IDENTITY_AVAILABLE = False
 
 
+#: API-key env var per Azure model family. The Cognitive Services /
+#: Azure OpenAI resource and the Azure AI Foundry project are separate
+#: resources with separate keys, so an ``AZURE_API_KEY`` in the env is
+#: useless for a ``azure_ai/*`` call (it would be sent to the wrong
+#: endpoint and rejected). Family-aware mode resolution looks at the
+#: matching env var only.
+_FAMILY_KEY_ENV: Mapping[str, str] = {
+    "azure": "AZURE_API_KEY",
+    "azure_ai": "AZURE_AI_API_KEY",
+}
+
+
 def _is_truthy(value: str | None) -> bool:
     return value is not None and value.strip().lower() in _TRUTHY
 
 
-def resolve_azure_auth_mode(env: Mapping[str, str] | None = None) -> Mode:
-    """Decide which auth mode applies to Azure OpenAI calls.
+def resolve_azure_auth_mode(
+    env: Mapping[str, str] | None = None,
+    family: str = "azure",
+) -> Mode:
+    """Decide which auth mode applies to a given Azure model family.
 
     Pure function over the environment; safe to call repeatedly. The
     caller is responsible for checking whether the in-flight request is
-    actually an ``azure/*`` model before acting on the returned mode.
+    actually an Azure model before acting on the returned mode.
+
+    ``family`` selects which API-key env var counts as a static-key
+    auth signal:
+
+    - ``azure``: ``AZURE_API_KEY`` (Azure OpenAI / Cognitive Services).
+    - ``azure_ai``: ``AZURE_AI_API_KEY`` (Azure AI Foundry data plane).
+
+    The ``ASSERT_AZURE_USE_AAD`` flag still forces AAD across both
+    families. Defaults to ``family='azure'`` so all existing call sites
+    behave identically.
 
     Defaults to ``os.environ`` when no override is provided.
     """
     env = env if env is not None else os.environ
     if _is_truthy(env.get(ENV_USE_AAD_FLAG)):
         return "aad"
-    if (env.get("AZURE_API_KEY") or "").strip():
+    key_var = _FAMILY_KEY_ENV.get(family, "AZURE_API_KEY")
+    if (env.get(key_var) or "").strip():
         return "key"
     return "aad-fallback"
 

--- a/assert_ai/core/azure_auth.py
+++ b/assert_ai/core/azure_auth.py
@@ -248,11 +248,19 @@ def _wrap_provider_with_provenance_log(
 _AZURE_AUTH_MODE: Mode | None = None
 
 # True when the user's environment selects AAD (explicit or fallback)
-# but the ``azure-identity`` package is not importable. Used by
+# for the ``azure`` family (Azure OpenAI, AZURE_OPENAI_SCOPE) but the
+# ``azure-identity`` package is not importable. Used by
 # ``model_client._classify_llm_error`` to swap the RBAC hint for an
-# install hint. Updated alongside ``_AZURE_AUTH_MODE`` whenever the
-# cache is refreshed.
-_AZURE_AAD_DEP_MISSING: bool = False
+# install hint on ``azure/*`` calls. Updated alongside
+# ``_AZURE_AUTH_MODE`` whenever the cache is refreshed.
+#
+# The dep-availability check is family-agnostic in practice (the
+# import either works or it does not), so the install-hint branch in
+# the classifier reuses this flag for ``azure_ai/*`` calls too. The
+# name is scoped to ``OPENAI`` to make it explicit that the
+# ``_AZURE_AUTH_MODE`` half of the pair is azure-family only;
+# ``azure_ai/*`` re-resolves its own mode per request.
+_AZURE_OPENAI_AAD_DEP_MISSING: bool = False
 
 
 def refresh_azure_auth_mode(force: bool = False) -> Mode:
@@ -265,11 +273,11 @@ def refresh_azure_auth_mode(force: bool = False) -> Mode:
 
     Returns the resolved mode for the caller's convenience.
     """
-    global _AZURE_AUTH_MODE, _AZURE_AAD_DEP_MISSING
+    global _AZURE_AUTH_MODE, _AZURE_OPENAI_AAD_DEP_MISSING
     if _AZURE_AUTH_MODE is not None and not force:
         return _AZURE_AUTH_MODE
     _AZURE_AUTH_MODE = resolve_azure_auth_mode()
-    _AZURE_AAD_DEP_MISSING = (
+    _AZURE_OPENAI_AAD_DEP_MISSING = (
         _AZURE_AUTH_MODE in ("aad", "aad-fallback")
         and get_azure_token_provider() is None
     )
@@ -300,7 +308,7 @@ def log_resolved_azure_auth_mode() -> None:
             "Azure OpenAI auth mode: AAD (forced via %s).",
             ENV_USE_AAD_FLAG,
         )
-        if _AZURE_AAD_DEP_MISSING:
+        if _AZURE_OPENAI_AAD_DEP_MISSING:
             log.warning(
                 "%s is set but azure-identity is not installed; the next "
                 "azure/* request will fail. Install with: "
@@ -308,7 +316,7 @@ def log_resolved_azure_auth_mode() -> None:
                 ENV_USE_AAD_FLAG,
             )
     elif mode == "aad-fallback":
-        if _AZURE_AAD_DEP_MISSING:
+        if _AZURE_OPENAI_AAD_DEP_MISSING:
             log.info(
                 "Azure OpenAI auth mode: AAD fallback (no AZURE_API_KEY set; "
                 "azure-identity not installed — install with: "
@@ -335,12 +343,12 @@ def _reset_cache_for_tests() -> None:
 def _reset_auth_mode_cache_for_tests() -> None:
     """Clear the cached auth-mode resolution — for tests only.
 
-    Resets both ``_AZURE_AUTH_MODE`` and ``_AZURE_AAD_DEP_MISSING`` to
-    their pre-resolution baseline so the next ``refresh_azure_auth_mode``
+    Resets both ``_AZURE_AUTH_MODE`` and ``_AZURE_OPENAI_AAD_DEP_MISSING``
+    to their pre-resolution baseline so the next ``refresh_azure_auth_mode``
     or ``_get_azure_auth_mode`` call resolves against the current env.
     Centralises the field list so future additions to the auth-mode
     cache do not require touching every test that needs a clean slate.
     """
-    global _AZURE_AUTH_MODE, _AZURE_AAD_DEP_MISSING
+    global _AZURE_AUTH_MODE, _AZURE_OPENAI_AAD_DEP_MISSING
     _AZURE_AUTH_MODE = None
-    _AZURE_AAD_DEP_MISSING = False
+    _AZURE_OPENAI_AAD_DEP_MISSING = False

--- a/assert_ai/core/azure_auth.py
+++ b/assert_ai/core/azure_auth.py
@@ -202,7 +202,7 @@ def _wrap_provider_with_provenance_log(
     ``DefaultAzureCredential`` extends) sets ``_successful_credential``
     after a successful ``get_token``. We read it once after the first
     successful token to give users a single, friendly provenance line
-    (``"Azure OpenAI auth: AAD token acquired via AzureCliCredential
+    (``"Azure auth: AAD token acquired via AzureCliCredential
     (az login)."``) without flooding logs with the SDK's per-step
     chain trace.
 
@@ -221,7 +221,7 @@ def _wrap_provider_with_provenance_log(
             label = _FRIENDLY_CRED_LABELS.get(cls_name or "", "credential chain")
             if cls_name:
                 log.info(
-                    "Azure OpenAI auth: AAD token acquired via %s (%s).",
+                    "Azure auth: AAD token acquired via %s (%s).",
                     cls_name,
                     label,
                 )
@@ -229,7 +229,7 @@ def _wrap_provider_with_provenance_log(
                 # Token came back but we couldn't identify the inner
                 # credential — still tell the user AAD succeeded so
                 # they're not left guessing.
-                log.info("Azure OpenAI auth: AAD token acquired.")
+                log.info("Azure auth: AAD token acquired.")
             logged["done"] = True
         return token
 
@@ -305,30 +305,30 @@ def log_resolved_azure_auth_mode() -> None:
     mode = _get_azure_auth_mode()
     if mode == "aad":
         log.info(
-            "Azure OpenAI auth mode: AAD (forced via %s).",
+            "Azure auth mode: AAD (forced via %s).",
             ENV_USE_AAD_FLAG,
         )
         if _AZURE_OPENAI_AAD_DEP_MISSING:
             log.warning(
                 "%s is set but azure-identity is not installed; the next "
-                "azure/* request will fail. Install with: "
+                "azure/* or azure_ai/* request will fail. Install with: "
                 "pip install 'assert-ai[azure-aad]'",
                 ENV_USE_AAD_FLAG,
             )
     elif mode == "aad-fallback":
         if _AZURE_OPENAI_AAD_DEP_MISSING:
             log.info(
-                "Azure OpenAI auth mode: AAD fallback (no AZURE_API_KEY set; "
+                "Azure auth mode: AAD fallback (no AZURE_API_KEY set; "
                 "azure-identity not installed — install with: "
                 "pip install 'assert-ai[azure-aad]').",
             )
         else:
             log.info(
-                "Azure OpenAI auth mode: AAD fallback (no AZURE_API_KEY set; "
+                "Azure auth mode: AAD fallback (no AZURE_API_KEY set; "
                 "using DefaultAzureCredential).",
             )
     else:
-        log.info("Azure OpenAI auth mode: API key (AZURE_API_KEY).")
+        log.info("Azure auth mode: API key (AZURE_API_KEY).")
 
 
 def _reset_cache_for_tests() -> None:

--- a/assert_ai/core/config_model.py
+++ b/assert_ai/core/config_model.py
@@ -147,6 +147,26 @@ class TargetConfig:
             raise ValueError("endpoint target must not define target.tools")
         if self.tools is not None and not has_model:
             raise ValueError("target.tools requires target.model")
+        # azure_ai/agents/<id> routes to a Foundry-hosted agent that owns
+        # its own tools and instructions server-side. Accepting
+        # target.tools or target.system_prompt here would silently mislead
+        # users into thinking those fields apply when they do not.
+        if has_model:
+            assert isinstance(self.model, ModelConfig)
+            model_name = self.model.name.strip().lower()
+            if model_name.startswith("azure_ai/agents/"):
+                if self.tools is not None:
+                    raise ValueError(
+                        "target.tools is not supported when target.model is "
+                        "'azure_ai/agents/<id>'; the hosted Foundry agent "
+                        "owns its tools server-side."
+                    )
+                if self.system_prompt is not None:
+                    raise ValueError(
+                        "target.system_prompt is not supported when "
+                        "target.model is 'azure_ai/agents/<id>'; the hosted "
+                        "Foundry agent owns its instructions server-side."
+                    )
 
     @property
     def is_external(self) -> bool:

--- a/assert_ai/core/model_client.py
+++ b/assert_ai/core/model_client.py
@@ -935,23 +935,49 @@ def _classify_llm_error(exc: Exception, model: str | None = None) -> Exception:
     from APIStatusError → APIError on some providers).
     """
     litellm = _get_litellm_module()
-    is_azure_model = bool(model) and model.startswith("azure/")
+    is_azure_family = bool(model) and _model_family(model) in {"azure", "azure_ai"}
+    # The cached azure-family mode is driven by AZURE_API_KEY; azure_ai
+    # needs its own per-family resolution against AZURE_AI_API_KEY for
+    # the hint-vs-no-hint decision to be accurate.
+    if is_azure_family and _model_family(model) == "azure_ai":
+        azure_mode = azure_auth.resolve_azure_auth_mode(family="azure_ai")
+    elif is_azure_family:
+        azure_mode = azure_auth._get_azure_auth_mode()
+    else:
+        azure_mode = "key"  # any non-aad value; the gate below filters azure-only paths
     # 401 — bad credentials
     if isinstance(exc, litellm.AuthenticationError):
         msg = f"Authentication failed: {exc}"
         # Azure-specific RBAC / install hints only apply when the failing
-        # call targeted an ``azure/*`` model. Without this gate, a user
+        # call targeted an Azure family (``azure/*`` for Azure OpenAI or
+        # ``azure_ai/*`` for Azure AI Foundry). Without this gate, a user
         # running an ``openai/*`` model in the same process while
-        # ``ASSERT_AZURE_USE_AAD=1`` is set would see "verify the
-        # 'Cognitive Services OpenAI User' role" on a vanilla OpenAI 401,
-        # which is misleading.
-        if is_azure_model and azure_auth._get_azure_auth_mode() in {"aad", "aad-fallback"}:
-            if azure_auth._AZURE_AAD_DEP_MISSING:
+        # ``ASSERT_AZURE_USE_AAD=1`` is set would see Azure-only role
+        # text on a vanilla OpenAI 401, which is misleading.
+        if is_azure_family and azure_mode in {"aad", "aad-fallback"}:
+            if azure_auth._AZURE_OPENAI_AAD_DEP_MISSING:
+                if _model_family(model) == "azure_ai":
+                    msg += (
+                        "\nNo AZURE_AI_API_KEY is set and azure-identity is "
+                        "not installed. Either export AZURE_AI_API_KEY with "
+                        "a manually-minted token (`az account "
+                        "get-access-token --resource https://ai.azure.com`), "
+                        "or install Azure AD support with "
+                        "`pip install 'assert-ai[azure-aad]'`."
+                    )
+                else:
+                    msg += (
+                        "\nNo AZURE_API_KEY is set and azure-identity is not "
+                        "installed. Either export AZURE_API_KEY, or install "
+                        "Azure AD support with "
+                        "`pip install 'assert-ai[azure-aad]'`."
+                    )
+            elif _model_family(model) == "azure_ai":
                 msg += (
-                    "\nNo AZURE_API_KEY is set and azure-identity is not "
-                    "installed. Either export AZURE_API_KEY, or install "
-                    "Azure AD support with "
-                    "`pip install 'assert-ai[azure-aad]'`."
+                    "\nAzure AD auth is active. Verify the caller identity "
+                    "has the 'Azure AI User' role on the Azure AI Foundry "
+                    "project, or set AZURE_AI_API_KEY to a manually-minted "
+                    "bearer token to fall back to static-token auth."
                 )
             else:
                 msg += (
@@ -1066,6 +1092,39 @@ def _classify_llm_error(exc: Exception, model: str | None = None) -> Exception:
     # InternalServerError, ServiceUnavailableError, and Timeout
     # (all inherit from APIError or APIConnectionError).
     if isinstance(exc, (litellm.APIError, litellm.APIConnectionError)):
+        # Two LiteLLM-side validation errors for the azure_ai/agents
+        # provider come through as APIConnectionError because the
+        # request never leaves the process. They are not transient and
+        # should not be retried; surface them as LLMAuthError /
+        # LLMInputError with actionable hints so users know what to fix.
+        if is_azure_family and _model_family(model) == "azure_ai":
+            exc_text = str(exc)
+            if "api_key (Azure AD token) is required" in exc_text:
+                hint = (
+                    "Azure AI Foundry rejected the call because no bearer "
+                    "token was supplied. Install Azure AD support with "
+                    "`pip install 'assert-ai[azure-aad]'` and run "
+                    "`az login`, or export AZURE_AI_API_KEY with a "
+                    "manually-minted token (`az account get-access-token "
+                    "--resource https://ai.azure.com`)."
+                )
+                err = LLMAuthError(f"Authentication failed: {exc}\n{hint}")
+                err.__cause__ = exc
+                return err
+            # LiteLLM has two raise sites for the missing-api_base check
+            # ("api_base is required for Azure AI Agents..." in the
+            # provider transformation, and "Azure AI Agents requests
+            # require an api_base..." in main.py). Both mention the
+            # AZURE_AI_API_BASE env var, so anchor on that stable token.
+            if "AZURE_AI_API_BASE" in exc_text:
+                hint = (
+                    "Set AZURE_AI_API_BASE to your Foundry project endpoint "
+                    "(e.g. https://<resource>.services.ai.azure.com/api/"
+                    "projects/<project>) before running the eval."
+                )
+                err = LLMInputError(f"Bad request: {exc}\n{hint}")
+                err.__cause__ = exc
+                return err
         err = LLMProviderError(f"Provider error: {exc}")
         err.__cause__ = exc
         return err

--- a/assert_ai/core/model_client.py
+++ b/assert_ai/core/model_client.py
@@ -12,11 +12,12 @@ Import side effects (intentional for the ``assert-ai`` CLI):
 * ``azure_auth.refresh_azure_auth_mode()`` reads ``ASSERT_AZURE_USE_AAD`` and
   ``AZURE_API_KEY`` lazily on first access (or eagerly when an
   entrypoint calls it with ``force=True`` after ``load_dotenv``) to
-  pick the Azure OpenAI auth mode for the process. When the resolved
-  mode is AAD, it pre-warms the ``azure-identity`` credential so
-  first-request latency stays low and missing-dep errors surface
-  early. The mode is read again per-request only as a cheap
-  module-global lookup, never re-derived.
+  pick the Azure auth mode for the process (applies to both ``azure/*``
+  and ``azure_ai/*`` LiteLLM routes). When the resolved mode is AAD,
+  it pre-warms the ``azure-identity`` credential so first-request
+  latency stays low and missing-dep errors surface early. The mode is
+  read again per-request only as a cheap module-global lookup, never
+  re-derived.
 * The first activation of the Chat Completions fallback (either via
   ``ASSERT_PREFER_CHAT_COMPLETIONS=1`` at import time, an explicit
   API preference, or a reactive recovery from a region error) calls

--- a/assert_ai/core/model_client.py
+++ b/assert_ai/core/model_client.py
@@ -359,11 +359,40 @@ def _model_family(model: str) -> str:
     return normalized
 
 
+def _aad_scope_for_model(model: str) -> str | None:
+    """Return the AAD scope to use for ``model``, or ``None`` for non-Azure families.
+
+    ``azure/*`` (Azure OpenAI) uses the Cognitive Services data-plane scope.
+    ``azure_ai/*`` (Azure AI Foundry: hosted agents, embeddings, chat) uses
+    the Azure AI Foundry data-plane scope. Other families are not Azure and
+    return ``None`` so injection is a no-op.
+    """
+    family = _model_family(model)
+    if family == "azure":
+        return azure_auth.AZURE_OPENAI_SCOPE
+    if family == "azure_ai":
+        return azure_auth.AZURE_FOUNDRY_SCOPE
+    return None
+
+
 def _maybe_inject_azure_aad_token(model: str, payload: dict[str, Any]) -> None:
-    """Attach an Azure AD token provider to ``azure/*`` payloads when AAD is active.
+    """Attach Azure AD credentials to ``azure/*`` and ``azure_ai/*`` payloads.
 
     No-op for non-Azure models and for the ``key`` auth mode, so existing
     API-key users are completely unaffected.
+
+    For ``azure/*`` (Azure OpenAI): injects ``azure_ad_token_provider``,
+    a callable LiteLLM invokes per request so the underlying
+    ``DefaultAzureCredential`` cache handles refresh.
+
+    For ``azure_ai/*`` (Azure AI Foundry): the LiteLLM ``azure_ai/agents``
+    provider only accepts a static ``api_key`` string (it sets
+    ``Authorization: Bearer <api_key>`` on outbound requests), so we call
+    the provider once per request to mint a fresh token. The provider is
+    cached per scope; ``DefaultAzureCredential`` caches the token itself,
+    so the per-request call resolves from memory until the token nears
+    expiry. Same Service Principal env vars and ``az login`` flow as the
+    ``azure/*`` path — they flow through the same chain credential.
 
     When the resolved mode is ``aad`` (explicit opt-in via
     ``ASSERT_AZURE_USE_AAD=1``) but ``azure-identity`` is not installed,
@@ -376,14 +405,24 @@ def _maybe_inject_azure_aad_token(model: str, payload: dict[str, Any]) -> None:
     install hint is then appended in :func:`_classify_llm_error`.
 
     Callers must invoke this *before* applying ``extra_kwargs`` so that
-    any explicit user-supplied ``azure_ad_token_provider`` still wins.
+    any explicit user-supplied ``azure_ad_token_provider`` / ``api_key``
+    still wins.
     """
-    if _model_family(model) != "azure":
+    scope = _aad_scope_for_model(model)
+    if scope is None:
         return
-    mode = azure_auth._get_azure_auth_mode()
+    # The cached ``_AZURE_AUTH_MODE`` only tracks the azure/* family
+    # (driven by AZURE_API_KEY). For azure_ai/* (Foundry agents) the
+    # relevant static-key env var is AZURE_AI_API_KEY, so we re-resolve
+    # per request with the right family. Cheap: three env reads.
+    family = _model_family(model)
+    if family == "azure_ai":
+        mode = azure_auth.resolve_azure_auth_mode(family="azure_ai")
+    else:
+        mode = azure_auth._get_azure_auth_mode()
     if mode == "key":
         return
-    provider = azure_auth.get_azure_token_provider()
+    provider = azure_auth.get_azure_token_provider(scope)
     if provider is None:
         if mode == "aad":
             raise LLMAuthError(
@@ -395,7 +434,11 @@ def _maybe_inject_azure_aad_token(model: str, payload: dict[str, Any]) -> None:
         # aad-fallback path: silently skip — LiteLLM's own auth error
         # will be augmented with an install hint by _classify_llm_error.
         return
-    payload["azure_ad_token_provider"] = provider
+    if scope == azure_auth.AZURE_FOUNDRY_SCOPE:
+        # azure_ai/* providers want a static bearer string, not a callable.
+        payload["api_key"] = provider()
+    else:
+        payload["azure_ad_token_provider"] = provider
 
 
 def _supports_web_search_preview(model: str) -> bool:

--- a/docs/config/schema.md
+++ b/docs/config/schema.md
@@ -173,7 +173,7 @@ pipeline:
 Accepted keys:
 
 - `target` — mapping. Required when `inference` is enabled.
-  - `model` — model config. Use for the [Prompt Agent target](../targets/model-and-tools.md) (hosted model + system prompt + optional tools, runtime owns the loop).
+  - `model` — model config. Use for the [Prompt Agent target](../targets/model-and-tools.md) (hosted model + system prompt + optional tools, runtime owns the loop). Also accepts `azure_ai/agents/<AGENT_ID>` to evaluate a hosted Azure AI Foundry agent; requires the `AZURE_AI_API_BASE` env var (Foundry project endpoint) and the same Azure auth setup as `azure/*` models. `target.tools` and `target.system_prompt` are not allowed in this mode since the hosted agent owns its tools and instructions server-side.
   - `callable` — Python callable reference in `package.module:function` form. Use for any agent or multi-agent system with a Python entrypoint, including local apps, framework agents, and custom orchestration.
   - `endpoint` — HTTP endpoint URL. Use only when a Python callable is not available.
   - `connector` — external connector target (supported by parser/runtime, not recommended for customer-preview onboarding).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -168,6 +168,12 @@ Auth resolution at process start follows a single precedence rule:
 `AZURE_API_BASE` is still required so LiteLLM knows which Azure OpenAI endpoint
 to call.
 
+The same auth mode also applies to `azure_ai/*` LiteLLM routes, including
+hosted Azure AI Foundry agents (`azure_ai/agents/<AGENT_ID>`). Those routes
+need `AZURE_AI_API_BASE` set to the Foundry project endpoint instead of
+`AZURE_API_BASE`. No extra setup beyond `pip install -e ".[azure-aad]"` and
+`az login` (or Service Principal env vars).
+
 ### Local development with `az login`
 
 ```bash

--- a/tests/test_acs_language_model.py
+++ b/tests/test_acs_language_model.py
@@ -131,7 +131,7 @@ def _patch_aad(monkeypatch, *, mode: str, provider) -> None:
     from assert_ai.core import azure_auth
 
     monkeypatch.setattr(azure_auth, "_AZURE_AUTH_MODE", mode)
-    monkeypatch.setattr(azure_auth, "get_azure_token_provider", lambda: provider)
+    monkeypatch.setattr(azure_auth, "get_azure_token_provider", lambda *a, **kw: provider)
 
 
 def test_assert_language_model_injects_aad_provider_for_azure_in_aad_mode(monkeypatch) -> None:

--- a/tests/test_azure_auth.py
+++ b/tests/test_azure_auth.py
@@ -54,6 +54,48 @@ class ResolveAzureAuthModeTest(unittest.TestCase):
         ):
             self.assertEqual(azure_auth.resolve_azure_auth_mode(), "aad")
 
+    # ── family-aware resolution ────────────────────────────────
+
+    def test_azure_ai_family_reads_azure_ai_api_key_not_azure_api_key(self) -> None:
+        """An AZURE_API_KEY in the env is for an Azure OpenAI resource and
+        is the wrong credential for an Azure AI Foundry endpoint. The
+        family-aware resolver must ignore it for the azure_ai family and
+        return aad-fallback so AAD injection kicks in.
+        """
+        env = {"AZURE_API_KEY": "sk-azure-openai-key"}
+        self.assertEqual(
+            azure_auth.resolve_azure_auth_mode(env, family="azure_ai"),
+            "aad-fallback",
+        )
+
+    def test_azure_ai_family_returns_key_when_azure_ai_api_key_set(self) -> None:
+        env = {"AZURE_AI_API_KEY": "user-supplied-foundry-token"}
+        self.assertEqual(
+            azure_auth.resolve_azure_auth_mode(env, family="azure_ai"),
+            "key",
+        )
+
+    def test_flag_wins_over_azure_ai_api_key(self) -> None:
+        env = {
+            "ASSERT_AZURE_USE_AAD": "1",
+            "AZURE_AI_API_KEY": "ignored-when-flag-set",
+        }
+        self.assertEqual(
+            azure_auth.resolve_azure_auth_mode(env, family="azure_ai"),
+            "aad",
+        )
+
+    def test_default_family_is_azure(self) -> None:
+        """Existing zero-arg call sites (boot log, cache refresh) keep
+        seeing the azure family (AZURE_API_KEY) behaviour unchanged."""
+        env = {"AZURE_API_KEY": "sk-azure-openai-key"}
+        self.assertEqual(azure_auth.resolve_azure_auth_mode(env), "key")
+        # And azure_ai/* is unaffected by AZURE_API_KEY.
+        self.assertEqual(
+            azure_auth.resolve_azure_auth_mode(env, family="azure_ai"),
+            "aad-fallback",
+        )
+
 
 # ── get_azure_token_provider ──────────────────────────────────
 

--- a/tests/test_azure_auth.py
+++ b/tests/test_azure_auth.py
@@ -74,14 +74,14 @@ class GetAzureTokenProviderTest(unittest.TestCase):
         self.assertIsNone(provider)
 
     def test_returns_callable_when_azure_identity_available(self) -> None:
-        captured: dict[str, object] = {"cred_kwargs": None, "scope": None}
+        captured: dict[str, object] = {"cred_kwargs": None, "scopes": []}
 
         class FakeCred:
             def __init__(self, **kwargs: object) -> None:
                 captured["cred_kwargs"] = kwargs
 
         def fake_get_bearer_token_provider(cred: object, scope: str) -> object:
-            captured["scope"] = scope
+            captured["scopes"].append(scope)  # type: ignore[attr-defined]
             return lambda: "stub-token"
 
         fake_identity = ModuleType("azure.identity")
@@ -104,8 +104,8 @@ class GetAzureTokenProviderTest(unittest.TestCase):
         self.assertTrue(cred_kwargs["exclude_interactive_browser_credential"])
         self.assertTrue(cred_kwargs["exclude_visual_studio_code_credential"])
 
-        # Defensive: confirm the Azure OpenAI scope was requested.
-        self.assertEqual(captured["scope"], azure_auth.AZURE_OPENAI_SCOPE)
+        # Defensive: confirm the default scope is Azure OpenAI's audience.
+        self.assertEqual(captured["scopes"], [azure_auth.AZURE_OPENAI_SCOPE])
 
     def test_provider_is_cached_across_calls(self) -> None:
         construct_count = {"n": 0}
@@ -148,6 +148,62 @@ class GetAzureTokenProviderTest(unittest.TestCase):
             azure_auth.get_azure_token_provider()
 
         self.assertEqual(attempt_count["n"], 1)
+
+    def test_distinct_scopes_share_one_credential(self) -> None:
+        """Adding a Foundry-scope caller must not double up on DefaultAzureCredential.
+
+        Each scope gets its own bearer-token provider (different audience),
+        but the underlying credential-chain probe runs exactly once for the
+        process lifetime so the Foundry route does not pay for a second
+        ``az login`` / managed-identity round trip.
+        """
+        construct_count = {"n": 0}
+        scope_calls: list[str] = []
+
+        class FakeCred:
+            def __init__(self, **kwargs: object) -> None:
+                construct_count["n"] += 1
+
+        def fake_get_bearer_token_provider(cred: object, scope: str):
+            scope_calls.append(scope)
+            return lambda: f"token-for-{scope}"
+
+        fake_identity = ModuleType("azure.identity")
+        fake_identity.DefaultAzureCredential = FakeCred  # type: ignore[attr-defined]
+        fake_identity.get_bearer_token_provider = fake_get_bearer_token_provider  # type: ignore[attr-defined]
+
+        with patch.dict(
+            sys.modules,
+            {"azure": ModuleType("azure"), "azure.identity": fake_identity},
+        ):
+            openai_provider = azure_auth.get_azure_token_provider(
+                azure_auth.AZURE_OPENAI_SCOPE,
+            )
+            foundry_provider = azure_auth.get_azure_token_provider(
+                azure_auth.AZURE_FOUNDRY_SCOPE,
+            )
+            # Repeat calls must hit the per-scope cache.
+            assert openai_provider is azure_auth.get_azure_token_provider(
+                azure_auth.AZURE_OPENAI_SCOPE,
+            )
+            assert foundry_provider is azure_auth.get_azure_token_provider(
+                azure_auth.AZURE_FOUNDRY_SCOPE,
+            )
+
+        self.assertEqual(construct_count["n"], 1)
+        self.assertEqual(
+            sorted(scope_calls),
+            sorted([azure_auth.AZURE_OPENAI_SCOPE, azure_auth.AZURE_FOUNDRY_SCOPE]),
+        )
+        assert openai_provider is not None
+        assert foundry_provider is not None
+        self.assertIsNot(openai_provider, foundry_provider)
+        self.assertEqual(
+            openai_provider(), f"token-for-{azure_auth.AZURE_OPENAI_SCOPE}"
+        )
+        self.assertEqual(
+            foundry_provider(), f"token-for-{azure_auth.AZURE_FOUNDRY_SCOPE}"
+        )
 
 
 # ── provenance logging ────────────────────────────────────────

--- a/tests/test_azure_auth_dotenv.py
+++ b/tests/test_azure_auth_dotenv.py
@@ -59,13 +59,13 @@ class _DotenvHarness(unittest.TestCase):
         # against the test's env, not whatever a prior test cached.
         azure_auth._reset_cache_for_tests()
         self._mode_before = azure_auth._AZURE_AUTH_MODE
-        self._dep_missing_before = azure_auth._AZURE_AAD_DEP_MISSING
+        self._dep_missing_before = azure_auth._AZURE_OPENAI_AAD_DEP_MISSING
         azure_auth._reset_auth_mode_cache_for_tests()
         self.addCleanup(self._restore_model_client_cache)
 
     def _restore_model_client_cache(self) -> None:
         azure_auth._AZURE_AUTH_MODE = self._mode_before
-        azure_auth._AZURE_AAD_DEP_MISSING = self._dep_missing_before
+        azure_auth._AZURE_OPENAI_AAD_DEP_MISSING = self._dep_missing_before
         azure_auth._reset_cache_for_tests()
 
     def _write_dotenv(self, contents: str) -> Path:

--- a/tests/test_framework_agnostic.py
+++ b/tests/test_framework_agnostic.py
@@ -387,6 +387,48 @@ class TestTargetConfigCallable(unittest.TestCase):
             TargetConfig(callable="my_module:my_fn", connector="some.connector")
 
 
+class TestTargetConfigAzureAiHostedAgent(unittest.TestCase):
+    """Foundry-hosted agents (``azure_ai/agents/<id>``) own tools and
+    instructions server-side. The config validator must reject fields
+    that would silently be ignored at runtime, so users find out at
+    config-parse time instead of after a successful but wrong eval.
+    """
+
+    def test_hosted_agent_target_is_valid(self):
+        from assert_ai.core.config_model import TargetConfig
+        tc = TargetConfig(model="azure_ai/agents/asst_xxx")
+        self.assertIsNotNone(tc.model)
+
+    def test_hosted_agent_rejects_tools(self):
+        from assert_ai.core.config_model import TargetConfig, ToolsConfig
+        with self.assertRaisesRegex(ValueError, "azure_ai/agents"):
+            TargetConfig(
+                model="azure_ai/agents/asst_xxx",
+                tools=ToolsConfig(module="some.tools"),
+            )
+
+    def test_hosted_agent_rejects_system_prompt(self):
+        from assert_ai.core.config_model import TargetConfig
+        with self.assertRaisesRegex(ValueError, "azure_ai/agents"):
+            TargetConfig(
+                model="azure_ai/agents/asst_xxx",
+                system_prompt="ignored at runtime",
+            )
+
+    def test_non_hosted_azure_ai_model_still_allows_tools_and_prompt(self):
+        """Only the hosted-agent route is restricted. Other azure_ai/*
+        routes (chat completions, embeddings) are runtime-owned just like
+        azure/* and must keep working with tools / system_prompt."""
+        from assert_ai.core.config_model import TargetConfig, ToolsConfig
+        tc = TargetConfig(
+            model="azure_ai/gpt-4o",
+            system_prompt="hi",
+            tools=ToolsConfig(module="some.tools"),
+        )
+        self.assertIsNotNone(tc.tools)
+        self.assertEqual(tc.system_prompt, "hi")
+
+
 # ── SpanValidator tests ──────────────────────────────────────────
 
 

--- a/tests/test_model_client.py
+++ b/tests/test_model_client.py
@@ -1070,9 +1070,31 @@ class AzureAadTokenInjectionTest(unittest.IsolatedAsyncioTestCase):
     ) -> dict[str, object]:
         captured: dict[str, object] = {}
         fake_litellm = self._stub_litellm(captured)
+        # For azure_ai/* the injection layer re-resolves the auth mode
+        # against the family-specific env var (AZURE_AI_API_KEY); for
+        # azure/* it reads the cached _AZURE_AUTH_MODE. We patch both
+        # sides so a single ``mode`` arg drives the test regardless of
+        # family, and we wipe the relevant env vars so a stray
+        # AZURE_API_KEY in the dev shell does not leak into the per-family
+        # resolver.
+        env_overrides = {
+            "AZURE_API_KEY": "",
+            "AZURE_AI_API_KEY": "",
+            "ASSERT_AZURE_USE_AAD": "",
+        }
+        if mode == "key":
+            family = model.split("/", 1)[0]
+            if family == "azure_ai":
+                env_overrides["AZURE_AI_API_KEY"] = "fake-static-key"
+            else:
+                env_overrides["AZURE_API_KEY"] = "fake-static-key"
+        elif mode == "aad":
+            env_overrides["ASSERT_AZURE_USE_AAD"] = "1"
+        # mode == "aad-fallback" leaves all three blank.
         with patch.object(model_client, "_get_litellm_module", return_value=fake_litellm), \
              patch.object(model_client.azure_auth, "_AZURE_AUTH_MODE", mode), \
-             patch.object(model_client.azure_auth, "get_azure_token_provider", return_value=provider):
+             patch.object(model_client.azure_auth, "get_azure_token_provider", return_value=provider), \
+             patch.dict("os.environ", env_overrides, clear=False):
             await model_client.generate(model, "hi")
         return captured
 
@@ -1174,6 +1196,159 @@ class AzureAadTokenInjectionTest(unittest.IsolatedAsyncioTestCase):
              patch.object(model_client.azure_auth, "get_azure_token_provider", return_value=lambda: "auto-token"):
             await model_client.generate("azure/gpt-4o-mini", "hi", opts)
         self.assertIs(captured["azure_ad_token_provider"], user_provider)
+
+    # ── azure_ai/* (Azure AI Foundry) injection ────────────────────
+
+    def test_aad_scope_for_model_dispatches_on_family(self) -> None:
+        """The scope picker must route each Azure family to the right audience."""
+        self.assertEqual(
+            model_client._aad_scope_for_model("azure/gpt-4o"),
+            model_client.azure_auth.AZURE_OPENAI_SCOPE,
+        )
+        self.assertEqual(
+            model_client._aad_scope_for_model("azure_ai/agents/asst_xxx"),
+            model_client.azure_auth.AZURE_FOUNDRY_SCOPE,
+        )
+        self.assertIsNone(model_client._aad_scope_for_model("openai/gpt-5-mini"))
+        self.assertIsNone(model_client._aad_scope_for_model("anthropic/claude-3"))
+
+    async def test_aad_mode_azure_ai_agent_injects_api_key_string(self) -> None:
+        """Foundry agents need a static bearer string, not a provider callable.
+
+        LiteLLM's azure_ai/agents provider sets ``Authorization: Bearer
+        <api_key>`` directly from ``payload['api_key']``; passing a
+        callable there would fail. We must call the provider once per
+        request to mint a fresh token.
+        """
+        captured = await self._run_chat(
+            model="azure_ai/agents/asst_xxx",
+            mode="aad",
+            provider=lambda: "foundry-token",
+        )
+        self.assertEqual(captured.get("api_key"), "foundry-token")
+        self.assertNotIn("azure_ad_token_provider", captured)
+
+    async def test_aad_fallback_azure_ai_agent_injects_api_key_string(self) -> None:
+        captured = await self._run_chat(
+            model="azure_ai/agents/asst_xxx",
+            mode="aad-fallback",
+            provider=lambda: "foundry-token",
+        )
+        self.assertEqual(captured.get("api_key"), "foundry-token")
+
+    async def test_key_mode_azure_ai_agent_no_injection(self) -> None:
+        """In key mode we leave the payload alone — LiteLLM resolves auth itself."""
+        captured = await self._run_chat(
+            model="azure_ai/agents/asst_xxx",
+            mode="key",
+            provider=lambda: "should-not-be-used",
+        )
+        self.assertNotIn("api_key", captured)
+        self.assertNotIn("azure_ad_token_provider", captured)
+
+    async def test_aad_mode_azure_ai_agent_missing_dep_raises(self) -> None:
+        with patch.object(model_client.azure_auth, "_AZURE_AUTH_MODE", "aad"), \
+             patch.object(model_client.azure_auth, "get_azure_token_provider", return_value=None), \
+             patch.dict("os.environ", {
+                 "ASSERT_AZURE_USE_AAD": "1",
+                 "AZURE_API_KEY": "",
+                 "AZURE_AI_API_KEY": "",
+             }, clear=False):
+            with self.assertRaises(model_client.LLMAuthError) as ctx:
+                await model_client.generate("azure_ai/agents/asst_xxx", "hi")
+        self.assertIn("azure-identity", str(ctx.exception))
+        self.assertIn("assert-ai[azure-aad]", str(ctx.exception))
+
+    async def test_aad_fallback_azure_ai_agent_missing_dep_silently_skips(self) -> None:
+        captured = await self._run_chat(
+            model="azure_ai/agents/asst_xxx",
+            mode="aad-fallback",
+            provider=None,
+        )
+        self.assertNotIn("api_key", captured)
+        self.assertNotIn("azure_ad_token_provider", captured)
+
+    async def test_user_extra_kwargs_api_key_wins_for_azure_ai_agent(self) -> None:
+        """Explicit user-supplied api_key must override the auto-minted token."""
+        captured: dict[str, object] = {}
+        fake_litellm = self._stub_litellm(captured)
+        opts = model_client.GenerateOptions(
+            extra_kwargs={"api_key": "user-supplied-token"},
+        )
+        with patch.object(model_client, "_get_litellm_module", return_value=fake_litellm), \
+             patch.object(model_client.azure_auth, "_AZURE_AUTH_MODE", "aad"), \
+             patch.object(
+                 model_client.azure_auth,
+                 "get_azure_token_provider",
+                 return_value=lambda: "auto-token",
+             ), patch.dict("os.environ", {
+                 "ASSERT_AZURE_USE_AAD": "1",
+                 "AZURE_API_KEY": "",
+                 "AZURE_AI_API_KEY": "",
+             }, clear=False):
+            await model_client.generate("azure_ai/agents/asst_xxx", "hi", opts)
+        self.assertEqual(captured["api_key"], "user-supplied-token")
+
+    async def test_azure_api_key_in_env_does_not_block_foundry_aad(self) -> None:
+        """Regression: AZURE_API_KEY (Azure OpenAI key) must not gate AAD
+        injection for azure_ai/* targets. The two resources have separate
+        keys; mixing them silently sent users into key mode for the wrong
+        endpoint and surfaced as a 'no bearer token' error from Foundry.
+
+        Real-world setup that hit this: AZURE_API_KEY set so the
+        systematize/tester/judge azure/* calls work, no AZURE_AI_API_KEY,
+        target.model is azure_ai/agents/<id>. Pre-fix behavior: cached
+        mode='key' suppressed AAD injection for the Foundry call too.
+        """
+        captured: dict[str, object] = {}
+        fake_litellm = self._stub_litellm(captured)
+        stub_provider = lambda: "foundry-token"
+        with patch.object(model_client, "_get_litellm_module", return_value=fake_litellm), \
+             patch.object(model_client.azure_auth, "_AZURE_AUTH_MODE", "key"), \
+             patch.object(model_client.azure_auth, "get_azure_token_provider", return_value=stub_provider), \
+             patch.dict("os.environ", {
+                 "AZURE_API_KEY": "sk-azure-openai-key",
+                 "AZURE_AI_API_KEY": "",
+                 "ASSERT_AZURE_USE_AAD": "",
+             }, clear=False):
+            await model_client.generate("azure_ai/agents/asst_xxx", "hi")
+        # AZURE_AI_API_KEY is unset, so the Foundry-family resolver sees
+        # 'aad-fallback' and the new AAD token gets injected.
+        self.assertEqual(captured.get("api_key"), "foundry-token")
+
+    async def test_azure_ai_api_key_in_env_skips_foundry_aad_injection(self) -> None:
+        """When the user has set AZURE_AI_API_KEY explicitly, the family
+        resolver returns 'key' and we leave the payload alone so LiteLLM
+        can use the static token from the env. Symmetric to the azure/*
+        + AZURE_API_KEY path."""
+        captured: dict[str, object] = {}
+        fake_litellm = self._stub_litellm(captured)
+        with patch.object(model_client, "_get_litellm_module", return_value=fake_litellm), \
+             patch.object(model_client.azure_auth, "_AZURE_AUTH_MODE", "aad-fallback"), \
+             patch.object(model_client.azure_auth, "get_azure_token_provider", return_value=lambda: "should-not-be-injected"), \
+             patch.dict("os.environ", {
+                 "AZURE_API_KEY": "",
+                 "AZURE_AI_API_KEY": "user-supplied-foundry-key",
+                 "ASSERT_AZURE_USE_AAD": "",
+             }, clear=False):
+            await model_client.generate("azure_ai/agents/asst_xxx", "hi")
+        self.assertNotIn("api_key", captured)
+
+    async def test_assert_use_aad_flag_overrides_azure_ai_api_key(self) -> None:
+        """Explicit ASSERT_AZURE_USE_AAD=1 wins over a static
+        AZURE_AI_API_KEY too, matching the existing azure/* precedence."""
+        captured: dict[str, object] = {}
+        fake_litellm = self._stub_litellm(captured)
+        with patch.object(model_client, "_get_litellm_module", return_value=fake_litellm), \
+             patch.object(model_client.azure_auth, "_AZURE_AUTH_MODE", "aad"), \
+             patch.object(model_client.azure_auth, "get_azure_token_provider", return_value=lambda: "foundry-token"), \
+             patch.dict("os.environ", {
+                 "AZURE_API_KEY": "",
+                 "AZURE_AI_API_KEY": "ignored-when-flag-set",
+                 "ASSERT_AZURE_USE_AAD": "1",
+             }, clear=False):
+            await model_client.generate("azure_ai/agents/asst_xxx", "hi")
+        self.assertEqual(captured.get("api_key"), "foundry-token")
 
 
 class ClassifyLlmErrorAadHintTest(unittest.TestCase):

--- a/tests/test_model_client.py
+++ b/tests/test_model_client.py
@@ -1384,7 +1384,7 @@ class ClassifyLlmErrorAadHintTest(unittest.TestCase):
         exc = fake_litellm.AuthenticationError("401: bad token")
         with patch.object(model_client, "_get_litellm_module", return_value=fake_litellm), \
              patch.object(model_client.azure_auth, "_AZURE_AUTH_MODE", "aad"), \
-             patch.object(model_client.azure_auth, "_AZURE_AAD_DEP_MISSING", False):
+             patch.object(model_client.azure_auth, "_AZURE_OPENAI_AAD_DEP_MISSING", False):
             wrapped = model_client._classify_llm_error(exc, model="azure/gpt-5.4-mini")
         self.assertIsInstance(wrapped, model_client.LLMAuthError)
         self.assertIn("Cognitive Services OpenAI User", str(wrapped))
@@ -1405,12 +1405,37 @@ class ClassifyLlmErrorAadHintTest(unittest.TestCase):
         exc = fake_litellm.AuthenticationError("401: no api key supplied")
         with patch.object(model_client, "_get_litellm_module", return_value=fake_litellm), \
              patch.object(model_client.azure_auth, "_AZURE_AUTH_MODE", "aad-fallback"), \
-             patch.object(model_client.azure_auth, "_AZURE_AAD_DEP_MISSING", True):
+             patch.object(model_client.azure_auth, "_AZURE_OPENAI_AAD_DEP_MISSING", True):
             wrapped = model_client._classify_llm_error(exc, model="azure/gpt-5.4-mini")
         self.assertIsInstance(wrapped, model_client.LLMAuthError)
         self.assertIn("assert-ai[azure-aad]", str(wrapped))
         # The RBAC hint must not appear in this branch — it would be misleading.
         self.assertNotIn("Cognitive Services OpenAI User", str(wrapped))
+
+    def test_install_hint_mentions_azure_ai_api_key_for_foundry_family(self) -> None:
+        """When the dep-missing install hint fires on an azure_ai/* call,
+        the env var named in the hint must be AZURE_AI_API_KEY, not
+        AZURE_API_KEY. Otherwise users go set the Azure OpenAI key and
+        wonder why their Foundry call still fails."""
+        fake_litellm = self._fake_litellm_with_auth_error()
+        exc = fake_litellm.AuthenticationError("401: no api key supplied")
+        with patch.object(model_client, "_get_litellm_module", return_value=fake_litellm), \
+             patch.object(model_client.azure_auth, "_AZURE_OPENAI_AAD_DEP_MISSING", True), \
+             patch.dict("os.environ", {
+                 "ASSERT_AZURE_USE_AAD": "",
+                 "AZURE_API_KEY": "",
+                 "AZURE_AI_API_KEY": "",
+             }, clear=False):
+            wrapped = model_client._classify_llm_error(
+                exc, model="azure_ai/agents/asst_xxx"
+            )
+        self.assertIsInstance(wrapped, model_client.LLMAuthError)
+        self.assertIn("assert-ai[azure-aad]", str(wrapped))
+        self.assertIn("AZURE_AI_API_KEY", str(wrapped))
+        # The Azure OpenAI env var must not appear: it would send the
+        # user to the wrong resource's key.
+        self.assertNotIn("AZURE_API_KEY,", str(wrapped))
+        self.assertNotIn("export AZURE_API_KEY", str(wrapped))
 
     def test_auth_error_omits_azure_hints_for_non_azure_model(self) -> None:
         """A 401 on an ``openai/*`` model must not leak Azure-specific hints
@@ -1422,7 +1447,7 @@ class ClassifyLlmErrorAadHintTest(unittest.TestCase):
         exc = fake_litellm.AuthenticationError("401: invalid api key")
         with patch.object(model_client, "_get_litellm_module", return_value=fake_litellm), \
              patch.object(model_client.azure_auth, "_AZURE_AUTH_MODE", "aad"), \
-             patch.object(model_client.azure_auth, "_AZURE_AAD_DEP_MISSING", False):
+             patch.object(model_client.azure_auth, "_AZURE_OPENAI_AAD_DEP_MISSING", False):
             wrapped = model_client._classify_llm_error(exc, model="openai/gpt-5.4-mini")
         self.assertIsInstance(wrapped, model_client.LLMAuthError)
         # Neither the RBAC hint nor the install hint should appear on a
@@ -1439,11 +1464,84 @@ class ClassifyLlmErrorAadHintTest(unittest.TestCase):
         exc = fake_litellm.AuthenticationError("401")
         with patch.object(model_client, "_get_litellm_module", return_value=fake_litellm), \
              patch.object(model_client.azure_auth, "_AZURE_AUTH_MODE", "aad"), \
-             patch.object(model_client.azure_auth, "_AZURE_AAD_DEP_MISSING", False):
+             patch.object(model_client.azure_auth, "_AZURE_OPENAI_AAD_DEP_MISSING", False):
             wrapped = model_client._classify_llm_error(exc)
         self.assertIsInstance(wrapped, model_client.LLMAuthError)
         self.assertNotIn("Cognitive Services OpenAI User", str(wrapped))
         self.assertNotIn("assert-ai[azure-aad]", str(wrapped))
+
+    # ── azure_ai/* (Azure AI Foundry) hints ────────────────────────
+
+    def test_auth_error_uses_foundry_role_hint_for_azure_ai_family(self) -> None:
+        """A 401 on azure_ai/* must mention the Azure AI Foundry role and
+        AZURE_AI_API_KEY (not the Cognitive Services role and AZURE_API_KEY,
+        which would point users at the wrong resource)."""
+        fake_litellm = self._fake_litellm_with_auth_error()
+        exc = fake_litellm.AuthenticationError("401: bad token")
+        with patch.object(model_client, "_get_litellm_module", return_value=fake_litellm), \
+             patch.object(model_client.azure_auth, "_AZURE_AUTH_MODE", "aad"), \
+             patch.object(model_client.azure_auth, "_AZURE_OPENAI_AAD_DEP_MISSING", False):
+            wrapped = model_client._classify_llm_error(
+                exc, model="azure_ai/agents/asst_xxx"
+            )
+        self.assertIsInstance(wrapped, model_client.LLMAuthError)
+        self.assertIn("Azure AI User", str(wrapped))
+        self.assertIn("AZURE_AI_API_KEY", str(wrapped))
+        self.assertNotIn("Cognitive Services OpenAI User", str(wrapped))
+
+    def test_azure_ai_missing_token_api_connection_error_becomes_auth_error(self) -> None:
+        """LiteLLM raises the missing-token validation error from azure_ai/agents
+        as APIConnectionError because the request never leaves the process.
+        Surface it as LLMAuthError with the install hint so users do not see
+        it classified as a retryable provider error."""
+        fake_litellm = self._fake_litellm_with_auth_error()
+        exc = fake_litellm.APIConnectionError(
+            "Azure_aiException - api_key (Azure AD token) is required for "
+            "Azure Foundry Agents. Either pass api_key directly, ..."
+        )
+        with patch.object(model_client, "_get_litellm_module", return_value=fake_litellm):
+            wrapped = model_client._classify_llm_error(
+                exc, model="azure_ai/agents/asst_xxx"
+            )
+        self.assertIsInstance(wrapped, model_client.LLMAuthError)
+        self.assertIn("assert-ai[azure-aad]", str(wrapped))
+        self.assertIn("az login", str(wrapped))
+        self.assertIn("AZURE_AI_API_KEY", str(wrapped))
+
+    def test_azure_ai_missing_api_base_becomes_input_error_with_hint(self) -> None:
+        """LiteLLM raises the missing-api_base validation as APIConnectionError too;
+        we reclassify as LLMInputError pointing at AZURE_AI_API_BASE."""
+        fake_litellm = self._fake_litellm_with_auth_error()
+        exc = fake_litellm.APIConnectionError(
+            "Azure_aiException - api_base is required for Azure AI Agents. "
+            "Set it via AZURE_AI_API_BASE env var or api_base parameter."
+        )
+        with patch.object(model_client, "_get_litellm_module", return_value=fake_litellm):
+            wrapped = model_client._classify_llm_error(
+                exc, model="azure_ai/agents/asst_xxx"
+            )
+        self.assertIsInstance(wrapped, model_client.LLMInputError)
+        self.assertIn("AZURE_AI_API_BASE", str(wrapped))
+
+    def test_azure_ai_missing_api_base_second_variant_also_classified(self) -> None:
+        """LiteLLM raises a second wording of the same error from main.py
+        ('Azure AI Agents requests require an api_base. Set `api_base` or
+        the AZURE_AI_API_BASE env var.'). The classifier must catch both
+        variants; before this fix it would retry the call 5 times before
+        giving up because the error was classified as a retryable provider
+        error.
+        """
+        fake_litellm = self._fake_litellm_with_auth_error()
+        exc = fake_litellm.APIConnectionError(
+            "Azure_aiException - Azure AI Agents requests require an api_base. "
+            "Set `api_base` or the AZURE_AI_API_BASE env var."
+        )
+        with patch.object(model_client, "_get_litellm_module", return_value=fake_litellm):
+            wrapped = model_client._classify_llm_error(
+                exc, model="azure_ai/agents/asst_xxx"
+            )
+        self.assertIsInstance(wrapped, model_client.LLMInputError)
+        self.assertIn("AZURE_AI_API_BASE", str(wrapped))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds native AAD support for Azure AI Foundry hosted agents (and other `azure_ai/*` LiteLLM routes), so users can point `target.model` at `azure_ai/agents/<asst_id>` and have it just work with `az login` / managed identity / service principal, the same way `azure/*` models already do.

## Problem

`target.model: azure_ai/agents/<id>` was technically reachable via LiteLLM, but the existing AAD wiring only injected tokens for `azure/*` models. Users hit two confusing dead ends:

1. **`AZURE_API_KEY` (Azure OpenAI) silently suppressed AAD injection** for `azure_ai/*` calls because mode resolution was global. With a key set for orchestration (`azure/gpt-4o-mini` systematize/tester/judge), the Foundry call also entered key mode and was sent to Foundry without a bearer token, returning a misleading 'no api_key' error.
2. **LiteLLM's missing-`api_base` error was misclassified as retryable**, so the eval burned 5 retries before surfacing the real cause.

## Changes

| File | Change |
|---|---|
| [assert_ai/core/azure_auth.py](https://github.com/responsibleai/ASSERT/blob/feat/foundry-agent-target/assert_ai/core/azure_auth.py) | Add `AZURE_FOUNDRY_SCOPE`. Per-scope `get_azure_token_provider(scope=...)` cache that shares one `DefaultAzureCredential`. Family-aware `resolve_azure_auth_mode(family=...)` that checks `AZURE_API_KEY` for the `azure` family and `AZURE_AI_API_KEY` for the `azure_ai` family. Broaden boot-log label to `Azure auth mode:` since it covers both families. |
| [assert_ai/core/model_client.py](https://github.com/responsibleai/ASSERT/blob/feat/foundry-agent-target/assert_ai/core/model_client.py) | New `_aad_scope_for_model()` dispatch. Inject AAD credentials for both Azure families: `azure/*` keeps `azure_ad_token_provider` callable, `azure_ai/*` calls the provider once per request and stuffs the bearer into `payload['api_key']` (what LiteLLM's `azure_ai/agents` provider expects). Re-resolve mode per family on `azure_ai/*` injection to avoid the `AZURE_API_KEY` leak. Classifier widened so 401s and missing-token/`AZURE_AI_API_BASE` errors on `azure_ai/*` surface actionable hints instead of generic retryable errors. |
| [assert_ai/core/config_model.py](https://github.com/responsibleai/ASSERT/blob/feat/foundry-agent-target/assert_ai/core/config_model.py) | Reject `target.tools` and `target.system_prompt` on `azure_ai/agents/*` (the hosted agent owns its tools and instructions server-side). |
| [docs/getting-started.md](https://github.com/responsibleai/ASSERT/blob/feat/foundry-agent-target/docs/getting-started.md), [docs/config/schema.md](https://github.com/responsibleai/ASSERT/blob/feat/foundry-agent-target/docs/config/schema.md) | Two-line addendum noting Foundry agents share the same auth setup; new schema bullet for `azure_ai/agents/<AGENT_ID>`. |
| tests | +8 tests: per-scope cache, family-aware resolver, env-isolation regression for the `AZURE_API_KEY` leak, both LiteLLM `api_base` error variants, hosted-agent validation guards. |

## Commits (6, each independently green)

| SHA | Subject |
|---|---|
| `924eced5` | feat(azure-auth): per-scope token-provider cache for azure_ai/* support |
| `4b3f91b0` | feat(model_client): inject AAD credentials for azure_ai/* models |
| `a2699d23` | feat(model_client): friendly error hints for azure_ai/* failures |
| `4429314d` | chore(azure-auth): broaden boot-log label to cover azure_ai/* family |
| `7b23b57a` | feat(config): reject target.tools and system_prompt on azure_ai/agents/* |
| `1f97de8d` | docs(azure-auth): note azure_ai/* (Foundry agents) shares the same auth |

## User-visible change

Before this PR, the only paths to a hosted Foundry agent were a callable wrapper or a manually-minted `AZURE_AI_API_KEY=$(az account get-access-token ...)`. After this PR, point `target.model` at the agent and ASSERT mints the AAD token for you:

```yaml
pipeline:
  inference:
    target:
      model:
        name: azure_ai/agents/asst_xxx
```

```bash
pip install -e ".[azure-aad]"
az login
export AZURE_AI_API_BASE=https://<resource>.services.ai.azure.com/api/projects/<project>
assert-ai run --config <your_config>.yaml
```

Service Principal (`AZURE_TENANT_ID` / `AZURE_CLIENT_ID` / `AZURE_CLIENT_SECRET`) and managed identity flow through the same `DefaultAzureCredential` chain.

## Testing

- Full suite: **1113 passed**, 17 skipped, 1 deselected (docker-env test unrelated).
- Each commit green standalone (rebase-friendly history).
- End-to-end smoke-tested against a real Foundry-hosted Assistant: AAD token minted with `https://ai.azure.com/.default` scope, injected into `payload['api_key']`, request reached the Foundry endpoint, server-side run completed, reply returned correctly.

## Out of scope

- **v2 Foundry Agents** (UUID IDs at `{project}/agents/{uuid}/threads/...`). LiteLLM's `azure_ai/agents` provider only speaks the v1 Assistants surface (`asst_xxx`) and rejects UUIDs with `Invalid 'assistant_id': '<uuid>'. Expected an ID that begins with 'asst'`. v2 agents are evaluable today via the callable-wrapper path demonstrated in #250. A native v2 target will be tracked in a separate issue.
- **OTel trace visibility** for hosted Foundry agents. Foundry server-side traces would need a separate export integration; out of scope here.

## Related

- #250 — community-contributed callable-wrapper example for hosted Foundry agents. Complementary path: use that example's pattern when you need a Python entrypoint with full OTel visibility, or when targeting v2 agents.
