### PR TITLE
docs: post-#252 reconciliation for azure_ai/agents/<id> (init prompt + targets docs) [blocked on #253]

### DIFF
--- a/assert_ai/internal_pipeline_prompts/init_system.md
+++ b/assert_ai/internal_pipeline_prompts/init_system.md
@@ -119,7 +119,7 @@ Two built-in judge dimensions — `policy_violation` and `overrefusal` — are a
 **Prerequisite — do NOT emit `"propose"` until every check below is "yes":**
 
 1. **Application Context** — Do I have enough detail for a rich `context` field (what it does, who uses it, tools, constraints)?
-2. **Target Type** — Do I know if it's callable/model/endpoint and the specific path, model name, or URL? If it's `model`, did I also collect `target.system_prompt` as a separate field?
+2. **Target Type** — Do I know if it's callable/model/endpoint and the specific path, model name, or URL? If it's `model` and the user wants a hosted chat model, did I also collect `target.system_prompt` as a separate field? If it's `model: azure_ai/agents/<id>` (a Foundry hosted agent), did I confirm I am NOT collecting `system_prompt` or `tools` — the hosted agent owns both server-side?
 3. **Pipeline Default Model** — Did I confirm a `default_model` for the eval driver (not blindly reused from the target)?
 4. **Behavior Definition** — Do I have a focused, specific behavior spec (not a laundry list)?
 5. **Test Set Generation** — Did I confirm sample sizes and whether dimensions are needed?
@@ -284,7 +284,10 @@ Runs the target system against test cases.
 pipeline:
   inference:
     target:
-      # Exactly one of: callable, model, or endpoint
+      # Exactly one of: callable, model, or endpoint.
+      # `model` covers both raw hosted chat models and Foundry hosted agents
+      # (`azure_ai/agents/<AGENT_ID>`); see "Target Types" decision tree below for
+      # which fields are allowed in each sub-case.
       callable: my_package.agent:chat_sync
       trace:                    # recommended for callable targets
         backend: phoenix        # or "otel" — OpenTelemetry trace capture
@@ -307,7 +310,12 @@ Use this decision tree:
    - Example: if their agent code is in `src/my_agent/bot.py` and the function is `run_chat`, the callable is `src.my_agent.bot:run_chat`.
    - The function should take a `message` string and return a string response.
 
-2. **model**: The user has a hosted model + system prompt, optionally with tools. Set `target.model.name`, `target.system_prompt`, and optionally `target.tools` for tool schemas. The runtime owns the tool-call loop.
+2. **model**: The user has a hosted model. Two sub-cases:
+
+   - **2a. Hosted chat model + system prompt (+ optional tools).** Set `target.model.name`, `target.system_prompt`, and optionally `target.tools` for tool schemas. The runtime owns the tool-call loop. Use this when the user describes a system prompt they wrote, or wants to attach a tool schema themselves.
+
+   - **2b. Foundry hosted agent.** Set `target.model: azure_ai/agents/<AGENT_ID>` and stop — the hosted agent owns its instructions and tools server-side. **Do NOT propose `target.system_prompt` or `target.tools` in this sub-case**; the config parser rejects both fields when the model name starts with `azure_ai/agents/`. Requires the `AZURE_AI_API_BASE` env var (Foundry project endpoint) and the same Azure auth setup as `azure/*` models. Route here when the user mentions "Foundry agent", "hosted agent", "agent ID", or hands you a model string starting with `azure_ai/agents/`.
+
 3. **endpoint**: The user has an HTTP endpoint. Set `target.endpoint` to the URL. The endpoint must accept POST with `{"message": "...", "history": [...]}` and return `{"response": "..."}`. Last resort — use callable or model when possible.
 
 ## pipeline.judge
@@ -415,7 +423,7 @@ For callable targets, always include `target.trace` with `backend: phoenix` (or 
 In the generated YAML, consider adding short `# customize:` comments next to fields where you made a judgment call or used a default the user didn't explicitly confirm. These are suggestions — not every field needs a comment. Common candidates:
 
 - Numeric tuning: `sample_size`, `concurrency`, `max_turns`, `max_tool_calls`
-- Target verification: `inference.target.callable` module/function path, `inference.target.endpoint` URL, `inference.target.trace` backend
+- Target verification: `inference.target.callable` module/function path, `inference.target.endpoint` URL, `inference.target.trace` backend, and — for Foundry hosted agents — the `<AGENT_ID>` in `inference.target.model: azure_ai/agents/<AGENT_ID>` (add a `# review:` comment so the user double-checks the agent ID)
 - Model choices: `default_model` (per-stage `model:` overrides are commented-only unless the user asked to override — see above)
 - Content you inferred: `behavior.description`, `context`, `stratify.dimensions`, judge `dimensions` rubrics
 

--- a/docs/targets/README.md
+++ b/docs/targets/README.md
@@ -9,6 +9,7 @@ Pick a target based on how your agent is built.
 | Your target looks like... | Use this path | Start here |
 |---|---|---|
 | A system prompt + tool schema, no orchestration code yet | **Prompt Agent target** (`target.model`, `target.system_prompt`, `target.tools`): the runtime owns the tool-call loop (up to 10 rounds, real or simulated tools). Best for test-driven prompt + toolset design before any agent is implemented | [Prompt Agent Target (model + tools)](model-and-tools.md) |
+| An Azure AI Foundry **hosted agent** (the agent's tools and instructions live server-side in Foundry) | **Foundry hosted-agent target**: `target.model: azure_ai/agents/<AGENT_ID>` — do not set `target.system_prompt` or `target.tools`; the hosted agent owns both. Requires `AZURE_AI_API_BASE` (Foundry project endpoint) and the same Azure auth setup as `azure/*` models | [Prompt Agent Target → Foundry hosted agent](model-and-tools.md#foundry-hosted-agent-target) |
 | Any agent or multi-agent system you can invoke from Python (LangGraph, CrewAI, OpenAI Agents SDK, DSPy, LlamaIndex, AutoGen / MAF, custom orchestration, and others) | **Callable target with OTel traces (recommended)**: point `target.callable` at your entry function and add `target.trace` so Phoenix/OpenInference (or your own OTel SDK spans) feed tool calls, routing, model calls, and latency to the judge | [Callable Target](callable.md) |
 | A black-box API you cannot instrument | **Plain callable (customization fallback, not recommended)**: `target.callable` with no `target.trace`. The judge sees only the final response; use only when instrumentation is impossible | [Callable Target (without traces)](callable.md#customization-without-traces) |
 
@@ -47,6 +48,7 @@ The callable target also accepts a plain Python function with no `target.trace` 
 |---|---|---|---|
 | Callable target with OTel traces (recommended) | You (your callable runs the loop; ASSERT reads the OTel spans) | Any agent or multi-agent system you can invoke from Python | `target.callable` + `target.trace` |
 | Prompt Agent (model + tools) | ASSERT runtime (declared in YAML; runtime orchestrates up to 10 rounds) | Test-driven prompt + toolset design; agents that haven't been written yet | `target.model`, `target.system_prompt`, `target.tools` |
+| Foundry hosted agent | The Foundry-hosted agent (server-side; ASSERT just sends the user turn) | Evaluating an agent already deployed in Azure AI Foundry whose tools and instructions live server-side | `target.model: azure_ai/agents/<AGENT_ID>` (no `system_prompt`, no `tools`) |
 | Plain callable (customization fallback) | Whoever (ASSERT doesn't see inside) | Black-box APIs you cannot instrument; pipeline smoke tests | `target.callable` (no `target.trace`) |
 
 ## Current support

--- a/docs/targets/model-and-tools.md
+++ b/docs/targets/model-and-tools.md
@@ -62,6 +62,28 @@ pipeline:
         questions when user constraints are missing.
 ```
 
+## Foundry hosted agent target
+
+When the hosted target is an agent already deployed in Azure AI Foundry — one whose tools and instructions live server-side, not in your YAML — set `target.model` to `azure_ai/agents/<AGENT_ID>`:
+
+```yaml
+pipeline:
+  inference:
+    target:
+      model:
+        name: azure_ai/agents/asst_xxxxxxxxxxxxxxxx
+        temperature: 0.0
+        max_tokens: 8000
+      # Do NOT set system_prompt or tools here — the hosted agent
+      # owns both server-side, and the config parser rejects them
+      # for azure_ai/agents/* model names.
+```
+
+Requirements:
+
+- `AZURE_AI_API_BASE` env var set to the Foundry project endpoint (not `AZURE_API_BASE`).
+- Same Azure auth setup as `azure/*` models — `pip install -e ".[azure-aad]"` and `az login` (or Service Principal env vars). See [Getting Started → Azure AAD](../getting-started.md) for the full setup.
+
 ## When to switch to the callable target
 
 The Prompt Agent target is for agents declared in YAML — one model in a runtime-owned tool loop. Once you have a real agent implemented in code (LangGraph, CrewAI, LlamaIndex, OpenAI Agents SDK, AutoGen / MAF, DSPy, custom orchestration, …), switch to the [callable target](callable.md). At that point your code owns the loop, and the recommended OTel-traced integration captures routing, sub-agent decisions, and intermediate tool calls — visibility the Prompt Agent target cannot give you because, by design, you didn't write the loop.


### PR DESCRIPTION
## Summary

Reconciles the `assert-ai init` system prompt and the user-facing target docs with the `azure_ai/agents/<AGENT_ID>` Foundry hosted-agent route that #252 added.

Splits cleanly into two commits so the safe part can ship independently if needed:

1. **`docs(prompts): teach assert-ai init about azure_ai/agents/<id>`** — Parse-error prevention. The `TargetConfig` parser rejects `target.tools` and `target.system_prompt` when the model name starts with `azure_ai/agents/`, but the init system prompt did not learn this rule, so `assert-ai init` currently proposes configs that fail at parse time when a user describes a Foundry agent. v1/v2-agnostic — would be correct to ship today.

2. **`docs(targets): document Foundry hosted-agent target [BLOCKED on #253]`** — Promotes the Foundry route in `docs/targets/README.md` (decision-tree + "paths at a glance" tables) and adds a "Foundry hosted agent target" subsection to `docs/targets/model-and-tools.md`. **Held until #253 ships full Foundry v2 agent support.** PR #252 only covers v1, and the v2 path still needs a workaround, so promoting the route in public target docs now would oversell coverage.

## Why draft?

Bidirectional pickup for #253:

- This PR → #253: documents the dependency, so commit 2 doesn't ship prematurely.
- #253 → this PR: gives whoever implements v2 a ready-to-rebase doc diff, so they don't have to re-derive what user-facing surfaces need updating.

When #253 lands, the v2 implementer should:
1. Rebase this branch.
2. Adjust commit 2's wording if needed (e.g. cover both v1 and v2 ID shapes).
3. Flip the PR to ready for review.

If we want commit 1 sooner, it can be cherry-picked into a tiny standalone ship-now PR without losing the draft.

## Verification

- Re-read the updated decision tree end-to-end as if I were the init LLM, with two synthetic inputs:
  1. "I have a LangGraph agent in `src/my_agent/bot.py`" → routes to `callable`. ✓
  2. "I have a Foundry agent, agent ID `asst_abc123`" → routes to `model` sub-case 2b; does not ask for `system_prompt`/`tools`. ✓
- `python3 -m compileall -q assert_ai` (no code changed; sanity check).

## Files

| File | Commit |
|------|--------|
| `assert_ai/internal_pipeline_prompts/init_system.md` | 1 |
| `docs/targets/README.md` | 2 (blocked) |
| `docs/targets/model-and-tools.md` | 2 (blocked) |

Related: #252, #253
