### PR TITLE
Hygiene: finish public terminology cleanup

### DIFF
--- a/viewer/src/lib/export/ExportPage.svelte
+++ b/viewer/src/lib/export/ExportPage.svelte
@@ -67,7 +67,7 @@
 	} = $props();
 
 	const RUN_STAGE_LABELS: Record<string, string> = {
-		seeds: 'Seed Generation',
+		seeds: 'Test Set Generation',
 		inference: 'Inference',
 		judge: 'Scoring'
 	};

--- a/viewer/src/lib/result-view.ts
+++ b/viewer/src/lib/result-view.ts
@@ -17,7 +17,7 @@ export function scenarioStopReasonDisplay(stopReason: string | null | undefined)
 	if (stopReason === 'completed' || stopReason === 'max_turns') return null;
 	if (stopReason === 'tester_input_refused') {
 		return {
-			label: 'Refused before inference',
+			label: 'Refused before Inference',
 			description:
 				'The tester refused to generate input for this scenario, so no target conversation was produced.',
 			tone: 'refusal'

--- a/viewer/src/routes/api/csv/[suite_id]/+server.ts
+++ b/viewer/src/routes/api/csv/[suite_id]/+server.ts
@@ -159,7 +159,7 @@ export const GET: RequestHandler = async ({ params, url }) => {
 				});
 			}
 		}
-		if (allScores.length === 0) throw error(404, 'No inference scores found across runs');
+		if (allScores.length === 0) throw error(404, 'No Inference scores found across runs');
 
 		const judgeDims = [...allJudgeDims].sort();
 		const dimensions = [...allDimensions].sort();

--- a/viewer/src/routes/api/csv/[suite_id]/+server.ts
+++ b/viewer/src/routes/api/csv/[suite_id]/+server.ts
@@ -159,7 +159,7 @@ export const GET: RequestHandler = async ({ params, url }) => {
 				});
 			}
 		}
-		if (allScores.length === 0) throw error(404, 'No Inference scores found across runs');
+		if (allScores.length === 0) throw error(404, 'No scenario scores found across runs');
 
 		const judgeDims = [...allJudgeDims].sort();
 		const dimensions = [...allDimensions].sort();

--- a/viewer/src/routes/api/csv/[suite_id]/[run_id]/+server.ts
+++ b/viewer/src/routes/api/csv/[suite_id]/[run_id]/+server.ts
@@ -54,7 +54,7 @@ export const GET: RequestHandler = async ({ params, url }) => {
 
 	if (type === 'audit_scores') {
 		const scores = loadAuditScores(suite_id, run_id);
-		if (scores.length === 0) throw error(404, 'No Inference scores found');
+		if (scores.length === 0) throw error(404, 'No scenario scores found');
 
 		const transcripts = loadAuditTranscripts(suite_id, run_id);
 		const transcriptMap = new Map<string, AuditTranscript>();

--- a/viewer/src/routes/api/csv/[suite_id]/[run_id]/+server.ts
+++ b/viewer/src/routes/api/csv/[suite_id]/[run_id]/+server.ts
@@ -54,7 +54,7 @@ export const GET: RequestHandler = async ({ params, url }) => {
 
 	if (type === 'audit_scores') {
 		const scores = loadAuditScores(suite_id, run_id);
-		if (scores.length === 0) throw error(404, 'No inference scores found');
+		if (scores.length === 0) throw error(404, 'No Inference scores found');
 
 		const transcripts = loadAuditTranscripts(suite_id, run_id);
 		const transcriptMap = new Map<string, AuditTranscript>();

--- a/viewer/src/routes/new/+page.svelte
+++ b/viewer/src/routes/new/+page.svelte
@@ -1640,7 +1640,7 @@
 
 				<div class="mb-5">
 					<h3 class="mb-1 text-base font-semibold text-text">Measurement suite & run identity</h3>
-					<p class="mb-3 text-xs text-text-muted">Measurement suites group behaviors and test cases; runs hold measurement results.</p>
+					<p class="mb-3 text-xs text-text-muted">Measurement suites group a behavior and its test set; runs hold measurement results.</p>
 					<div class="grid grid-cols-2 gap-4">
 						<div>
 							<label for="suite-id" class="mb-1 block text-xs font-semibold text-text-secondary">Measurement suite ID</label>

--- a/viewer/src/routes/new/+page.svelte
+++ b/viewer/src/routes/new/+page.svelte
@@ -1640,7 +1640,7 @@
 
 				<div class="mb-5">
 					<h3 class="mb-1 text-base font-semibold text-text">Measurement suite & run identity</h3>
-					<p class="mb-3 text-xs text-text-muted">Measurement suites group policy + seeds; runs hold measurement results.</p>
+					<p class="mb-3 text-xs text-text-muted">Measurement suites group behaviors and test cases; runs hold measurement results.</p>
 					<div class="grid grid-cols-2 gap-4">
 						<div>
 							<label for="suite-id" class="mb-1 block text-xs font-semibold text-text-secondary">Measurement suite ID</label>

--- a/viewer/src/routes/suite/[suite_id]/[run_id]/+page.svelte
+++ b/viewer/src/routes/suite/[suite_id]/[run_id]/+page.svelte
@@ -221,7 +221,7 @@
 	}
 
 	const RUN_STAGE_LABELS: Record<string, string> = {
-		seeds: 'Seed Generation',
+		seeds: 'Test Set Generation',
 		inference: 'Inference',
 		judge: 'Scoring',
 	};
@@ -481,7 +481,7 @@
 
 	async function openSampleModal(sample: JudgedSample) {
 		if (!sample.test_case_id) {
-			promptDrawerError = 'Prompt is missing a seed id.';
+			promptDrawerError = 'Prompt is missing a test case ID.';
 			return;
 		}
 		const token = bumpPromptDrawerLoadToken();
@@ -1069,7 +1069,7 @@
 				<p>{auditRefusedCount} {auditRefusedCount === 1 ? 'scenario was' : 'scenarios were'} refused before producing a transcript.</p>
 			{/if}
 			{#if activeTab === 'audit' && auditErroredCount > 0}
-				<p>{auditErroredCount} {auditErroredCount === 1 ? 'scenario' : 'scenarios'} hit an inference error and {auditErroredCount === 1 ? 'was' : 'were'} excluded from the rates.</p>
+				<p>{auditErroredCount} {auditErroredCount === 1 ? 'scenario' : 'scenarios'} hit an Inference error and {auditErroredCount === 1 ? 'was' : 'were'} excluded from the rates.</p>
 			{/if}
 		</div>
 	{/if}

--- a/viewer/src/routes/suite/[suite_id]/[run_id]/+page.svelte
+++ b/viewer/src/routes/suite/[suite_id]/[run_id]/+page.svelte
@@ -1069,7 +1069,7 @@
 				<p>{auditRefusedCount} {auditRefusedCount === 1 ? 'scenario was' : 'scenarios were'} refused before producing a transcript.</p>
 			{/if}
 			{#if activeTab === 'audit' && auditErroredCount > 0}
-				<p>{auditErroredCount} {auditErroredCount === 1 ? 'scenario' : 'scenarios'} hit an Inference error and {auditErroredCount === 1 ? 'was' : 'were'} excluded from the rates.</p>
+				<p>{auditErroredCount} {auditErroredCount === 1 ? 'scenario' : 'scenarios'} encountered an error during Inference and {auditErroredCount === 1 ? 'was' : 'were'} excluded from the rates.</p>
 			{/if}
 		</div>
 	{/if}


### PR DESCRIPTION
## Summary

- restore `Test Set Generation` and test case terminology defined in #23
- use behavior + test set for suite-level collections and scenario for multi-turn score exports
- capitalize `Inference` only when referring to the pipeline stage, consistent with #135
- preserve intentional `overrefusal` terminology and legacy internal route/stage keys

Issue #152 is partially stale: `overrefusal` is now an intentional built-in judge dimension. This PR applies only the remaining valid public terminology cleanup and follows the canonical vocabulary established in #23.

Closes #152