### PR TITLE
Hygiene: standardize remaining example sample sizes

### DIFF
--- a/examples/change_control_agent/eval_config.yaml
+++ b/examples/change_control_agent/eval_config.yaml
@@ -93,9 +93,9 @@ pipeline:
 
   test_set:
     prompt:
-      sample_size: 20
+      sample_size: 5
     scenario:
-      sample_size: 4
+      sample_size: 5
 
   inference:
     concurrency: 4

--- a/examples/science_research_agent/eval_config.yaml
+++ b/examples/science_research_agent/eval_config.yaml
@@ -46,9 +46,9 @@ pipeline:
 
   test_set:
     prompt:
-      sample_size: 16
+      sample_size: 5
     scenario:
-      sample_size: 4
+      sample_size: 5
 
   inference:
     concurrency: 4


### PR DESCRIPTION
## Summary

- reduce `change_control_agent` from 20 prompt / 4 scenario test cases to 5 / 5
- reduce `science_research_agent` from 16 prompt / 4 scenario test cases to 5 / 5
- align both examples with the convention established in #140

Closes #151