### PR TITLE
Sync science and eng repos, fill missing gaps, and add configurable test-set sampling methods

### DIFF
--- a/assert_ai/internal_pipeline_prompts/init_system.md
+++ b/assert_ai/internal_pipeline_prompts/init_system.md
@@ -278,7 +278,10 @@ test_set:
 
 Sampling defaults to `pairwise`. `stratified` accepts `stratify_by`,
 `full_factorial` accepts `replication: balanced|none`, and `random` accepts
-`with_replacement: true|false`.
+`with_replacement: true|false`. Pairwise budgets above the covering-array size
+replicate its complete assignments rather than adding new assignment cells.
+Stratified sampling balances joint strata; below the joint-strata count,
+individual axes are not guaranteed to be marginally balanced.
 
 ## pipeline.inference
 

--- a/assert_ai/internal_pipeline_prompts/init_system.md
+++ b/assert_ai/internal_pipeline_prompts/init_system.md
@@ -276,6 +276,10 @@ test_set:
     # model: ...                # optional — uncomment to override default_model
 ```
 
+Sampling defaults to `pairwise`. `stratified` accepts `stratify_by`,
+`full_factorial` accepts `replication: balanced|none`, and `random` accepts
+`with_replacement: true|false`.
+
 ## pipeline.inference
 
 Runs the target system against test cases.

--- a/assert_ai/stages/test_set.py
+++ b/assert_ai/stages/test_set.py
@@ -11,6 +11,7 @@ import logging
 import random
 import warnings
 from dataclasses import dataclass
+from itertools import product
 from pathlib import Path
 from typing import Any
 
@@ -63,6 +64,7 @@ SUITE_OUTPUT = TEST_SET_FILE
 # 67 covering-array tuples (≈15 test_set per tuple): 65/67 batches truncated
 # without this cap, only 30 valid test_set survived.
 MAX_TEST_CASES_PER_BATCH = 5
+SAMPLING_METHODS = {"pairwise", "stratified", "full_factorial", "random"}
 
 TOOL_SOURCE_RUNTIME = "runtime"
 TOOL_SOURCE_PER_TEST_CASE = "per_test_case"
@@ -572,6 +574,200 @@ def sample_from_covering_array(
     return result
 
 
+def validate_sampling_config(
+    raw: Any,
+    *,
+    field_name: str = "sampling",
+) -> dict[str, Any]:
+    """Validate one test-set sampling configuration."""
+    if raw is None:
+        return {"method": "pairwise"}
+    if not isinstance(raw, dict):
+        raise ValueError(f"{field_name} must be a mapping")
+    method = raw.get("method", "pairwise")
+    if not isinstance(method, str) or method not in SAMPLING_METHODS:
+        raise ValueError(
+            f"{field_name}.method must be one of {sorted(SAMPLING_METHODS)}"
+        )
+    allowed = {
+        "pairwise": {"method"},
+        "stratified": {"method", "stratify_by"},
+        "full_factorial": {"method", "replication"},
+        "random": {"method", "with_replacement"},
+    }[method]
+    unknown = sorted(set(raw).difference(allowed))
+    if unknown:
+        raise ValueError(f"{field_name} unknown key(s): {', '.join(unknown)}")
+
+    if method == "stratified":
+        stratify_by = raw.get("stratify_by", ["behavior"])
+        if (
+            not isinstance(stratify_by, list)
+            or not stratify_by
+            or not all(isinstance(axis, str) and axis for axis in stratify_by)
+        ):
+            raise ValueError(f"{field_name}.stratify_by must be a non-empty list of strings")
+        if len(set(stratify_by)) != len(stratify_by):
+            raise ValueError(f"{field_name}.stratify_by must not contain duplicates")
+        return {"method": method, "stratify_by": list(stratify_by)}
+
+    if method == "full_factorial":
+        replication = raw.get("replication", "balanced")
+        if not isinstance(replication, str) or replication not in {"balanced", "none"}:
+            raise ValueError(
+                f"{field_name}.replication must be 'balanced' or 'none'"
+            )
+        return {"method": method, "replication": replication}
+
+    if method == "random":
+        with_replacement = raw.get("with_replacement", True)
+        if not isinstance(with_replacement, bool):
+            raise ValueError(f"{field_name}.with_replacement must be a boolean")
+        return {"method": method, "with_replacement": with_replacement}
+
+    return {"method": method}
+
+
+def _sample_non_pairwise_assignments(
+    *,
+    stratification: dict[str, list[dict[str, Any]]],
+    sample_size: int,
+    sampling: dict[str, Any],
+    rng: random.Random,
+) -> list[dict[str, str]]:
+    """Select assignments for an explicitly configured non-pairwise method."""
+    cfg = sampling
+    axes = tuple(key for key in stratification if not key.startswith("_"))
+    levels = {
+        axis: [str(entry["name"]) for entry in stratification[axis]]
+        for axis in axes
+    }
+    method = cfg["method"]
+    if method == "pairwise":
+        raise ValueError("pairwise sampling uses the existing covering-array path")
+
+    if method == "stratified":
+        stratify_by = tuple(cfg["stratify_by"])
+        missing = sorted(set(stratify_by).difference(axes))
+        if missing:
+            raise ValueError(
+                f"sampling.stratify_by axis not found: {', '.join(missing)}"
+            )
+        stratum_count = 1
+        for axis in stratify_by:
+            stratum_count *= len(levels[axis])
+
+        def stratum_at(flat_index: int) -> dict[str, str]:
+            values: dict[str, str] = {}
+            index = flat_index
+            for axis in reversed(stratify_by):
+                axis_levels = levels[axis]
+                index, level_index = divmod(index, len(axis_levels))
+                values[axis] = axis_levels[level_index]
+            return {axis: values[axis] for axis in stratify_by}
+
+        if sample_size < stratum_count:
+            indexed_allocations = [
+                (index, 1)
+                for index in _sample_unique_indices(stratum_count, sample_size, rng)
+            ]
+        else:
+            base, remainder = divmod(sample_size, stratum_count)
+            extras = set(_sample_unique_indices(stratum_count, remainder, rng))
+            indexed_allocations = [
+                (index, base + (1 if index in extras else 0))
+                for index in range(stratum_count)
+            ]
+        inner_axes = tuple(axis for axis in axes if axis not in stratify_by)
+        rows: list[dict[str, str]] = []
+        for index, count in indexed_allocations:
+            stratum = stratum_at(index)
+            for _ in range(count):
+                row = dict(stratum)
+                row.update({
+                    axis: rng.choice(levels[axis])
+                    for axis in inner_axes
+                })
+                rows.append(row)
+        rng.shuffle(rows)
+        return rows
+
+    if method == "random" and cfg["with_replacement"]:
+        return [
+            {axis: rng.choice(levels[axis]) for axis in axes}
+            for _ in range(sample_size)
+        ]
+
+    full_size = 1
+    for axis in axes:
+        full_size *= len(levels[axis])
+
+    if method == "random":
+        if sample_size > full_size:
+            raise ValueError(
+                "random sampling without replacement requires sample_size "
+                f"<= the factorial size ({full_size})"
+            )
+        sampled_indices = _sample_unique_indices(full_size, sample_size, rng)
+        rows: list[dict[str, str]] = []
+        for sampled_index in sampled_indices:
+            index = sampled_index
+            row: dict[str, str] = {}
+            for axis in reversed(axes):
+                axis_levels = levels[axis]
+                index, level_index = divmod(index, len(axis_levels))
+                row[axis] = axis_levels[level_index]
+            rows.append({axis: row[axis] for axis in axes})
+        return rows
+
+    if method == "full_factorial":
+        if cfg["replication"] == "none":
+            if sample_size != full_size:
+                raise ValueError(
+                    "full_factorial with replication=none requires sample_size "
+                    f"to equal the factorial size ({full_size})"
+                )
+        elif sample_size < full_size:
+            raise ValueError(
+                "full_factorial with balanced replication requires sample_size "
+                f">= the factorial size ({full_size})"
+            )
+        full = [
+            dict(zip(axes, values, strict=True))
+            for values in product(*(levels[axis] for axis in axes))
+        ]
+        if cfg["replication"] == "none":
+            rng.shuffle(full)
+            return full
+        rows = [dict(row) for row in full for _ in range(sample_size // full_size)]
+        remainder = sample_size % full_size
+        rows.extend(
+            dict(full[index])
+            for index in _sample_unique_indices(len(full), remainder, rng)
+        )
+        rng.shuffle(rows)
+        return rows
+
+    raise AssertionError(f"unsupported sampling method: {method}")
+
+
+def _sample_unique_indices(
+    population_size: int,
+    sample_size: int,
+    rng: random.Random,
+) -> list[int]:
+    """Sample unique indices without requiring a sys.maxsize-bounded range."""
+    selected: set[int] = set()
+    start = population_size - sample_size
+    for offset in range(sample_size):
+        upper = start + offset
+        candidate = rng.randrange(upper + 1)
+        selected.add(upper if candidate in selected else candidate)
+    result = list(selected)
+    rng.shuffle(result)
+    return result
+
+
 # ---------------------------------------------------------------------------
 # Job building
 # ---------------------------------------------------------------------------
@@ -587,18 +783,93 @@ class TestCaseJob:
     tuple_spec: dict[str, dict[str, Any]] | None = None
 
 
+def _build_jobs_from_assignments(
+    *,
+    stratification: dict[str, list[dict[str, Any]]],
+    assignments: list[dict[str, str]],
+) -> tuple[list[TestCaseJob], list[dict[str, str]] | None]:
+    """Convert sampled assignments into batched generation jobs."""
+    behavior_entries = stratification["behavior"]
+    factor_names = stratification_dimensions(stratification)
+    level_lookup: dict[str, dict[str, dict[str, str]]] = {
+        factor_name: {
+            entry["name"]: entry for entry in stratification[factor_name]
+        }
+        for factor_name in factor_names
+    }
+    behavior_level_lookup = {
+        str(entry["name"]): entry for entry in behavior_entries
+    }
+    all_axes = ("behavior",) + factor_names if factor_names else ("behavior",)
+    counts: dict[tuple[str, ...], int] = {}
+    rows_by_key: dict[tuple[str, ...], dict[str, str]] = {}
+    for row in assignments:
+        key = tuple(row[axis] for axis in all_axes)
+        rows_by_key.setdefault(key, row)
+        counts[key] = counts.get(key, 0) + 1
+
+    jobs: list[TestCaseJob] = []
+    next_index = 0
+    for key, count in counts.items():
+        row = rows_by_key[key]
+        behavior_name = row["behavior"]
+        behavior_entry = behavior_level_lookup[behavior_name]
+        spec: dict[str, dict[str, Any]] = {
+            factor_name: level_lookup[factor_name][row[factor_name]]
+            for factor_name in factor_names
+        }
+        spec["behavior"] = behavior_entry
+
+        # Split the per-tuple budget into chunks ≤ MAX_TEST_CASES_PER_BATCH so
+        # each LLM call stays inside the default max_tokens budget. Each
+        # chunk becomes its own TestCaseJob with a contiguous start_index slot
+        # so generated test case IDs remain stable and unique within the tuple.
+        chunk_offset = 0
+        remaining = count
+        while remaining > 0:
+            chunk = min(MAX_TEST_CASES_PER_BATCH, remaining)
+            jobs.append(
+                TestCaseJob(
+                    order=len(jobs),
+                    behavior=behavior_entry,
+                    count=chunk,
+                    start_index=next_index + chunk_offset,
+                    tuple_spec=spec,
+                )
+            )
+            chunk_offset += chunk
+            remaining -= chunk
+        next_index += count
+
+    return jobs, assignments or None
+
+
 def build_generation_jobs(
     *,
     taxonomy: dict[str, Any],
     stratification: dict[str, list[dict[str, Any]]],
     sample_size: int,
     rng: random.Random,
+    sampling: dict[str, Any] | None = None,
 ) -> tuple[list[TestCaseJob], list[dict[str, str]] | None]:
     """Build generation jobs — one per covering-array tuple.
 
     Budget is spread evenly across tuples via divmod. Each job produces
     its allocated number of test_set for a single (behavior, dimension…) tuple.
     """
+    sampling_cfg = validate_sampling_config(sampling)
+    if sampling_cfg["method"] != "pairwise":
+        assignments = _sample_non_pairwise_assignments(
+            stratification=stratification,
+            sample_size=sample_size,
+            sampling=sampling_cfg,
+            rng=rng,
+        )
+        return _build_jobs_from_assignments(
+            stratification=stratification,
+            assignments=assignments,
+        )
+
     behavior_entries = stratification["behavior"]
     factor_names = stratification_dimensions(stratification)
     level_lookup: dict[str, dict[str, dict[str, str]]] = {
@@ -683,6 +954,7 @@ async def _generate_records(
     fixed_system_prompt: str | None = None,
     context: str | None = None,
     stratification: dict[str, Any] | None = None,
+    sampling: dict[str, Any] | None = None,
     seed: int = 0,
     concurrency: int = 8,
 ) -> dict[str, Any]:
@@ -713,6 +985,7 @@ async def _generate_records(
         stratification=stratification_data,
         sample_size=sample_size,
         rng=random.Random(seed),
+        sampling=sampling,
     )
     factor_names = stratification_dimensions(stratification_data)
 
@@ -892,6 +1165,7 @@ async def run_test_set(
             tool_source=tool_source, fixed_system_prompt=fixed_system_prompt,
             context=normalized_context,
             stratification=stratification,
+            sampling=cfg.get("sampling"),
             seed=seed,
             concurrency=concurrency,
         )
@@ -960,7 +1234,7 @@ def _parse_kind_config(
     reject_unknown_keys(
         raw,
         field_name=f"test_set.{kind}",
-        allowed={"model", "sample_size", "timeout_s"},
+        allowed={"model", "sample_size", "timeout_s", "sampling"},
     )
     model = raw.get("model") or raw_cfg.get("model")
     if not isinstance(model, dict):
@@ -978,6 +1252,10 @@ def _parse_kind_config(
         "max_tokens": model_cfg.max_tokens,
         "reasoning_effort": model_cfg.reasoning_effort,
         "timeout_s": raw.get("timeout_s") or raw_cfg.get("timeout_s"),
+        "sampling": validate_sampling_config(
+            raw.get("sampling"),
+            field_name=f"test_set.{kind}.sampling",
+        ),
     }
 
 

--- a/assert_ai/stages/test_set.py
+++ b/assert_ai/stages/test_set.py
@@ -1186,21 +1186,18 @@ async def run_test_set(
     covered_categories = {row_behavior(r) for r in all_records} - {""}
     missing_categories = all_categories - covered_categories
     if missing_categories:
-        # With stratification dimensions the covering array has more tuples
-        # than categories.  The minimum sample_size per kind that guarantees
-        # every category appears at least once equals the number of
-        # categories (no extra dimensions) or more (with extra dimensions).
-        min_per_kind = len(all_categories)
         log.warning(
             "Test cases cover only %d of %d behavior categories. "
             "Missing categories: %s. "
-            "To cover all categories, set sample_size >= %d per kind "
-            "(prompt / scenario). With additional stratification dimensions "
-            "the required minimum may be higher.",
+            "Coverage depends on the sampling method and successful generation: "
+            "pairwise requires a budget at least as large as the covering array; "
+            "stratified guarantees behavior coverage when stratify_by=[behavior] "
+            "and sample_size >= %d; full_factorial covers every assignment; "
+            "random does not guarantee category coverage.",
             len(covered_categories),
             len(all_categories),
             ", ".join(sorted(missing_categories)),
-            min_per_kind,
+            len(all_categories),
         )
     # -------------------------------------------------------------------------
 

--- a/docs/config/schema.md
+++ b/docs/config/schema.md
@@ -126,10 +126,12 @@ Accepted keys:
   - `sample_size` — integer from `1` to `100000`. Default: `100`.
   - `model` — model config.
   - `timeout_s` — optional per-call timeout for generation.
+  - `sampling` — optional assignment-selection config. Default: `{method: pairwise}`.
 - `scenario` — mapping. Optional.
   - `sample_size` — integer from `1` to `100000`. Default: `100`.
   - `model` — model config.
   - `timeout_s` — optional per-call timeout for generation.
+  - `sampling` — optional assignment-selection config. Default: `{method: pairwise}`.
 - `stratify` — mapping. Optional.
   - `dimensions` — list of dimensions crossed with behavior categories.
   - `level_count` — positive integer. Default: `3`. Used when dimensions need generated levels.
@@ -141,6 +143,13 @@ Accepted keys:
 - `save_path` — optional override path for `test_set.jsonl` output.
 
 At least one of `prompt` or `scenario` is required. The fallback order for prompt generation is `test_set.prompt.model`, then `test_set.model`, then `default_model`. Scenario generation uses the same order with `test_set.scenario.model` first. Stratify generation uses `test_set.stratify.model`, then `test_set.model`, then `default_model`.
+
+Sampling methods:
+
+- `pairwise` — default. Uses an IPOG covering array; full pair coverage requires a budget at least as large as the covering array.
+- `stratified` — balances across `stratify_by` (default `[behavior]`) and samples remaining dimensions uniformly.
+- `full_factorial` — covers every dimension cell. `replication` is `balanced` by default or `none` when `sample_size` must exactly equal the factorial size.
+- `random` — uniform random assignments. `with_replacement` defaults to `true`.
 
 `tool_source: per_test_case` requires `pipeline.inference.target.model` and `pipeline.inference.target.tools.simulator`. It rejects callable targets, endpoint targets, Python tool modules, and fixed toolsets.
 
@@ -156,6 +165,9 @@ pipeline:
     tool_source: runtime
     prompt:
       sample_size: 10
+      sampling:
+        method: stratified
+        stratify_by: [behavior]
       model:
         name: azure/gpt-4o-mini
         max_tokens: 3000

--- a/docs/config/schema.md
+++ b/docs/config/schema.md
@@ -146,8 +146,8 @@ At least one of `prompt` or `scenario` is required. The fallback order for promp
 
 Sampling methods:
 
-- `pairwise` — default. Uses an IPOG covering array; full pair coverage requires a budget at least as large as the covering array.
-- `stratified` — balances across `stratify_by` (default `[behavior]`) and samples remaining dimensions uniformly.
+- `pairwise` — default. Uses an IPOG covering array; full pair coverage requires a budget at least as large as the covering array. Budgets above the covering-array size replicate its complete assignments as evenly as possible; they do not add new assignment cells.
+- `stratified` — balances across the joint Cartesian product of `stratify_by` (default `[behavior]`) and samples remaining dimensions uniformly. When the budget is smaller than the number of joint strata, it samples distinct joint strata uniformly; individual axes are not guaranteed to be marginally balanced.
 - `full_factorial` — covers every dimension cell. `replication` is `balanced` by default or `none` when `sample_size` must exactly equal the factorial size.
 - `random` — uniform random assignments. `with_replacement` defaults to `true`.
 

--- a/tests/test_test_set.py
+++ b/tests/test_test_set.py
@@ -18,6 +18,7 @@ from assert_ai.stages.stratification import (
     normalize_stratification,
 )
 from assert_ai.stages.test_set import (
+    _parse_kind_config,
     build_covering_array,
     build_generation_jobs,
     build_generation_prompt,
@@ -188,6 +189,154 @@ class CoveringArrayTest(unittest.TestCase):
         ca = build_covering_array(stratification, random.Random(42), axes=FACTOR_NAMES)
         drawn = sample_from_covering_array(ca, 4, random.Random(7))
         self.assertEqual(len(drawn), 4)
+
+
+class SamplingMethodsTest(unittest.TestCase):
+    def test_stratified_balances_requested_axes(self) -> None:
+        stratification = _make_stratification_with_behavior(2)
+        _, assignments = build_generation_jobs(
+            taxonomy=_make_policy(),
+            stratification=stratification,
+            sample_size=8,
+            sampling={"method": "stratified", "stratify_by": ["behavior", "domain"]},
+            rng=random.Random(7),
+        )
+        counts: dict[tuple[str, str], int] = {}
+        for row in assignments or []:
+            key = (row["behavior"], row["domain"])
+            counts[key] = counts.get(key, 0) + 1
+        self.assertEqual(set(counts.values()), {2})
+
+    def test_stratified_small_sample_does_not_expand_large_product(self) -> None:
+        stratification = {
+            "behavior": [{"name": f"behavior-{index}"} for index in range(100)],
+            **{
+                f"axis-{axis}": [{"name": f"level-{index}"} for index in range(100)]
+                for axis in range(10)
+            },
+        }
+        _, assignments = build_generation_jobs(
+            taxonomy=_make_policy(),
+            stratification=stratification,
+            sample_size=3,
+            sampling={
+                "method": "stratified",
+                "stratify_by": list(stratification),
+            },
+            rng=random.Random(7),
+        )
+        self.assertEqual(len(assignments or []), 3)
+
+    def test_full_factorial_covers_every_cell(self) -> None:
+        stratification = _make_stratification_with_behavior(2)
+        factorial_size = 2 ** 3
+        _, assignments = build_generation_jobs(
+            taxonomy=_make_policy(),
+            stratification=stratification,
+            sample_size=factorial_size,
+            sampling={"method": "full_factorial", "replication": "none"},
+            rng=random.Random(7),
+        )
+        rows = assignments or []
+        self.assertEqual(len(rows), factorial_size)
+        self.assertEqual(
+            len({tuple(sorted(row.items())) for row in rows}),
+            factorial_size,
+        )
+
+    def test_full_factorial_balances_replication(self) -> None:
+        stratification = _make_stratification_with_behavior(2)
+        _, assignments = build_generation_jobs(
+            taxonomy=_make_policy(),
+            stratification=stratification,
+            sample_size=10,
+            sampling={"method": "full_factorial"},
+            rng=random.Random(7),
+        )
+        counts: dict[tuple[tuple[str, str], ...], int] = {}
+        for row in assignments or []:
+            key = tuple(sorted(row.items()))
+            counts[key] = counts.get(key, 0) + 1
+        self.assertEqual(set(counts.values()), {1, 2})
+
+    def test_random_without_replacement_returns_unique_assignments(self) -> None:
+        _, assignments = build_generation_jobs(
+            taxonomy=_make_policy(),
+            stratification=_make_stratification_with_behavior(2),
+            sample_size=6,
+            sampling={"method": "random", "with_replacement": False},
+            rng=random.Random(7),
+        )
+        rows = assignments or []
+        self.assertEqual(len(rows), 6)
+        self.assertEqual(len({tuple(sorted(row.items())) for row in rows}), 6)
+
+    def test_random_with_replacement_allows_oversized_sample(self) -> None:
+        _, assignments = build_generation_jobs(
+            taxonomy=_make_policy(),
+            stratification=_make_stratification_with_behavior(2),
+            sample_size=9,
+            sampling={"method": "random", "with_replacement": True},
+            rng=random.Random(7),
+        )
+        self.assertEqual(len(assignments or []), 9)
+
+    def test_random_without_replacement_rejects_oversized_sample(self) -> None:
+        stratification = _make_stratification_with_behavior(2)
+        with self.assertRaisesRegex(ValueError, "factorial size"):
+            build_generation_jobs(
+                taxonomy=_make_policy(),
+                stratification=stratification,
+                sample_size=9,
+                sampling={"method": "random", "with_replacement": False},
+                rng=random.Random(7),
+            )
+
+    def test_stratified_rejects_unknown_axis(self) -> None:
+        with self.assertRaisesRegex(ValueError, "axis not found"):
+            build_generation_jobs(
+                taxonomy=_make_policy(),
+                stratification=_make_stratification_with_behavior(2),
+                sample_size=4,
+                sampling={"method": "stratified", "stratify_by": ["missing"]},
+                rng=random.Random(7),
+            )
+
+    def test_full_factorial_rejects_non_string_replication(self) -> None:
+        with self.assertRaisesRegex(ValueError, "replication"):
+            _parse_kind_config(
+                {"model": {"name": "azure/gpt-5.4-mini"}},
+                "prompt",
+                {
+                    "sampling": {
+                        "method": "full_factorial",
+                        "replication": ["balanced"],
+                    },
+                },
+                sample_size=100,
+                temperature=1.0,
+                max_tokens=3000,
+            )
+
+    def test_kind_config_parses_sampling(self) -> None:
+        parsed = _parse_kind_config(
+            {"model": {"name": "azure/gpt-5.4-mini"}},
+            "prompt",
+            {
+                "sample_size": 8,
+                "sampling": {
+                    "method": "stratified",
+                    "stratify_by": ["behavior", "domain"],
+                },
+            },
+            sample_size=100,
+            temperature=1.0,
+            max_tokens=3000,
+        )
+        self.assertEqual(
+            parsed["sampling"],
+            {"method": "stratified", "stratify_by": ["behavior", "domain"]},
+        )
 
 
 class FillTemplateTest(unittest.TestCase):

--- a/tests/test_test_set.py
+++ b/tests/test_test_set.py
@@ -225,7 +225,12 @@ class SamplingMethodsTest(unittest.TestCase):
             },
             rng=random.Random(7),
         )
-        self.assertEqual(len(assignments or []), 3)
+        rows = assignments or []
+        self.assertEqual(len(rows), 3)
+        self.assertEqual(
+            len({tuple(row[axis] for axis in stratification) for row in rows}),
+            3,
+        )
 
     def test_full_factorial_covers_every_cell(self) -> None:
         stratification = _make_stratification_with_behavior(2)
@@ -560,6 +565,27 @@ class BuildGenerationJobsTest(unittest.TestCase):
         counts = [job.count for job in jobs]
         self.assertEqual(counts.count(3), 3)
         self.assertEqual(counts.count(2), num_tuples - 3)
+
+    def test_pairwise_budget_above_array_size_replicates_fixed_assignments(self) -> None:
+        taxonomy = _make_policy()
+        stratification = _make_stratification_with_behavior(2)
+        ca = build_covering_array(
+            stratification,
+            random.Random(42),
+            axes=("behavior",) + FACTOR_NAMES,
+        )
+        _, assignments = build_generation_jobs(
+            taxonomy=taxonomy,
+            stratification=stratification,
+            sample_size=len(ca) * 2,
+            rng=random.Random(42),
+        )
+        assignment_counts: dict[tuple[tuple[str, str], ...], int] = {}
+        for row in assignments or []:
+            key = tuple(sorted(row.items()))
+            assignment_counts[key] = assignment_counts.get(key, 0) + 1
+        self.assertEqual(len(assignment_counts), len(ca))
+        self.assertEqual(set(assignment_counts.values()), {2})
 
     def test_generation_jobs_sample_size_smaller_than_array(self) -> None:
         """When sample_size < covering array, some tuples get 0 and are skipped."""

--- a/tests/test_test_set_stage.py
+++ b/tests/test_test_set_stage.py
@@ -149,6 +149,52 @@ class TestSetStageTest(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("meta", rows[0])
         self.assertNotIn("meta", rows[1])
 
+    async def test_missing_behavior_warning_is_sampling_method_aware(self) -> None:
+        async def fake_generate_structured(model, prompt, *, schema_name, json_schema, options):
+            del model, prompt, schema_name, json_schema, options
+            return ModelResponse(
+                parsed={"test_set": [{"description": "seed one"}]},
+                text="{}",
+                model="azure/gpt-5.4",
+            )
+
+        taxonomy_payload = {
+            "behavior": {"name": "Risk"},
+            "behavior_categories": [
+                {"name": "behavior-a", "definition": "definition-a"},
+                {"name": "behavior-b", "definition": "definition-b"},
+            ],
+        }
+
+        with TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            taxonomy_path = tmp_path / "taxonomy.json"
+            test_set_path = tmp_path / "test_set.jsonl"
+            taxonomy_path.write_text(json.dumps(taxonomy_payload), encoding="utf-8")
+
+            with (
+                patch("assert_ai.stages.test_set.generate_structured", new=fake_generate_structured),
+                self.assertLogs("assert_ai.stages.test_set", level="WARNING") as captured,
+            ):
+                await run_test_set(
+                    taxonomy_path=str(taxonomy_path),
+                    save_path=str(test_set_path),
+                    context=None,
+                    prompt={
+                        "model": "azure/gpt-5.4",
+                        "sample_size": 1,
+                        "temperature": None,
+                        "max_tokens": 1000,
+                        "sampling": {"method": "random", "with_replacement": True},
+                    },
+                    scenario=None,
+                    target=TargetConfig(model="azure/gpt-5.4"),
+                )
+
+        warning = "\n".join(captured.output)
+        self.assertIn("random does not guarantee category coverage", warning)
+        self.assertNotIn("To cover all categories, set sample_size", warning)
+
     async def test_run_test_set_omits_generated_system_prompts_when_target_prompt_is_fixed(self) -> None:
         async def fake_generate_structured(model, messages, *, schema_name, json_schema, options):
             del model, messages, schema_name, json_schema, options


### PR DESCRIPTION
## Summary
- preserve the existing pairwise IPOG strategy as the default
- add opt-in `stratified`, `full_factorial`, and `random` sampling for prompt and scenario test sets
- validate method-specific options and keep sampling changes in the test-set artifact cache key

## Configuration
```yaml
pipeline:
  test_set:
    prompt:
      sample_size: 100
      sampling:
        method: stratified
        stratify_by: [behavior]
```

Supported methods:
- `pairwise` (default)
- `stratified` with `stratify_by`
- `full_factorial` with `replication: balanced|none`
- `random` with `with_replacement: true|false`

## Validation
- full Python suite: 1,147 passed, 21 skipped
- pairwise assignments and generation jobs match current `main` exactly across multiple designs, budgets, and seeds
- randomized balance, coverage, uniqueness, determinism, invalid-config, and artifact-cache checks passed