### PR TITLE
fix(viewer): compare falls back to scenarios when a suite has no prompt samples

### DIFF
--- a/viewer/src/routes/suite/[suite_id]/compare/+page.server.ts
+++ b/viewer/src/routes/suite/[suite_id]/compare/+page.server.ts
@@ -29,6 +29,15 @@ export const load: PageServerLoad = async ({ params, url }) => {
 	const payload = loadComparePageData(suite_id, runIds, kind);
 	if (payload) return payload;
 
+	// Auto-fallback: the default kind is 'prompts', but a scenarios-only suite
+	// (no prompt samples) would otherwise 404. When the user did not explicitly
+	// pin a kind, fall back to scenarios so the comparison renders instead of
+	// erroring. (An explicit ?kind=scenarios keeps the empty-state handling below.)
+	if (kind === 'prompts') {
+		const scenariosPayload = loadComparePageData(suite_id, runIds, 'scenarios');
+		if (scenariosPayload) return scenariosPayload;
+	}
+
 	// Scenarios-mode empty state: when one or more runs have no scenario
 	// samples, we still want to render the toggle so the user can switch back
 	// to Prompts. Reuse the prompts payload for the shared metadata (runs,


### PR DESCRIPTION
## Problem

The suite **compare** route (`/suite/[suite_id]/compare`) defaults to `kind='prompts'`. For a **scenarios-only suite** (runs generated with scenario test cases only, no prompt-type cases), `loadComparePageData(..., 'prompts')` returns `null` because every run has zero prompt samples. The route then throws:

> 404 — One or more runs had no judged samples

…even though the runs have plenty of judged **scenario** samples. The comparison is effectively unreachable from the UI: the 404 page renders no kind toggle, so the only workaround is to hand-edit `?kind=scenarios` into the URL.

## Fix

When the default (`prompts`) lookup yields no payload **and the user did not explicitly pin a kind**, fall back to `scenarios` before erroring. Behavior is otherwise unchanged:

- Prompts-present suites: unchanged (prompts payload returned as before).
- Explicit `?kind=scenarios`: unchanged (existing empty-state handling with the back-to-Prompts toggle).
- Only when **both** kinds are empty do we still 404.

9-line change, all in `compare/+page.server.ts`.

## Verification

- Reproduced against a real scenarios-only suite (4 behaviors × baseline/prompted/acs): every compare link 404'd before, and returns **200** after the fix, with `policy_violation` + the custom dimension rendering.
- `npm run check` (svelte-check): **0 errors** (pre-existing a11y warnings only, in unrelated files).

## Notes for reviewers

Touches `viewer/` so it needs a viewer-codeowner review. This is a pure server-route guard change — no schema, no client changes.
