### PR TITLE
perf(judge): decouple judge fan-out from inference concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `pipeline.judge.concurrency`: pin how many transcripts the judge scores in parallel. See `docs/config/schema.md`.
 - ACS guardrail adapter (`assert-ai[acs]` extra): turn a completed run's findings into a deployable Agent Control Specification policy via `assert-ai acs generate`, validate it against known-bad examples with `assert-ai acs validate`, and re-run a target guarded with the `guard_target` Python API. See `docs/guides/securing-agents-with-acs.md`.
 - `assert-ai acs eval-config`: generate a small ASSERT config from an existing ACS manifest for regression/sanity checking an already-guarded target without requiring ACS runtime dependencies.
 
 ### Changed
+
+- The judge stage no longer inherits a low `pipeline.inference.concurrency`. That setting exists to protect targets that can't be driven in parallel; the judge only scores transcripts already written to `inference_set.jsonl`, so it now defaults to `max(pipeline.inference.concurrency, 10) // max(judge.n, 1)`. Configs that pin `pipeline.inference.concurrency` below 10 will see the judge stage run faster and issue more concurrent judge-model calls. Set `pipeline.judge.concurrency` to restore the previous fan-out if your judge model shares a rate limit or deployment with your target. The effective value is logged when the judge stage starts.
 
 ### Fixed
 

--- a/assert_ai/cli.py
+++ b/assert_ai/cli.py
@@ -703,8 +703,11 @@ cli.add_command(init)
     default=None,
     help=(
         "Override inference/judge fan-out for this run. Wins over "
-        "pipeline.inference.concurrency in the YAML. Defaults to the value in "
-        f"the config (or {DEFAULT_INFERENCE_CONCURRENCY} if unset)."
+        "pipeline.inference.concurrency and pipeline.judge.concurrency in the "
+        "YAML. Without this flag, inference defaults to the config value (or "
+        f"{DEFAULT_INFERENCE_CONCURRENCY} if unset) and the judge — which "
+        "never calls your target — defaults to "
+        f"max(inference.concurrency, {DEFAULT_INFERENCE_CONCURRENCY})."
     ),
     show_envvar=True,
 )

--- a/assert_ai/config.py
+++ b/assert_ai/config.py
@@ -831,7 +831,7 @@ def parse_pipeline_config(raw: dict[str, Any]) -> PipelineConfig | None:
             scorer_stage,
             field_name="pipeline.judge",
             allowed={"model", "n", "dimensions", "disabled_dimensions", "inference_set_path", "taxonomy_path", "save_dir",
-                       "enabled", "file_path", "preset"},
+                       "enabled", "file_path", "preset", "concurrency"},
         )
         if judge_enabled:
             model_raw = scorer_stage.get("model", default_model_raw)
@@ -873,6 +873,10 @@ def parse_pipeline_config(raw: dict[str, Any]) -> PipelineConfig | None:
                 n=_coalesce(_optional_int(scorer_stage.get("n"), field_name="pipeline.judge.n"), 1),
                 dimensions=dimensions,
                 disabled_dimensions=disabled_dimensions,
+                concurrency=_optional_int(
+                    scorer_stage.get("concurrency"),
+                    field_name="pipeline.judge.concurrency",
+                ),
             )
 
     evaluation = None

--- a/assert_ai/core/config_model.py
+++ b/assert_ai/core/config_model.py
@@ -219,12 +219,17 @@ class JudgeConfig:
     n: int = 1
     dimensions: list[dict[str, Any]] = field(default_factory=list)
     disabled_dimensions: list[str] = field(default_factory=list)
+    # ``None`` means "derive from inference.concurrency" — see
+    # ``EvaluationConfig.judge_concurrency``.
+    concurrency: int | None = None
 
     def __post_init__(self) -> None:
         if isinstance(self.model, str):
             self.model = ModelConfig(name=self.model)
         if self.n <= 0:
             raise ValueError("judge.n must be > 0")
+        if self.concurrency is not None and self.concurrency <= 0:
+            raise ValueError("judge.concurrency must be > 0")
         if not isinstance(self.dimensions, list):
             raise ValueError("judge.dimensions must be a list")
         for dimension in self.dimensions:
@@ -245,6 +250,35 @@ class EvaluationConfig:
     judge: JudgeConfig | None = None
     tester: TesterConfig | None = None
     inference: InferenceConfig = field(default_factory=InferenceConfig)
+
+    @property
+    def judge_concurrency(self) -> int:
+        """Number of transcripts the judge scores in parallel.
+
+        ``inference.concurrency`` throttles calls into the *target* — users
+        lower it (often to 1) because their agent, tracer, or tool backend
+        can't be driven in parallel. The judge never touches the target: it
+        makes stateless LLM calls over transcripts that already exist on
+        disk. Inheriting the target's limit therefore serialized scoring for
+        no reason.
+
+        Explicit ``pipeline.judge.concurrency`` always wins and is used
+        verbatim. Otherwise the default is derived from
+        ``max(inference.concurrency, DEFAULT_INFERENCE_CONCURRENCY)`` so
+        target-constrained configs get the normal default while configs that
+        deliberately widened inference fan-out keep their higher value.
+
+        The derived default is divided by ``judge.n`` because each scored row
+        fans out into ``judge.n`` concurrent model calls that the stage
+        semaphore does not bound (``core/judge.py`` gathers them per row).
+        Without this, ``judge.n=3`` would put 30 calls in flight against a
+        deployment the user may have throttled to 1.
+        """
+        if self.judge is not None and self.judge.concurrency is not None:
+            return self.judge.concurrency
+        budget = max(self.inference.concurrency, DEFAULT_INFERENCE_CONCURRENCY)
+        samples_per_row = max(1, self.judge.n) if self.judge is not None else 1
+        return max(1, budget // samples_per_row)
 
 
 @dataclass

--- a/assert_ai/internal_pipeline_prompts/init_system.md
+++ b/assert_ai/internal_pipeline_prompts/init_system.md
@@ -344,6 +344,10 @@ pipeline:
           false = Agent selected the appropriate tool.
     # model: ...                # optional — uncomment to override default_model for the judge
     n: 1                        # optional — judge repetitions for consensus
+    # concurrency: 10           # optional — transcripts scored in parallel.
+                                # Defaults to max(inference.concurrency, 10) // max(n, 1).
+                                # Pin it when the judge model shares a rate limit
+                                # or deployment with the target.
 ```
 
 ### Rubric format

--- a/assert_ai/runner.py
+++ b/assert_ai/runner.py
@@ -625,12 +625,20 @@ def run_pipeline(
     # widened or narrowed without editing the config. We mutate the live
     # InferenceConfig instance (it's a regular dataclass, not frozen) because
     # downstream stages read `ctx["evaluation"].inference.concurrency` directly.
+    # The flag is documented as covering inference *and* judge fan-out, so it
+    # also pins judge.concurrency explicitly — otherwise the judge would fall
+    # back to its own default and silently ignore the flag.
     if concurrency is not None:
         evaluation = ctx.get("evaluation")
         inference_cfg = getattr(evaluation, "inference", None) if evaluation is not None else None
+        judge_cfg = getattr(evaluation, "judge", None) if evaluation is not None else None
+        if judge_cfg is not None:
+            judge_cfg.concurrency = concurrency
         if inference_cfg is not None:
             inference_cfg.concurrency = concurrency
             log.info(f"[runner] Concurrency override: {concurrency} (CLI --concurrency)")
+        elif judge_cfg is not None:
+            log.info(f"[runner] Judge concurrency override: {concurrency} (CLI --concurrency)")
         else:
             log.warning(
                 "[runner] --concurrency ignored: this config has no inference stage to override."

--- a/assert_ai/stages/judge.py
+++ b/assert_ai/stages/judge.py
@@ -388,7 +388,14 @@ async def run_judge(
         if (str(row.get("type") or ""), str(row.get("test_case_id", ""))) not in completed_keys
     ]
 
-    semaphore = asyncio.Semaphore(max(1, min(evaluation.inference.concurrency, len(pending) or 1)))
+    judge_fan_out = evaluation.judge_concurrency
+    semaphore = asyncio.Semaphore(max(1, min(judge_fan_out, len(pending) or 1)))
+    if pending:
+        samples_note = f" x {judge_n} samples/row" if judge_n > 1 else ""
+        log.info(
+            f"[judge] Scoring {len(pending)} row(s) at fan-out {judge_fan_out}"
+            f"{samples_note} (override with pipeline.judge.concurrency)"
+        )
 
     async def guard(item: tuple[int, dict[str, Any]]) -> dict[str, Any]:
         async with semaphore:

--- a/docs/config/schema.md
+++ b/docs/config/schema.md
@@ -200,7 +200,7 @@ Accepted keys:
 - `tester` — mapping. Optional.
   - `model` — model config. Optional when `default_model` is set.
 - `max_turns` — positive integer. Default: `10`.
-- `concurrency` — positive integer. Default: `10`.
+- `concurrency` — positive integer. Default: `10`. Bounds concurrent calls into the **target**. It also seeds the judge stage's default fan-out (see `pipeline.judge.concurrency`), but never lowers it below `10`.
 - `max_tool_calls` — positive integer. Default: `10`.
 - `tool_timeout_s` — optional positive number.
 - `startup_timeout_s` — optional positive number.
@@ -269,6 +269,11 @@ Accepted keys:
   - `scale` — optional ordered custom scale. Set `type: ordinal` and map at least two integer or string grade values to non-empty labels under `values`. All grade values must use the same type, and mapping order defines grade order. Without `scale`, the dimension remains boolean.
 - `model` — model config. Required unless `default_model` is set.
 - `n` — positive integer. Default: `1`.
+- `concurrency` — positive integer. Optional. How many transcripts to score in parallel. Defaults to `max(pipeline.inference.concurrency, 10) // max(judge.n, 1)`.
+
+  The judge never calls your target — it scores transcripts already written to `inference_set.jsonl` — so a low `pipeline.inference.concurrency` set to protect a target that can't be driven in parallel does not hold the judge back. A higher `pipeline.inference.concurrency` is still inherited. The `judge.n` divisor exists because each scored row fans out into `n` concurrent model calls that this setting does not bound.
+
+  **Set this explicitly when the judge model shares a rate limit or deployment with your target**, or when you want scoring pinned to a specific fan-out. The `--concurrency` CLI flag overrides both stages. The effective value is logged at the start of the judge stage.
 - `preset` — optional string or list of strings. Loads judge dimension presets; inline `dimensions` override preset dimensions with the same name.
 
 Compatibility note:

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -594,6 +594,11 @@ def main(argv: list[str] | None = None) -> int:
         exit_code = run_pipeline(
             config=str(target_config),
             force_stages=list(args.force_stage),
+            # Pin BOTH stages explicitly. Writing only
+            # pipeline.inference.concurrency would leave the judge on its own
+            # derived default, so a sweep point below that default would be
+            # recorded under a concurrency it never actually ran at.
+            concurrency=args.concurrency,
         )
     except SystemExit as exc:
         exit_code = int(exc.code) if exc.code is not None else 1

--- a/scripts/turn_checkpoint_judge.py
+++ b/scripts/turn_checkpoint_judge.py
@@ -185,7 +185,25 @@ def load_checkpoint_judge_config(
             int(inference_stage_raw["concurrency"]),
             field_name="pipeline.inference.concurrency",
         )
-    concurrency = concurrency_override if concurrency_override is not None else inference_concurrency
+    # This script only ever calls the judge model, so it follows the same rule
+    # as the judge stage: an explicit pipeline.judge.concurrency wins verbatim,
+    # and otherwise a target-protecting pipeline.inference.concurrency must not
+    # throttle scoring below the normal default. The derived default is divided
+    # by judge_n because each scored row fans out into judge_n concurrent model
+    # calls (see assert_ai/core/judge.py), which this limit does not bound.
+    judge_concurrency_raw = (
+        judge_stage_raw.get("concurrency") if isinstance(judge_stage_raw, dict) else None
+    )
+    if judge_concurrency_raw is not None:
+        default_concurrency = _require_positive_int(
+            int(judge_concurrency_raw),
+            field_name="pipeline.judge.concurrency",
+        )
+    else:
+        default_concurrency = max(
+            1, max(inference_concurrency, DEFAULT_INFERENCE_CONCURRENCY) // max(1, judge_n)
+        )
+    concurrency = concurrency_override if concurrency_override is not None else default_concurrency
     if concurrency <= 0:
         raise ValueError("concurrency must be > 0")
 

--- a/tests/test_judge_concurrency.py
+++ b/tests/test_judge_concurrency.py
@@ -1,0 +1,224 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""The judge stage must not be throttled by a target-protecting inference limit."""
+
+import unittest
+
+from assert_ai.config import ConfigError, load_runtime_context
+from assert_ai.core.config_model import (
+    DEFAULT_INFERENCE_CONCURRENCY,
+    EvaluationConfig,
+    InferenceConfig,
+    JudgeConfig,
+    ModelConfig,
+)
+from assert_ai.stages import STAGES
+
+
+def _evaluation(
+    inference_concurrency: int,
+    judge_concurrency: int | None = None,
+    judge_n: int = 1,
+):
+    return EvaluationConfig(
+        judge=JudgeConfig(
+            model=ModelConfig(name="azure/gpt-5.4"),
+            concurrency=judge_concurrency,
+            n=judge_n,
+        ),
+        inference=InferenceConfig(concurrency=inference_concurrency),
+    )
+
+
+class JudgeConcurrencyTest(unittest.TestCase):
+    def test_low_inference_concurrency_does_not_serialize_the_judge(self) -> None:
+        # inference.concurrency=1 protects a target that can't be driven in
+        # parallel. The judge only reads transcripts off disk, so it keeps
+        # the normal default.
+        self.assertEqual(
+            _evaluation(1).judge_concurrency, DEFAULT_INFERENCE_CONCURRENCY
+        )
+
+    def test_high_inference_concurrency_is_still_inherited(self) -> None:
+        self.assertEqual(_evaluation(24).judge_concurrency, 24)
+
+    def test_explicit_judge_concurrency_wins(self) -> None:
+        self.assertEqual(_evaluation(24, judge_concurrency=2).judge_concurrency, 2)
+        self.assertEqual(_evaluation(1, judge_concurrency=32).judge_concurrency, 32)
+
+    def test_default_is_divided_by_judge_n(self) -> None:
+        # core/judge.py fires judge.n concurrent calls per row INSIDE the stage
+        # semaphore, so the derived default must account for them or a
+        # deployment throttled to 1 would see n x fan-out calls in flight.
+        self.assertEqual(_evaluation(1, judge_n=3).judge_concurrency, 3)
+        self.assertEqual(_evaluation(24, judge_n=3).judge_concurrency, 8)
+        self.assertEqual(_evaluation(1, judge_n=25).judge_concurrency, 1)
+
+    def test_explicit_judge_concurrency_is_not_divided_by_judge_n(self) -> None:
+        self.assertEqual(
+            _evaluation(1, judge_concurrency=6, judge_n=3).judge_concurrency, 6
+        )
+
+    def test_judge_concurrency_must_be_positive(self) -> None:
+        with self.assertRaisesRegex(ValueError, "judge.concurrency must be > 0"):
+            JudgeConfig(model=ModelConfig(name="m"), concurrency=0)
+
+    def test_evaluation_without_judge_still_resolves(self) -> None:
+        evaluation = EvaluationConfig(inference=InferenceConfig(concurrency=3))
+        self.assertEqual(evaluation.judge_concurrency, DEFAULT_INFERENCE_CONCURRENCY)
+
+
+class JudgeConcurrencyConfigParsingTest(unittest.TestCase):
+    def _context(self, judge_extra: dict) -> EvaluationConfig:
+        raw = {
+            "suite": "s",
+            "run": "r",
+            "behavior": {"name": "b", "description": "d"},
+            "default_model": {"name": "azure/gpt-5.4"},
+            "pipeline": {
+                "inference": {
+                    "concurrency": 1,
+                    "target": {"system_prompt": "p"},
+                },
+                "judge": {
+                    "dimensions": {
+                        "policy_violation": {
+                            "description": "d",
+                            "rubric": "true = x\nfalse = y",
+                        }
+                    },
+                    **judge_extra,
+                },
+            },
+        }
+        ctx = load_runtime_context(raw, "eval_config.yaml", stage_modules=STAGES)
+        return ctx["evaluation"]
+
+    def test_yaml_judge_concurrency_is_parsed(self) -> None:
+        self.assertEqual(self._context({"concurrency": 6}).judge_concurrency, 6)
+
+    def test_yaml_default_decouples_from_inference(self) -> None:
+        evaluation = self._context({})
+        self.assertEqual(evaluation.inference.concurrency, 1)
+        self.assertEqual(evaluation.judge_concurrency, DEFAULT_INFERENCE_CONCURRENCY)
+
+    def test_invalid_judge_concurrency_is_rejected(self) -> None:
+        with self.assertRaises((ValueError, ConfigError)):
+            self._context({"concurrency": 0})
+
+
+class BenchmarkScriptConcurrencyTest(unittest.TestCase):
+    """scripts/benchmark.py records a (test_set, concurrency) data point.
+
+    It writes only pipeline.inference.concurrency into the generated config, so
+    it must also pass --concurrency to run_pipeline; otherwise the judge runs on
+    its derived default and the recorded point is labelled with a fan-out the
+    run never used.
+    """
+
+    def test_benchmark_pins_both_stages_via_run_pipeline(self) -> None:
+        import ast
+        from pathlib import Path
+
+        source = Path(__file__).resolve().parents[1] / "scripts" / "benchmark.py"
+        tree = ast.parse(source.read_text(encoding="utf-8"))
+        calls = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and getattr(node.func, "id", getattr(node.func, "attr", None)) == "run_pipeline"
+        ]
+        self.assertTrue(calls, "benchmark.py no longer calls run_pipeline")
+        for call in calls:
+            self.assertIn(
+                "concurrency",
+                [kw.arg for kw in call.keywords],
+                f"run_pipeline call at line {call.lineno} must pass concurrency=",
+            )
+
+
+class CheckpointJudgeParityTest(unittest.TestCase):
+    """scripts/turn_checkpoint_judge.py only ever calls the judge model.
+
+    It resolves its own fan-out instead of using EvaluationConfig, so the two
+    implementations must agree or the script silently drifts from the stage.
+    This exercises the REAL loader, not a reimplementation of it.
+    """
+
+    @staticmethod
+    def _load_script_module():
+        import importlib.util
+        import sys
+        from pathlib import Path
+
+        path = Path(__file__).resolve().parents[1] / "scripts" / "turn_checkpoint_judge.py"
+        spec = importlib.util.spec_from_file_location("_tcj_parity", path)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules["_tcj_parity"] = module
+        spec.loader.exec_module(module)
+        return module
+
+    def test_checkpoint_loader_matches_evaluation_judge_concurrency(self) -> None:
+        import tempfile
+        from pathlib import Path
+
+        import yaml
+
+        script = self._load_script_module()
+        cases = [
+            # (inference.concurrency, judge.n, explicit judge.concurrency)
+            (1, 1, None),
+            (1, 3, None),
+            (24, 1, None),
+            (24, 3, None),
+            (1, 25, None),
+            (1, 3, 6),
+            (24, 1, 2),
+        ]
+        for inference_concurrency, judge_n, judge_concurrency in cases:
+            with self.subTest(inference=inference_concurrency, n=judge_n, judge=judge_concurrency):
+                judge_stage: dict[str, object] = {
+                    "n": judge_n,
+                    "model": {"name": "azure/gpt-5.4"},
+                    "dimensions": {
+                        "policy_violation": {
+                            "description": "d",
+                            "rubric": "true = x\nfalse = y",
+                        }
+                    },
+                }
+                if judge_concurrency is not None:
+                    judge_stage["concurrency"] = judge_concurrency
+
+                expected = EvaluationConfig(
+                    judge=JudgeConfig(
+                        model=ModelConfig(name="azure/gpt-5.4"),
+                        n=judge_n,
+                        concurrency=judge_concurrency,
+                    ),
+                    inference=InferenceConfig(concurrency=inference_concurrency),
+                ).judge_concurrency
+
+                with tempfile.TemporaryDirectory() as tmp:
+                    config_path = Path(tmp) / "config.yaml"
+                    config_path.write_text(
+                        yaml.safe_dump(
+                            {
+                                "pipeline": {
+                                    "inference": {"concurrency": inference_concurrency},
+                                    "judge": judge_stage,
+                                }
+                            },
+                            sort_keys=False,
+                        ),
+                        encoding="utf-8",
+                    )
+                    resolved = script.load_checkpoint_judge_config(config_path)
+
+                self.assertEqual(resolved.concurrency, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_turn_checkpoint_judge.py
+++ b/tests/test_turn_checkpoint_judge.py
@@ -108,7 +108,20 @@ class TurnCheckpointJudgeTest(unittest.IsolatedAsyncioTestCase):
         inference_concurrency = checkpoint_judge.DEFAULT_INFERENCE_CONCURRENCY
         if isinstance(inference_stage_raw, dict) and inference_stage_raw.get("concurrency") is not None:
             inference_concurrency = int(inference_stage_raw["concurrency"])
-        concurrency = concurrency_override if concurrency_override is not None else inference_concurrency
+        # Mirrors load_checkpoint_judge_config: explicit pipeline.judge.concurrency
+        # wins verbatim, otherwise a target-protecting inference limit must not
+        # throttle judge-only scoring below the default, divided by judge_n
+        # because each row fans out into judge_n concurrent calls.
+        judge_concurrency_raw = judge_stage_raw.get("concurrency")
+        if judge_concurrency_raw is not None:
+            default_concurrency = int(judge_concurrency_raw)
+        else:
+            default_concurrency = max(
+                1,
+                max(inference_concurrency, checkpoint_judge.DEFAULT_INFERENCE_CONCURRENCY)
+                // max(1, judge_n),
+            )
+        concurrency = concurrency_override if concurrency_override is not None else default_concurrency
         self.assertGreater(concurrency, 0)
 
         return checkpoint_judge.CheckpointJudgeConfig(


### PR DESCRIPTION
## Problem

The judge stage sized its semaphore from `pipeline.inference.concurrency`:

```python
semaphore = asyncio.Semaphore(max(1, min(evaluation.inference.concurrency, len(pending) or 1)))
```

That setting exists to throttle calls into the *target*. Configs lower it, often to 1, because the agent, tracer, or tool backend under evaluation cannot be driven in parallel. The judge never touches the target: it scores transcripts already written to `inference_set.jsonl` and makes stateless calls to the judge model. It was inheriting a limit for a reason that does not apply to it.

15 shipped example configs pin `inference.concurrency` below 10, including the flagship `examples/travel_planner_langgraph/eval_config.yaml` (`concurrency: 1`) and every `examples/phoenix_auto_trace/*` template. All of them were scoring one transcript at a time.

## Fix

`EvaluationConfig.judge_concurrency` resolves in this order:

1. explicit `pipeline.judge.concurrency`, used verbatim
2. otherwise `max(inference.concurrency, 10) // max(judge.n, 1)`

A config that deliberately widened inference fan-out (the incident-triage examples use 24) keeps its higher value. A config that pinned it low to protect a target gets the normal default back.

The `judge.n` divisor is load-bearing. `core/judge.py` gathers `judge.n` concurrent calls per row *inside* the stage semaphore, so fan-out is really `judge_concurrency × judge.n`. Without the divisor, `inference.concurrency: 1` with `judge.n: 3` would put 30 calls in flight against a deployment the user throttled to 1. Explicit values are not divided, on the assumption that someone setting the number directly means it.

The effective value is logged when the stage starts, so this is visible per run rather than something you infer from timings:

```
[judge] Scoring 12 row(s) at fan-out 3 x 3 samples/row (override with pipeline.judge.concurrency)
```

Two sibling call sites resolved fan-out the same wrong way and are fixed here too:

- `scripts/benchmark.py` wrote only `pipeline.inference.concurrency` into its generated config and never passed `--concurrency` to `run_pipeline`, so a sweep at `--concurrency 1` would have run the judge at 10 while recording the point as 1.
- `scripts/turn_checkpoint_judge.py` derived its own limit from `pipeline.inference.concurrency` and ignored both the new key and the divisor.

## Impact

`examples/prompt_agents/health_assistant.yaml` with `inference.concurrency: 1`, 10 transcripts, judge on `azure/gpt-5.4`. Suite artifacts were generated once and shared, so both arms scored identical inference sets:

| | before | after |
|---|---|---|
| judge stage | 96.7s / 103.3s | 15.0s / 13.9s |
| inference stage | 208.7s / 209.8s | 208.0s / 209.4s |
| end to end | 306.9s | 224.3s |

Judged output is unchanged. Fan-out is not part of `_judge_config_fingerprint`, so cached `scores.jsonl` stays valid and resume behavior is untouched.

The behavior change is recorded under `### Changed` in `CHANGELOG.md`, since anyone who pinned `inference.concurrency` low will now see more concurrent judge-model calls. If your judge model shares a rate limit or deployment with your target, set `pipeline.judge.concurrency` to restore the old fan-out.

## Validation

- `pytest tests/ -x -q`: 1144 passed, 70 skipped, 481 subtests
- Wheel-install subset (`test_import_smoke.py`, `test_library_loader.py`, `--import-mode=importlib`): 17 passed
- `python -m build`: wheel and sdist produced
- `uv.lock` unchanged, no dependencies added
- New `tests/test_judge_concurrency.py` (12 tests): resolution order, the `judge.n` divisor, YAML wiring, and a parity test that drives the real `load_checkpoint_judge_config` across 7 cases and asserts it agrees with `EvaluationConfig.judge_concurrency`. That test fails on the pre-fix tree.
- Semaphore verified end to end with a spy: `inference=1, n=1` gives 10; `inference=1, n=3` gives 3; explicit `judge.concurrency=6, n=3` gives 6.

## Notes for reviewers

The number to argue with is the default. Raising fan-out from 1 to 10 still concentrates calls on a deployment that may be shared with the target, and `inference.concurrency` is genuinely overloaded: it can mean "my target is single threaded" or "my quota is small." I went with the faster default plus a logged value, a changelog entry, and a one-line opt-out. Inverting it to opt-in is a small change if you would rather ship conservative.

I also prototyped sharding the taxonomy conversion in `systematization_convert.py`, which measured 2.1x on that stage, and dropped it. It violates three instructions the converter prompt states directly: the category count is soft ("or fewer if the behavior doesn't warrant that many"), line 25 says "Do not expand beyond the source to fill space," and cross-pattern merging plus global ordering both need the model to see every pattern at once. `taxonomy.json` feeds 12 modules and is cached per suite, so that was trading the quality of the measurement instrument for time on a stage that runs once. Happy to write it up separately if there is appetite for a contract-faithful version.
