### PR TITLE
docs: CI gate entry point, acs CLI reference, and two missing target rungs

### DIFF
--- a/.claude/skills/run-assert-eval/SKILL.md
+++ b/.claude/skills/run-assert-eval/SKILL.md
@@ -77,8 +77,8 @@ Help the user set the right target in the config:
   use `target.model` and `target.tools`.
 - **Pre-collected traces** (no live inference needed):
   use `assert-ai judge-traces --traces <path> --config <path>`; do not add a `--trace` flag to `assert-ai run`.
-- **Black-box HTTP endpoint** you cannot instrument:
-  write a thin Python callable shim that calls the endpoint, use it as `target.callable` with no `target.trace`, and state that the judge sees only final text. This is a fallback, not the recommended path.
+- **Black-box HTTP endpoint** you cannot import as Python:
+  use `target.endpoint` — the runtime POSTs `{"message": ..., "history": [...]}` and reads `{"response": ...}`, so no wrapper code is needed (requires `aiohttp`). Only write a thin `target.callable` shim if the service's request/response shape differs. Either way the judge sees only final text, so this is a fallback, not the recommended path.
 
 ### 3. Run the pipeline
 

--- a/.claude/skills/run-assert-eval/SKILL.md
+++ b/.claude/skills/run-assert-eval/SKILL.md
@@ -76,7 +76,9 @@ Help the user set the right target in the config:
 - **Hosted model** with a system prompt and optional tools:
   use `target.model` and `target.tools`.
 - **Pre-collected traces** (no live inference needed):
-  use `assert-ai judge-traces --traces <path> --config <path>`.
+  use `assert-ai judge-traces --traces <path> --config <path>`; do not add a `--trace` flag to `assert-ai run`.
+- **Black-box HTTP endpoint** you cannot instrument:
+  write a thin Python callable shim that calls the endpoint, use it as `target.callable` with no `target.trace`, and state that the judge sees only final text. This is a fallback, not the recommended path.
 
 ### 3. Run the pipeline
 
@@ -136,6 +138,14 @@ Suggest it specifically when the user wants to:
 - **watch a run in progress** → viewer live run monitor (`manifest.json`-driven)
 
 See `docs/guides/use-local-viewer.md` for the full layout.
+
+### 6. Hand off to CI
+
+Once the eval is passing locally and the user wants it enforced on PRs, hand off to the `wire-assert-ci` skill. Do not author CI wiring here; direct the user or agent to the action bootstrap:
+
+```
+read https://raw.githubusercontent.com/responsibleai/assert-action/main/ONBOARD.md
+```
 
 ## Output format
 

--- a/.claude/skills/run-assert-eval/SKILL.md
+++ b/.claude/skills/run-assert-eval/SKILL.md
@@ -45,7 +45,8 @@ runs*, or *watch a live run*.
    python -m pip install "assert-ai[otel]"
    ```
    Add route-specific extras as needed, for example `assert-ai[otel,langgraph]`
-   for LangGraph or `assert-ai[aiohttp]` for `target.endpoint`. Use
+   for LangGraph. `target.endpoint` needs `aiohttp`, which ships transitively via
+   `litellm`'s own dependency — no separate extra to install. Use
    `pip install -e ".[otel,langgraph]"` **only** when the working directory is a
    clone of the ASSERT repo itself; inside a customer repo it installs the wrong
    package.

--- a/.claude/skills/run-assert-eval/SKILL.md
+++ b/.claude/skills/run-assert-eval/SKILL.md
@@ -39,10 +39,16 @@ runs*, or *watch a live run*.
 
 ## Preconditions (check, don't assume)
 
-1. **ASSERT installed**: `assert-ai --help` succeeds. If not, guide install:
+1. **ASSERT installed**: `assert-ai --help` succeeds. If not, guide install from
+   PyPI — not an editable install of the user's own repo:
    ```
-   python -m pip install -e ".[otel,langgraph]"
+   python -m pip install "assert-ai[otel]"
    ```
+   Add route-specific extras as needed, for example `assert-ai[otel,langgraph]`
+   for LangGraph or `assert-ai[aiohttp]` for `target.endpoint`. Use
+   `pip install -e ".[otel,langgraph]"` **only** when the working directory is a
+   clone of the ASSERT repo itself; inside a customer repo it installs the wrong
+   package.
 
 2. **Provider creds exist** in `.env`. NEVER read or print `.env`. If a run fails
    with an auth error, tell the user which variable NAMES are required

--- a/.claude/skills/run-assert-eval/SKILL.md
+++ b/.claude/skills/run-assert-eval/SKILL.md
@@ -144,7 +144,7 @@ See `docs/guides/use-local-viewer.md` for the full layout.
 Once the eval is passing locally and the user wants it enforced on PRs, hand off to the `wire-assert-ci` skill. Do not author CI wiring here; direct the user or agent to the action bootstrap:
 
 ```
-read https://raw.githubusercontent.com/responsibleai/assert-action/main/ONBOARD.md
+read https://raw.githubusercontent.com/changliu2/assert-ai-action/main/ONBOARD.md
 ```
 
 ## Output format

--- a/.claude/skills/run-assert-eval/SKILL.md
+++ b/.claude/skills/run-assert-eval/SKILL.md
@@ -150,7 +150,7 @@ See `docs/guides/use-local-viewer.md` for the full layout.
 Once the eval is passing locally and the user wants it enforced on PRs, hand off to the `wire-assert-ci` skill. Do not author CI wiring here; direct the user or agent to the action bootstrap:
 
 ```
-read https://raw.githubusercontent.com/changliu2/assert-ai-action/main/ONBOARD.md
+read https://raw.githubusercontent.com/responsibleai/assert-ai-action/main/ONBOARD.md
 ```
 
 ## Output format

--- a/.cursor/rules/assert.mdc
+++ b/.cursor/rules/assert.mdc
@@ -58,7 +58,11 @@ stepping with citations highlighted). Answer in chat for "what / why / which"; h
 - **Framework agent** (LangGraph, CrewAI, etc.) with a Python entry function: `target.callable`
   WITH `target.trace` so the judge can cite tool calls and routing.
 - **Hosted model** with a system prompt and optional tools: `target.model` and `target.tools`.
-- **Pre-collected traces** (no live inference): `assert-ai judge-traces --traces <path> --config <path>`.
+- **Pre-collected traces** (no live inference): `assert-ai judge-traces --traces <path> --config <path>`;
+  do not add a `--trace` flag to `assert-ai run`.
+- **Black-box HTTP endpoint** you cannot instrument: write a thin Python callable shim that calls the
+  endpoint, use it as `target.callable` with no `target.trace`, and state that the judge sees only
+  final text. This is a fallback, not the recommended path.
 
 ### 3. Run the pipeline
 
@@ -99,6 +103,14 @@ highlighted. Suggest it when the user wants to **read a full transcript / see th
 drawer), **compare against a baseline** (viewer compare view, or `assert-ai results compare <suite>
 <runA> <runB>`), or **watch a run in progress** (live run monitor). See
 `docs/guides/use-local-viewer.md` for the layout.
+
+### 6. Hand off to CI
+
+Once the eval is passing locally and the user wants it enforced on PRs, hand off to the `wire-assert-ci` skill. Do not author CI wiring here; direct the user or agent to the action bootstrap:
+
+```
+read https://raw.githubusercontent.com/responsibleai/assert-action/main/ONBOARD.md
+```
 
 ### Output format
 

--- a/.cursor/rules/assert.mdc
+++ b/.cursor/rules/assert.mdc
@@ -60,9 +60,11 @@ stepping with citations highlighted). Answer in chat for "what / why / which"; h
 - **Hosted model** with a system prompt and optional tools: `target.model` and `target.tools`.
 - **Pre-collected traces** (no live inference): `assert-ai judge-traces --traces <path> --config <path>`;
   do not add a `--trace` flag to `assert-ai run`.
-- **Black-box HTTP endpoint** you cannot instrument: write a thin Python callable shim that calls the
-  endpoint, use it as `target.callable` with no `target.trace`, and state that the judge sees only
-  final text. This is a fallback, not the recommended path.
+- **Black-box HTTP endpoint** you cannot import as Python: use `target.endpoint` — the runtime POSTs
+  `{"message": ..., "history": [...]}` and reads `{"response": ...}`, so no wrapper code is needed
+  (requires `aiohttp`). Only write a thin `target.callable` shim if the service's request/response
+  shape differs. Either way the judge sees only final text, so this is a fallback, not the
+  recommended path.
 
 ### 3. Run the pipeline
 

--- a/.cursor/rules/assert.mdc
+++ b/.cursor/rules/assert.mdc
@@ -111,7 +111,7 @@ drawer), **compare against a baseline** (viewer compare view, or `assert-ai resu
 Once the eval is passing locally and the user wants it enforced on PRs, hand off to the `wire-assert-ci` skill. Do not author CI wiring here; direct the user or agent to the action bootstrap:
 
 ```
-read https://raw.githubusercontent.com/responsibleai/assert-action/main/ONBOARD.md
+read https://raw.githubusercontent.com/changliu2/assert-ai-action/main/ONBOARD.md
 ```
 
 ### Output format

--- a/.cursor/rules/assert.mdc
+++ b/.cursor/rules/assert.mdc
@@ -111,7 +111,7 @@ drawer), **compare against a baseline** (viewer compare view, or `assert-ai resu
 Once the eval is passing locally and the user wants it enforced on PRs, hand off to the `wire-assert-ci` skill. Do not author CI wiring here; direct the user or agent to the action bootstrap:
 
 ```
-read https://raw.githubusercontent.com/changliu2/assert-ai-action/main/ONBOARD.md
+read https://raw.githubusercontent.com/responsibleai/assert-ai-action/main/ONBOARD.md
 ```
 
 ### Output format

--- a/.github/prompts/run-assert-eval.prompt.md
+++ b/.github/prompts/run-assert-eval.prompt.md
@@ -56,7 +56,7 @@ Help the user set the right target in the config:
 - **Framework agent** (LangGraph, CrewAI, etc.) with a Python entry function: use `target.callable` WITH `target.trace` so the judge can cite tool calls and routing.
 - **Hosted model** with a system prompt and optional tools: use `target.model` and `target.tools`.
 - **Pre-collected traces** (no live inference needed): use `assert-ai judge-traces --traces <path> --config <path>`; do not add a `--trace` flag to `assert-ai run`.
-- **Black-box HTTP endpoint** you cannot instrument: write a thin Python callable shim that calls the endpoint, use it as `target.callable` with no `target.trace`, and state that the judge sees only final text. This is a fallback, not the recommended path.
+- **Black-box HTTP endpoint** you cannot import as Python: use `target.endpoint` — the runtime POSTs `{"message": ..., "history": [...]}` and reads `{"response": ...}`, so no wrapper code is needed (requires `aiohttp`). Only write a thin `target.callable` shim if the service's request/response shape differs. Either way the judge sees only final text, so this is a fallback, not the recommended path.
 
 ### 3. Run the pipeline
 

--- a/.github/prompts/run-assert-eval.prompt.md
+++ b/.github/prompts/run-assert-eval.prompt.md
@@ -55,7 +55,8 @@ Help the user set the right target in the config:
 
 - **Framework agent** (LangGraph, CrewAI, etc.) with a Python entry function: use `target.callable` WITH `target.trace` so the judge can cite tool calls and routing.
 - **Hosted model** with a system prompt and optional tools: use `target.model` and `target.tools`.
-- **Pre-collected traces** (no live inference needed): use `assert-ai judge-traces --traces <path> --config <path>`.
+- **Pre-collected traces** (no live inference needed): use `assert-ai judge-traces --traces <path> --config <path>`; do not add a `--trace` flag to `assert-ai run`.
+- **Black-box HTTP endpoint** you cannot instrument: write a thin Python callable shim that calls the endpoint, use it as `target.callable` with no `target.trace`, and state that the judge sees only final text. This is a fallback, not the recommended path.
 
 ### 3. Run the pipeline
 
@@ -99,6 +100,14 @@ Select the suite and run for forest plots, per-dimension breakdowns, facet group
 - **watch a run in progress** → viewer live run monitor (`manifest.json`-driven)
 
 See `docs/guides/use-local-viewer.md` for the full layout.
+
+### 6. Hand off to CI
+
+Once the eval is passing locally and the user wants it enforced on PRs, hand off to the `wire-assert-ci` skill. Do not author CI wiring here; direct the user or agent to the action bootstrap:
+
+```
+read https://raw.githubusercontent.com/responsibleai/assert-action/main/ONBOARD.md
+```
 
 ## Output format
 

--- a/.github/prompts/run-assert-eval.prompt.md
+++ b/.github/prompts/run-assert-eval.prompt.md
@@ -24,10 +24,11 @@ Copilot is for *answering questions* and *synthesis* — direct answers, failure
 
 ## Preconditions (check, don't assume)
 
-1. **ASSERT installed**: verify `assert-ai --help` succeeds. If not, guide install:
+1. **ASSERT installed**: verify `assert-ai --help` succeeds. If not, guide install from PyPI — not an editable install of the user's own repo:
    ```
-   python -m pip install -e ".[otel,langgraph]"
+   python -m pip install "assert-ai[otel]"
    ```
+   Add route-specific extras as needed, for example `assert-ai[otel,langgraph]` for LangGraph or `assert-ai[aiohttp]` for `target.endpoint`. Use `pip install -e ".[otel,langgraph]"` **only** when the working directory is a clone of the ASSERT repo itself; inside a customer repo it installs the wrong package.
 
 2. **Provider creds exist** in `.env`. NEVER read or print `.env`. If a run fails with an auth error, tell the user which variable NAMES are required (AZURE_API_KEY, AZURE_API_BASE, OPENAI_API_KEY, etc.) — never their values.
 

--- a/.github/prompts/run-assert-eval.prompt.md
+++ b/.github/prompts/run-assert-eval.prompt.md
@@ -106,7 +106,7 @@ See `docs/guides/use-local-viewer.md` for the full layout.
 Once the eval is passing locally and the user wants it enforced on PRs, hand off to the `wire-assert-ci` skill. Do not author CI wiring here; direct the user or agent to the action bootstrap:
 
 ```
-read https://raw.githubusercontent.com/responsibleai/assert-action/main/ONBOARD.md
+read https://raw.githubusercontent.com/changliu2/assert-ai-action/main/ONBOARD.md
 ```
 
 ## Output format

--- a/.github/prompts/run-assert-eval.prompt.md
+++ b/.github/prompts/run-assert-eval.prompt.md
@@ -107,7 +107,7 @@ See `docs/guides/use-local-viewer.md` for the full layout.
 Once the eval is passing locally and the user wants it enforced on PRs, hand off to the `wire-assert-ci` skill. Do not author CI wiring here; direct the user or agent to the action bootstrap:
 
 ```
-read https://raw.githubusercontent.com/changliu2/assert-ai-action/main/ONBOARD.md
+read https://raw.githubusercontent.com/responsibleai/assert-ai-action/main/ONBOARD.md
 ```
 
 ## Output format

--- a/.github/prompts/run-assert-eval.prompt.md
+++ b/.github/prompts/run-assert-eval.prompt.md
@@ -28,7 +28,7 @@ Copilot is for *answering questions* and *synthesis* — direct answers, failure
    ```
    python -m pip install "assert-ai[otel]"
    ```
-   Add route-specific extras as needed, for example `assert-ai[otel,langgraph]` for LangGraph or `assert-ai[aiohttp]` for `target.endpoint`. Use `pip install -e ".[otel,langgraph]"` **only** when the working directory is a clone of the ASSERT repo itself; inside a customer repo it installs the wrong package.
+   Add route-specific extras as needed, for example `assert-ai[otel,langgraph]` for LangGraph. `target.endpoint` needs `aiohttp`, which ships transitively via `litellm`'s own dependency — no separate extra to install. Use `pip install -e ".[otel,langgraph]"` **only** when the working directory is a clone of the ASSERT repo itself; inside a customer repo it installs the wrong package.
 
 2. **Provider creds exist** in `.env`. NEVER read or print `.env`. If a run fails with an auth error, tell the user which variable NAMES are required (AZURE_API_KEY, AZURE_API_BASE, OPENAI_API_KEY, etc.) — never their values.
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ cp .env.example .env                     # add your provider key
 assert-ai run --config examples/travel_planner_langgraph/eval_config.yaml
 ```
 
+### Add a CI safety gate
+
+Use [`responsibleai/assert-action`](https://github.com/responsibleai/assert-action) to run ASSERT as a PR regression gate. To wire it from your coding agent:
+
+```text
+read https://raw.githubusercontent.com/responsibleai/assert-action/main/ONBOARD.md
+```
+
+See [`docs/ci/`](docs/ci/README.md) for the short hand-off.
+
 <table align="center" style="width: 100%; border: 1px solid #d0d7de; border-collapse: collapse;">
         <tr>
                 <th style="border: 1px solid #d0d7de; padding: 10px; text-align: left;">🌐 Project website ↗</th>

--- a/README.md
+++ b/README.md
@@ -55,11 +55,14 @@ assert-ai run --config examples/travel_planner_langgraph/eval_config.yaml
 
 Use [`changliu2/assert-ai-action`](https://github.com/changliu2/assert-ai-action) to run ASSERT as a PR regression gate — it fails the build when a change makes agent behavior significantly worse.
 
-Install the skills into your coding agent (Cursor, Claude Code, Copilot, and [40+ others](https://github.com/vercel-labs/skills#supported-agents)):
+Install the skills into your coding agent (Cursor, Claude Code, Copilot, and [40+ others](https://github.com/vercel-labs/skills#supported-agents)). Two commands, because the bundle spans two repos on purpose — the evaluation skill is owned here in ASSERT and installed from here, so it never goes stale:
 
 ```bash
-npx skills add changliu2/assert-ai-action --skill "*" --yes
+npx skills add responsibleai/ASSERT --skill run-assert-eval --yes
+npx skills add changliu2/assert-ai-action --skill wire-assert-ci --yes
 ```
+
+Run them separately. `skills add` takes one package per invocation and silently ignores extras while still exiting 0, so a combined command looks like it worked and leaves you with half the bundle.
 
 Then ask it to wire the gate:
 

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ assert-ai run --config examples/travel_planner_langgraph/eval_config.yaml
 
 ### Add a CI safety gate
 
-Use [`responsibleai/assert-action`](https://github.com/responsibleai/assert-action) to run ASSERT as a PR regression gate. To wire it from your coding agent:
+Use [`changliu2/assert-ai-action`](https://github.com/changliu2/assert-ai-action) to run ASSERT as a PR regression gate. To wire it from your coding agent:
 
 ```text
-read https://raw.githubusercontent.com/responsibleai/assert-action/main/ONBOARD.md
+read https://raw.githubusercontent.com/changliu2/assert-ai-action/main/ONBOARD.md
 ```
 
 See [`docs/ci/`](docs/ci/README.md) for the short hand-off.

--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ assert-ai run --config examples/travel_planner_langgraph/eval_config.yaml
 
 ### Add a CI safety gate
 
-Use [`changliu2/assert-ai-action`](https://github.com/changliu2/assert-ai-action) to run ASSERT as a PR regression gate — it fails the build when a change makes agent behavior significantly worse.
+Use [`responsibleai/assert-ai-action`](https://github.com/responsibleai/assert-ai-action) to run ASSERT as a PR regression gate — it fails the build when a change makes agent behavior significantly worse.
 
 Install the skills into your coding agent (Cursor, Claude Code, Copilot, and [40+ others](https://github.com/vercel-labs/skills#supported-agents)). Two commands, because the bundle spans two repos on purpose — the evaluation skill is owned here in ASSERT and installed from here, so it never goes stale:
 
 ```bash
 npx skills add responsibleai/ASSERT --skill run-assert-eval --yes
-npx skills add changliu2/assert-ai-action --skill wire-assert-ci --yes
+npx skills add responsibleai/assert-ai-action --skill wire-assert-ci --yes
 ```
 
 Run them separately. `skills add` takes one package per invocation and silently ignores extras while still exiting 0, so a combined command looks like it worked and leaves you with half the bundle.
@@ -71,7 +71,7 @@ Then ask it to wire the gate:
 No Node? Paste this instead — the agent fetches the skills itself:
 
 ```text
-read https://raw.githubusercontent.com/changliu2/assert-ai-action/main/ONBOARD.md
+read https://raw.githubusercontent.com/responsibleai/assert-ai-action/main/ONBOARD.md
 ```
 
 See [`docs/ci/`](docs/ci/README.md) for the short hand-off.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,19 @@ assert-ai run --config examples/travel_planner_langgraph/eval_config.yaml
 
 ### Add a CI safety gate
 
-Use [`changliu2/assert-ai-action`](https://github.com/changliu2/assert-ai-action) to run ASSERT as a PR regression gate. To wire it from your coding agent:
+Use [`changliu2/assert-ai-action`](https://github.com/changliu2/assert-ai-action) to run ASSERT as a PR regression gate — it fails the build when a change makes agent behavior significantly worse.
+
+Install the skills into your coding agent (Cursor, Claude Code, Copilot, and [40+ others](https://github.com/vercel-labs/skills#supported-agents)):
+
+```bash
+npx skills add changliu2/assert-ai-action --skill "*" --yes
+```
+
+Then ask it to wire the gate:
+
+> Use the `wire-assert-ci` skill to add an ASSERT safety gate to this repo.
+
+No Node? Paste this instead — the agent fetches the skills itself:
 
 ```text
 read https://raw.githubusercontent.com/changliu2/assert-ai-action/main/ONBOARD.md

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,10 @@ Command reference for creating, running, and inspecting evaluations.
 - [CLI Overview](cli/overview.md): Learn the core CLI workflow for initializing, running, and comparing evaluations.
 - [CLI Commands](cli/commands.md): Browse command syntax, options, and examples for each CLI command group.
 
+## CI
+
+- [CI Safety Gate](ci/README.md): Wire ASSERT into pull requests with `assert-ai-action` to block on evidence of new safety regressions.
+
 ## Targets
 
 Choose the right target integration path for your system.

--- a/docs/ci/README.md
+++ b/docs/ci/README.md
@@ -1,0 +1,11 @@
+# CI safety gate
+
+Use [`responsibleai/assert-action`](https://github.com/responsibleai/assert-action) to run ASSERT in pull requests and fail on safety regressions.
+
+The fastest setup path is the action's agent bootstrap:
+
+```text
+read https://raw.githubusercontent.com/responsibleai/assert-action/main/ONBOARD.md
+```
+
+Generated workflows should call `responsibleai/assert-action@v1`. Keep provider credentials in CI secrets and reference environment variable names only.

--- a/docs/ci/README.md
+++ b/docs/ci/README.md
@@ -1,6 +1,6 @@
 # CI safety gate
 
-Use [`changliu2/assert-ai-action`](https://github.com/changliu2/assert-ai-action) to run ASSERT in pull requests and fail on safety regressions.
+Use [`responsibleai/assert-ai-action`](https://github.com/responsibleai/assert-ai-action) to run ASSERT in pull requests and fail on safety regressions.
 
 ## Setup
 
@@ -8,7 +8,7 @@ Install the skills into your coding agent — works with Cursor, Claude Code, Co
 
 ```bash
 npx skills add responsibleai/ASSERT --skill run-assert-eval --yes
-npx skills add changliu2/assert-ai-action --skill wire-assert-ci --yes
+npx skills add responsibleai/assert-ai-action --skill wire-assert-ci --yes
 ```
 
 Two commands, because the bundle spans two repositories on purpose. `wire-assert-ci` wires CI and delegates every live evaluation to `run-assert-eval`, which is owned here in ASSERT. Installing it from here rather than copying it into the action repo means it cannot drift out of sync.
@@ -20,7 +20,7 @@ Then: *"Use the `wire-assert-ci` skill to add an ASSERT safety gate to this repo
 Without Node, paste the bootstrap URL instead and the agent fetches the skills itself:
 
 ```text
-read https://raw.githubusercontent.com/changliu2/assert-ai-action/main/ONBOARD.md
+read https://raw.githubusercontent.com/responsibleai/assert-ai-action/main/ONBOARD.md
 ```
 
 ## What the agent does
@@ -29,6 +29,6 @@ Scans the repo, picks the highest-fidelity way to reach your agent (auto-traced 
 
 ## Notes
 
-Generated workflows call `changliu2/assert-ai-action@v1`. Keep provider credentials in CI secrets and reference environment variable names only — there is no shared endpoint, so you supply your own model credentials.
+Generated workflows call `responsibleai/assert-ai-action@v1`. Keep provider credentials in CI secrets and reference environment variable names only — there is no shared endpoint, so you supply your own model credentials.
 
 The gate blocks on **evidence of harm**: a statistically significant regression fails the build. A missing baseline, a changed test set, or an inconclusive result does not block — see the action's README for the full verdict table and its security model.

--- a/docs/ci/README.md
+++ b/docs/ci/README.md
@@ -7,8 +7,13 @@ Use [`changliu2/assert-ai-action`](https://github.com/changliu2/assert-ai-action
 Install the skills into your coding agent — works with Cursor, Claude Code, Copilot, Gemini CLI, Windsurf, Codex, and [40+ others](https://github.com/vercel-labs/skills#supported-agents):
 
 ```bash
-npx skills add changliu2/assert-ai-action --skill "*" --yes
+npx skills add responsibleai/ASSERT --skill run-assert-eval --yes
+npx skills add changliu2/assert-ai-action --skill wire-assert-ci --yes
 ```
+
+Two commands, because the bundle spans two repositories on purpose. `wire-assert-ci` wires CI and delegates every live evaluation to `run-assert-eval`, which is owned here in ASSERT. Installing it from here rather than copying it into the action repo means it cannot drift out of sync.
+
+Run them separately: `skills add` accepts one package per invocation and silently ignores extras while still exiting 0, so a combined command looks successful and installs half the bundle.
 
 Then: *"Use the `wire-assert-ci` skill to add an ASSERT safety gate to this repo."*
 

--- a/docs/ci/README.md
+++ b/docs/ci/README.md
@@ -2,10 +2,28 @@
 
 Use [`changliu2/assert-ai-action`](https://github.com/changliu2/assert-ai-action) to run ASSERT in pull requests and fail on safety regressions.
 
-The fastest setup path is the action's agent bootstrap:
+## Setup
+
+Install the skills into your coding agent — works with Cursor, Claude Code, Copilot, Gemini CLI, Windsurf, Codex, and [40+ others](https://github.com/vercel-labs/skills#supported-agents):
+
+```bash
+npx skills add changliu2/assert-ai-action --skill "*" --yes
+```
+
+Then: *"Use the `wire-assert-ci` skill to add an ASSERT safety gate to this repo."*
+
+Without Node, paste the bootstrap URL instead and the agent fetches the skills itself:
 
 ```text
 read https://raw.githubusercontent.com/changliu2/assert-ai-action/main/ONBOARD.md
 ```
 
-Generated workflows should call `changliu2/assert-ai-action@v1`. Keep provider credentials in CI secrets and reference environment variable names only.
+## What the agent does
+
+Scans the repo, picks the highest-fidelity way to reach your agent (auto-traced → bring-your-own-trace → callable → HTTP endpoint → prompt-agent), drafts an eval spec from your own README and prompts, asks you to confirm or replace it, splits it **one behavior per YAML**, runs a baseline, and opens the gate PR.
+
+## Notes
+
+Generated workflows call `changliu2/assert-ai-action@v1`. Keep provider credentials in CI secrets and reference environment variable names only — there is no shared endpoint, so you supply your own model credentials.
+
+The gate blocks on **evidence of harm**: a statistically significant regression fails the build. A missing baseline, a changed test set, or an inconclusive result does not block — see the action's README for the full verdict table and its security model.

--- a/docs/ci/README.md
+++ b/docs/ci/README.md
@@ -1,11 +1,11 @@
 # CI safety gate
 
-Use [`responsibleai/assert-action`](https://github.com/responsibleai/assert-action) to run ASSERT in pull requests and fail on safety regressions.
+Use [`changliu2/assert-ai-action`](https://github.com/changliu2/assert-ai-action) to run ASSERT in pull requests and fail on safety regressions.
 
 The fastest setup path is the action's agent bootstrap:
 
 ```text
-read https://raw.githubusercontent.com/responsibleai/assert-action/main/ONBOARD.md
+read https://raw.githubusercontent.com/changliu2/assert-ai-action/main/ONBOARD.md
 ```
 
-Generated workflows should call `responsibleai/assert-action@v1`. Keep provider credentials in CI secrets and reference environment variable names only.
+Generated workflows should call `changliu2/assert-ai-action@v1`. Keep provider credentials in CI secrets and reference environment variable names only.

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -22,6 +22,7 @@ assert-ai [GLOBAL_OPTIONS] COMMAND [ARGS] [OPTIONS]
 - `results`: list/status/compare suites and runs
 - `analysis`: post-hoc metrics commands
 - `judge-traces`: score pre-collected OTel traces
+- `acs`: generate, validate, and regression-check ACS policies
 - `library`: browse built-in behavior/judge presets
 
 ## `init`
@@ -176,6 +177,69 @@ Optional:
 
 - `--group-by <attribute>` default `session.id`
 - `--output <path>`
+
+## `acs generate`
+
+Generate a deployable ACS policy from an ASSERT run.
+
+```bash
+assert-ai acs generate [OPTIONS]
+```
+
+Required:
+
+- `--run-dir <path>` or `--suite <suite> --run <run>`
+
+Optional:
+
+- `--out <path>`
+- `--min-rate <float>` default `0.0`
+- `--min-count <int>` default `1`
+- `--model <name>`
+- `--lm-kind assert|openai-compatible` default `assert`
+- `--strict/--no-strict` default `--no-strict`
+- `--validate/--no-validate` default `--validate`
+- `--fail-on-allow` optional flag
+- `--require-block` optional flag
+
+## `acs validate`
+
+Validate an ACS manifest against an ASSERT run.
+
+```bash
+assert-ai acs validate --manifest <path> [OPTIONS]
+```
+
+Required:
+
+- `--manifest <path>`
+- `--run-dir <path>` or `--suite <suite> --run <run>`
+
+Optional:
+
+- `--min-rate <float>` default `0.0`
+- `--min-count <int>` default `1`
+- `--max-cases <int>`
+- `--fail-on-allow` optional flag
+- `--require-block` optional flag
+
+## `acs eval-config`
+
+Generate an ASSERT eval config from an existing ACS manifest.
+
+```bash
+assert-ai acs eval-config --manifest <path> --target-callable <module:function> --out <path> [OPTIONS]
+```
+
+Required:
+
+- `--manifest <path>`
+- `--target-callable <module:function>`
+- `--out <path>`
+
+Optional:
+
+- `--model <name>`
 
 ## `library list`
 

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -180,6 +180,9 @@ Optional:
 
 ## `acs generate`
 
+Requires the `acs` extra: `python -m pip install -e ".[acs]"` (editable install of the ASSERT
+repo itself — this is not yet published as an installable extra on PyPI's `assert-ai` package).
+
 Generate a deployable ACS policy from an ASSERT run.
 
 ```bash

--- a/docs/targets/README.md
+++ b/docs/targets/README.md
@@ -11,7 +11,7 @@ Pick a target based on how your agent is built.
 | A system prompt + tool schema, no orchestration code yet | **Prompt Agent target** (`target.model`, `target.system_prompt`, `target.tools`): the runtime owns the tool-call loop (up to 10 rounds, real or simulated tools). Best for test-driven prompt + toolset design before any agent is implemented | [Prompt Agent Target (model + tools)](model-and-tools.md) |
 | Any agent or multi-agent system you can invoke from Python (LangGraph, CrewAI, OpenAI Agents SDK, DSPy, LlamaIndex, AutoGen / MAF, custom orchestration, and others) | **Callable target with OTel traces (recommended)**: point `target.callable` at your entry function and add `target.trace` so Phoenix/OpenInference (or your own OTel SDK spans) feed tool calls, routing, model calls, and latency to the judge | [Callable Target](callable.md) |
 | Existing OpenTelemetry traces from a prior run | **Judge pre-collected traces**: skip live inference and score the trace file with `assert-ai judge-traces --traces <path> --config <path>` | [CLI reference](../cli/commands.md#judge-traces) |
-| A black-box HTTP API you cannot instrument | **HTTP shim as a plain callable (customization fallback, not recommended)**: wrap the endpoint in a thin Python callable and configure `target.callable` with no `target.trace`. ASSERT has no native HTTP target; the judge sees only the final response | [Callable Target (without traces)](callable.md#customization-without-traces) |
+| A black-box HTTP service you cannot import as Python | **HTTP endpoint target**: point `target.endpoint` at the service URL. The runtime POSTs to it directly — no wrapper code. Same black-box visibility as a plain callable: the judge sees only the final response | [HTTP endpoint (`target.endpoint`)](callable.md#http-endpoint-targetendpoint) |
 
 **Use simulated tools intentionally:** simulated tools are helpful for Prompt Agents when real backends are not ready. They are not a substitute for tracing a real multi-agent framework.
 
@@ -52,19 +52,21 @@ Use the **Prompt Agent target** (`target.model` + `target.system_prompt` + optio
 
 The callable target also accepts a plain Python function with no `target.trace` block. **This is not recommended for real agents** — the judge sees only the final response and misses tool calls, routing, and intermediate decisions. Use it only as a fallback when you cannot instrument the target (for example, evaluating a black-box third-party API), or for pipeline smoke testing.
 
-ASSERT has no native HTTP target. To evaluate an HTTP endpoint, write a thin callable shim and use it as a plain callable:
+ASSERT evaluates HTTP services natively — see [HTTP endpoint (`target.endpoint`)](callable.md#http-endpoint-targetendpoint). Reach for a callable shim only when your service's request or response shape differs from the one `target.endpoint` expects (it POSTs `{"message": ..., "history": [...]}` and reads `{"response": ...}`):
 
 ```python
 import requests
 
-def call_agent(prompt: str) -> str:
+
+def call_agent(message: str) -> str:
+    """Adapter for a service whose contract differs from target.endpoint's."""
     response = requests.post(
         "https://example.com/agent",
-        json={"input": prompt},
+        json={"input": message},          # this service wants "input", not "message"
         timeout=30,
     )
     response.raise_for_status()
-    return response.json()["output"]
+    return response.json()["output"]      # ...and returns "output", not "response"
 ```
 
 Because this path has no trace capture, the judge sees only the returned text. Prefer a traced Python callable whenever you control the agent runtime.
@@ -76,8 +78,8 @@ Because this path has no trace capture, the judge sees only the returned text. P
 | Callable target with OTel traces (recommended) | You (your callable runs the loop; ASSERT reads the OTel spans) | Any agent or multi-agent system you can invoke from Python | `target.callable` + `target.trace` |
 | Pre-collected OTel traces | You (ASSERT scores existing spans offline) | Repos that already captured spans from a prior run | `assert-ai judge-traces --traces <path> --config <path>` |
 | Prompt Agent (model + tools) | ASSERT runtime (declared in YAML; runtime orchestrates up to 10 rounds) | Test-driven prompt + toolset design; agents that haven't been written yet | `target.model`, `target.system_prompt`, `target.tools` |
-| HTTP shim as a plain callable (customization fallback) | The HTTP service (ASSERT doesn't see inside) | Black-box endpoints you cannot instrument | `target.callable` (no `target.trace`) |
-| Plain callable (customization fallback) | Whoever (ASSERT doesn't see inside) | Other uninstrumentable targets; pipeline smoke tests | `target.callable` (no `target.trace`) |
+| HTTP endpoint | The HTTP service (ASSERT doesn't see inside) | A deployed service you cannot import as Python | `target.endpoint` |
+| Plain callable (customization fallback) | Whoever (ASSERT doesn't see inside) | Uninstrumentable targets; services whose HTTP contract differs from `target.endpoint`'s; pipeline smoke tests | `target.callable` (no `target.trace`) |
 
 ## Current support
 

--- a/docs/targets/README.md
+++ b/docs/targets/README.md
@@ -10,7 +10,8 @@ Pick a target based on how your agent is built.
 |---|---|---|
 | A system prompt + tool schema, no orchestration code yet | **Prompt Agent target** (`target.model`, `target.system_prompt`, `target.tools`): the runtime owns the tool-call loop (up to 10 rounds, real or simulated tools). Best for test-driven prompt + toolset design before any agent is implemented | [Prompt Agent Target (model + tools)](model-and-tools.md) |
 | Any agent or multi-agent system you can invoke from Python (LangGraph, CrewAI, OpenAI Agents SDK, DSPy, LlamaIndex, AutoGen / MAF, custom orchestration, and others) | **Callable target with OTel traces (recommended)**: point `target.callable` at your entry function and add `target.trace` so Phoenix/OpenInference (or your own OTel SDK spans) feed tool calls, routing, model calls, and latency to the judge | [Callable Target](callable.md) |
-| A black-box API you cannot instrument | **Plain callable (customization fallback, not recommended)**: `target.callable` with no `target.trace`. The judge sees only the final response; use only when instrumentation is impossible | [Callable Target (without traces)](callable.md#customization-without-traces) |
+| Existing OpenTelemetry traces from a prior run | **Judge pre-collected traces**: skip live inference and score the trace file with `assert-ai judge-traces --traces <path> --config <path>` | [CLI reference](../cli/commands.md#judge-traces) |
+| A black-box HTTP API you cannot instrument | **HTTP shim as a plain callable (customization fallback, not recommended)**: wrap the endpoint in a thin Python callable and configure `target.callable` with no `target.trace`. ASSERT has no native HTTP target; the judge sees only the final response | [Callable Target (without traces)](callable.md#customization-without-traces) |
 
 **Use simulated tools intentionally:** simulated tools are helpful for Prompt Agents when real backends are not ready. They are not a substitute for tracing a real multi-agent framework.
 
@@ -31,6 +32,16 @@ For unsupported frameworks or custom orchestration, emit your own OTel spans wit
 
 After an eval finds policy violations, see [Securing agents with ACS](../guides/securing-agents-with-acs.md) to generate an ACS guard and re-run the same callable target secured.
 
+## Offline path: bring your own OTel traces
+
+If your repo already emits OpenTelemetry spans, you can score a captured trace file without running live inference:
+
+```bash
+assert-ai judge-traces --traces <path> --config <path>
+```
+
+This is separate from `assert-ai run`: there is no `--trace` flag on `assert-ai run`. Use `target.callable` + `target.trace` when ASSERT should run the target and collect traces; use `judge-traces` when traces already exist.
+
 ## Simple path: Prompt Agent (model + tools)
 
 Use the **Prompt Agent target** (`target.model` + `target.system_prompt` + optional `target.tools`) when you have a system prompt and a tool schema but no orchestration code yet. The runtime owns the tool-call loop. Real Python tools or LLM-simulated tool responses both work. Useful for test-driven prompt + toolset design *before* any agent is implemented.
@@ -41,13 +52,32 @@ Use the **Prompt Agent target** (`target.model` + `target.system_prompt` + optio
 
 The callable target also accepts a plain Python function with no `target.trace` block. **This is not recommended for real agents** — the judge sees only the final response and misses tool calls, routing, and intermediate decisions. Use it only as a fallback when you cannot instrument the target (for example, evaluating a black-box third-party API), or for pipeline smoke testing.
 
+ASSERT has no native HTTP target. To evaluate an HTTP endpoint, write a thin callable shim and use it as a plain callable:
+
+```python
+import requests
+
+def call_agent(prompt: str) -> str:
+    response = requests.post(
+        "https://example.com/agent",
+        json={"input": prompt},
+        timeout=30,
+    )
+    response.raise_for_status()
+    return response.json()["output"]
+```
+
+Because this path has no trace capture, the judge sees only the returned text. Prefer a traced Python callable whenever you control the agent runtime.
+
 ## Target paths at a glance
 
 | Path | Who owns the tool-call loop? | Best for | Config anchor |
 |---|---|---|---|
 | Callable target with OTel traces (recommended) | You (your callable runs the loop; ASSERT reads the OTel spans) | Any agent or multi-agent system you can invoke from Python | `target.callable` + `target.trace` |
+| Pre-collected OTel traces | You (ASSERT scores existing spans offline) | Repos that already captured spans from a prior run | `assert-ai judge-traces --traces <path> --config <path>` |
 | Prompt Agent (model + tools) | ASSERT runtime (declared in YAML; runtime orchestrates up to 10 rounds) | Test-driven prompt + toolset design; agents that haven't been written yet | `target.model`, `target.system_prompt`, `target.tools` |
-| Plain callable (customization fallback) | Whoever (ASSERT doesn't see inside) | Black-box APIs you cannot instrument; pipeline smoke tests | `target.callable` (no `target.trace`) |
+| HTTP shim as a plain callable (customization fallback) | The HTTP service (ASSERT doesn't see inside) | Black-box endpoints you cannot instrument | `target.callable` (no `target.trace`) |
+| Plain callable (customization fallback) | Whoever (ASSERT doesn't see inside) | Other uninstrumentable targets; pipeline smoke tests | `target.callable` (no `target.trace`) |
 
 ## Current support
 

--- a/docs/targets/README.md
+++ b/docs/targets/README.md
@@ -10,7 +10,7 @@ Pick a target based on how your agent is built.
 |---|---|---|
 | A system prompt + tool schema, no orchestration code yet | **Prompt Agent target** (`target.model`, `target.system_prompt`, `target.tools`): the runtime owns the tool-call loop (up to 10 rounds, real or simulated tools). Best for test-driven prompt + toolset design before any agent is implemented | [Prompt Agent Target (model + tools)](model-and-tools.md) |
 | Any agent or multi-agent system you can invoke from Python (LangGraph, CrewAI, OpenAI Agents SDK, DSPy, LlamaIndex, AutoGen / MAF, custom orchestration, and others) | **Callable target with OTel traces (recommended)**: point `target.callable` at your entry function and add `target.trace` so Phoenix/OpenInference (or your own OTel SDK spans) feed tool calls, routing, model calls, and latency to the judge | [Callable Target](callable.md) |
-| Existing OpenTelemetry traces from a prior run | **Judge pre-collected traces**: skip live inference and score the trace file with `assert-ai judge-traces --traces <path> --config <path>` | [CLI reference](../cli/commands.md#judge-traces) |
+| Existing OpenTelemetry traces from a prior run | **Judge pre-collected traces**: parse the trace file into an inference set with `assert-ai judge-traces --traces <path> --config <path>`, then score it with `assert-ai run --config <path> --force-stage judge` | [CLI reference](../cli/commands.md#judge-traces) |
 | A black-box HTTP service you cannot import as Python | **HTTP endpoint target**: point `target.endpoint` at the service URL. The runtime POSTs to it directly — no wrapper code. Same black-box visibility as a plain callable: the judge sees only the final response | [HTTP endpoint (`target.endpoint`)](callable.md#http-endpoint-targetendpoint) |
 
 **Use simulated tools intentionally:** simulated tools are helpful for Prompt Agents when real backends are not ready. They are not a substitute for tracing a real multi-agent framework.
@@ -34,13 +34,20 @@ After an eval finds policy violations, see [Securing agents with ACS](../guides/
 
 ## Offline path: bring your own OTel traces
 
-If your repo already emits OpenTelemetry spans, you can score a captured trace file without running live inference:
+If your repo already emits OpenTelemetry spans, you can turn a captured trace file into scored
+results without running live inference — in two steps:
 
 ```bash
 assert-ai judge-traces --traces <path> --config <path>
+assert-ai run --config <path> --force-stage judge
 ```
 
-This is separate from `assert-ai run`: there is no `--trace` flag on `assert-ai run`. Use `target.callable` + `target.trace` when ASSERT should run the target and collect traces; use `judge-traces` when traces already exist.
+`judge-traces` parses the OTel spans into an inference set (`inference_set.jsonl`); it does not
+call the judge itself. `--force-stage judge` runs the judge stage against that inference set and
+produces `scores.jsonl`. This is separate from `assert-ai run`'s normal path: there is no
+`--trace` flag on `assert-ai run`. Use `target.callable` + `target.trace` when ASSERT should run
+the target and collect traces; use `judge-traces` + `--force-stage judge` when traces already
+exist.
 
 ## Simple path: Prompt Agent (model + tools)
 
@@ -76,7 +83,7 @@ Because this path has no trace capture, the judge sees only the returned text. P
 | Path | Who owns the tool-call loop? | Best for | Config anchor |
 |---|---|---|---|
 | Callable target with OTel traces (recommended) | You (your callable runs the loop; ASSERT reads the OTel spans) | Any agent or multi-agent system you can invoke from Python | `target.callable` + `target.trace` |
-| Pre-collected OTel traces | You (ASSERT scores existing spans offline) | Repos that already captured spans from a prior run | `assert-ai judge-traces --traces <path> --config <path>` |
+| Pre-collected OTel traces | You (`judge-traces` parses spans into an inference set; `--force-stage judge` scores them) | Repos that already captured spans from a prior run | `assert-ai judge-traces --traces <path> --config <path>` then `assert-ai run --config <path> --force-stage judge` |
 | Prompt Agent (model + tools) | ASSERT runtime (declared in YAML; runtime orchestrates up to 10 rounds) | Test-driven prompt + toolset design; agents that haven't been written yet | `target.model`, `target.system_prompt`, `target.tools` |
 | HTTP endpoint | The HTTP service (ASSERT doesn't see inside) | A deployed service you cannot import as Python | `target.endpoint` |
 | Plain callable (customization fallback) | Whoever (ASSERT doesn't see inside) | Uninstrumentable targets; services whose HTTP contract differs from `target.endpoint`'s; pipeline smoke tests | `target.callable` (no `target.trace`) |


### PR DESCRIPTION
## Summary

Adds a CI-gating entry point to the docs, documents the missing `acs` command group, and closes two gaps in the target decision tree that the CI onboarding skill depends on.

## Motivation

The README had no path from "my eval passes locally" to "this blocks bad PRs". Separately, two things the docs said (or omitted) were actively misleading for anyone wiring up a target.

## Changes

**CI entry point** — a short README section pointing at the Action and the coding-agent bootstrap URL, plus a brief `docs/ci/README.md` that links out rather than duplicating the Action's docs.

**`docs/cli/commands.md`: document the `acs` group.** `acs generate`, `acs validate`, and `acs eval-config` were documented only in `docs/guides/securing-agents-with-acs.md` and were absent from the CLI reference. Flags were verified against `assert_ai/cli.py`, not just the guide.

**`docs/targets/README.md`: two missing rungs.**

- *Bring-your-own OTel traces.* A repo that already emits spans can score offline with `assert-ai judge-traces --traces <path> --config <path>`. This only appeared in the CLI reference, never in the decision tree. Now stated explicitly, including that there is **no `--trace` flag on `assert-ai run`** — a natural assumption that is wrong.
- *Black-box HTTP.* An earlier revision of this branch claimed ASSERT has no native HTTP target and told users to hand-write a `requests` shim. That was wrong: **`target.endpoint` exists and is fully implemented** (`config.py`, `config_model.py`, `security.py`). The runtime POSTs `{"message": ..., "history": [...]}` and reads `{"response": ...}`. `target.endpoint` is now the documented black-box path; the callable shim is re-scoped to its real use — a service whose request/response shape differs.

**`run-assert-eval` skill: CI hand-off + the corrected HTTP guidance**, applied identically across all three front-doors (`.claude/skills/`, `.github/prompts/`, `.cursor/rules/`). Minimal additive edits — the skill's logic, structure, and voice are unchanged. It keeps owning running and reporting; the `wire-assert-ci` skill owns CI wiring.

## Where the Action lives

Links here point at **[`changliu2/assert-ai-action`](https://github.com/changliu2/assert-ai-action)** (public, `v1` tagged, CI green).

The original `responsibleai/assert-action` was archived on Jul 14 and is read-only. Neither I nor the repo owner has admin to unarchive it, and pushes to newly created `responsibleai/*` repos are also denied, so the Action could not be hosted in the org. It is fully transferable once someone with org rights can accept it:

```
gh api -X POST repos/changliu2/assert-ai-action/transfer -f new_owner=responsibleai
```

> **Follow-up after any transfer:** re-point the URLs in this PR for clarity. An earlier revision of this description claimed `raw.githubusercontent.com` does not follow repo-transfer redirects — **that was wrong, and I have since tested it directly.** After transferring the companion demo repo into the org, the old-owner raw URL still returned `HTTP 200` with `num_redirects=0` on a cache-busted, never-before-fetched query string, while a nonexistent path 404'd identically under both owner names — so raw is resolving the transferred repo, not serving a stale cache. A transfer will **not** silently break the bootstrap URL. GitHub does not document this as a guarantee, so the URLs should still be re-pointed after a move, but it is not a blocking risk for merging this PR.

Bootstrap URL verified live (HTTP 200):

```
https://raw.githubusercontent.com/changliu2/assert-ai-action/main/ONBOARD.md
```

## Discrepancy found

`assert_ai/cli.py` supports `--require-block` on `acs generate`, but `docs/guides/securing-agents-with-acs.md` omits it. The CLI reference documents the code's actual behaviour. The guide is left alone here but is now known to be incomplete.

## Testing

- All YAML frontmatter parses (PyYAML)
- Every relative link added resolves to a real file
- Every external URL added returns HTTP 200
- The three skill front-doors were diffed to confirm the additions are substantively identical
- Diff touches only docs and skill markdown — no source, `pyproject.toml`, workflows, or viewer changes

