### PR TITLE
docs: document the ASSERT security and trust model

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,27 @@ assert-ai run --config examples/travel_planner_langgraph/eval_config.yaml
         </tr>
 </table>
 
+## Security model
+
+**An ASSERT eval config is executable content.** `target.callable`, `target.connector` and
+`target.tools.module` cause ASSERT to import and execute the Python module you name,
+in-process, with your full user privileges — including access to your `.env` credentials.
+Treat a config file exactly as you would treat source code: only run configs you wrote or
+have reviewed.
+
+**Evaluation artifacts may contain sensitive data.** `inference_set.jsonl` records full
+transcripts, and — when OpenTelemetry trace capture is enabled — tool arguments and tool
+results verbatim. `test_set.jsonl` is by construction a corpus of working adversarial
+prompts against your system. Handle both accordingly.
+
+**The local viewer is unauthenticated.** It binds `127.0.0.1` and must stay there. Do not
+expose it with `--host`, port-forwarding, or on a shared machine.
+
+**Supported deployment.** A single-tenant developer workstation. ASSERT is not currently
+designed to run as a shared or hosted multi-user service.
+
+To report a vulnerability, see [SECURITY.md](SECURITY.md).
+
 ## Acknowledgments
 
 ASSERT's core method is **AI-assisted systematization** — turning a broad, contested behavior concept into an explicit, measurable specification — following **[Agarwal et al. (2026), *AI-Assisted Systematization for Evaluating GenAI Systems*](https://www.microsoft.com/en-us/research/publication/ai-assisted-systematization-for-evaluating-genai-systems/)** from Microsoft Research. The staged pipeline that turns that specification into generated scenarios, runs them against a target, and judges the results is modeled in spirit on the design of **[Bloom](https://github.com/safety-research/bloom)** and **[Petri](https://github.com/safety-research/petri)**, open-source behavioral-evaluation frameworks from the Anthropic alignment team (Safety Research, MIT licensed).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,3 +39,32 @@ We prefer all communications to be in English.
 Microsoft follows the principle of [Coordinated Vulnerability Disclosure](https://aka.ms/security.md/cvd).
 
 <!-- END MICROSOFT SECURITY.MD BLOCK -->
+
+## ASSERT security model
+
+The section below is specific to this project. It describes intended, documented behaviour —
+not vulnerabilities — so that operators can make an informed decision before running ASSERT.
+
+**An ASSERT eval config is executable content.** `target.callable`, `target.connector` and
+`target.tools.module` cause ASSERT to import and execute the Python module you name,
+in-process, with your full user privileges — including access to your `.env` credentials.
+Importing a module runs its top-level code, so execution begins before any evaluation does.
+The guard in front of the import rejects a small set of path substrings; it is a hygiene
+filter, not a sandbox. Treat a config file exactly as you would treat source code: only run
+configs you wrote or have reviewed.
+
+**Evaluation artifacts may contain sensitive data.** `inference_set.jsonl` records full
+transcripts, and — when OpenTelemetry trace capture is enabled — tool arguments and tool
+results verbatim. `test_set.jsonl` is by construction a corpus of working adversarial
+prompts against your system. Handle both accordingly, and prefer a short retention window.
+
+**The local viewer is unauthenticated.** It binds `127.0.0.1` and must stay there. Do not
+expose it with `--host`, port-forwarding, or on a shared machine.
+
+**Supported deployment.** A single-tenant developer workstation. ASSERT is not currently
+designed to run as a shared or hosted multi-user service. On a shared build agent, a config
+arriving in a pull request would execute on that agent.
+
+If you believe you have found a vulnerability that goes beyond the behaviour described here,
+please report it through MSRC as described above rather than in a public issue.
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ Begin with the essential overview and first-run walkthrough.
 
 - [Getting Started](getting-started.md): Run your first evaluation with a canonical example
 - [Concepts](concepts.md): Understand the concepts of the ASSERT evaluation framework, its pipeline mental model and key terminology.
+- [Security model](concepts.md#security-model): **Read before running a config you did not write** — an eval config is executable content, and artifacts may contain sensitive data.
 
 ## How-to guides
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -101,6 +101,29 @@ Use of this system may also result in meaningful compute and inference costs. Yo
 - **This is not a substitute for human review.** High-stakes conclusions should be supported by expert review, grounded evidence, and, where appropriate, additional statistical validation.
 - **Reproducibility may be imperfect.** Results can vary across model versions, deployments, tool backends, and runtime settings.
 
+## Security model
+
+**An ASSERT eval config is executable content.** `target.callable`, `target.connector` and
+`target.tools.module` cause ASSERT to import and execute the Python module you name,
+in-process, with your full user privileges — including access to your `.env` credentials.
+The guard in front of that import rejects a small set of path substrings; it is a hygiene
+filter, not a sandbox. Treat a config file exactly as you would treat source code: only run
+configs you wrote or have reviewed.
+
+**Evaluation artifacts may contain sensitive data.** `inference_set.jsonl` records full
+transcripts, and — when OpenTelemetry trace capture is enabled — tool arguments and tool
+results verbatim. `test_set.jsonl` is by construction a corpus of working adversarial
+prompts against your system. Handle both accordingly, and prefer a short retention window.
+
+**The local viewer is unauthenticated.** It binds `127.0.0.1` and must stay there. Do not
+expose it with `--host`, port-forwarding, or on a shared machine.
+
+**Supported deployment.** A single-tenant developer workstation. ASSERT is not currently
+designed to run as a shared or hosted multi-user service. On a shared build agent, a config
+arriving in a pull request would execute on that agent.
+
+To report a vulnerability, see [SECURITY.md](../SECURITY.md).
+
 ## Related docs
 
 - [Getting Started](getting-started.md)

--- a/docs/config/schema.md
+++ b/docs/config/schema.md
@@ -2,6 +2,18 @@
 
 This page documents the `eval_config.yaml` schema for the standard `behavior -> systematize -> test_set -> inference -> judge` pipeline.
 
+> ## Security model
+>
+> **An ASSERT eval config is executable content.** The `target.callable`,
+> `target.connector` and `target.tools.module` keys documented on this page cause ASSERT to
+> import and execute the Python module you name, in-process, with your full user privileges
+> — including access to your `.env` credentials. Treat a config file exactly as you would
+> treat source code: only run configs you wrote or have reviewed.
+>
+> Evaluation artifacts may contain sensitive data, the local viewer is unauthenticated, and
+> the supported deployment is a single-tenant developer workstation. See
+> [Concepts › Security model](../concepts.md#security-model) for the full statement.
+
 ## Top-level keys
 
 ### `suite`

--- a/docs/targets/callable.md
+++ b/docs/targets/callable.md
@@ -7,6 +7,19 @@ The callable target has two integration paths:
 - **Recommended (happy path):** OTel-traced agent — central auto-instrumentation helper across supported OpenInference frameworks. The judge cites tool calls, routing decisions, model calls, and latency as evidence.
 - **Customization:** for unsupported frameworks (emit your own OTel spans) or for cases where instrumentation is impossible or unnecessary (plain callable / HTTP endpoint, no traces).
 
+> ## Security model
+>
+> **A config naming a callable is executable content.** `target.callable` and
+> `target.tools.module` cause ASSERT to import and execute the Python module you name,
+> in-process, with your full user privileges — including access to your `.env` credentials.
+> Importing a module runs its top-level code, so execution begins before any evaluation
+> does. The guard in front of the import rejects a small set of path substrings; it is a
+> hygiene filter, not a sandbox.
+>
+> Only run configs you wrote or have reviewed. See
+> [Concepts › Security model](../concepts.md#security-model) for the full statement,
+> including artifact sensitivity and the supported deployment.
+
 ## What the judge sees, by integration path
 
 Pick the path that exposes enough internals for the judge to score what matters. OTel is recommended because every other path is strictly narrower.


### PR DESCRIPTION
## Summary

Adds a `SECURITY.md` and threads the trust boundaries through the existing docs.

ASSERT executes configuration-supplied Python (`target.callable`), sends evaluation
content to third-party model providers, and writes transcripts to disk. None of that
was written down, so a user had no stated basis for deciding what a config file is
allowed to contain or who may read a run directory.

**Closes:** SEC-014 (no documented security model)

## Commits

- docs: document the ASSERT security and trust model

## Testing

```
pytest tests/ -q
```

Full suite green on this branch; `6 files changed, 99 insertions(+)`. Every change has a regression test, and the
suite was re-run after each commit rather than only at the end.

## Notes for reviewer

Documentation only. No code or behaviour changes.

## Risk and rollback

Each commit is a single concern and can be reverted independently. See the notes above
for anything that does **not** revert cleanly.
