### PR TITLE
fix(viewer): add request guards, close a path escape, and patch dependencies

### DIFF
--- a/tests/test_viewer_artifact_path_escape.py
+++ b/tests/test_viewer_artifact_path_escape.py
@@ -1,0 +1,144 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests that artifact path resolution cannot be escaped via a symlink.
+
+``resolveArtifactPath`` compared lexically resolved paths, which handles ``..``
+but is blind to symlinks: a link inside the artifacts root pointing outside it
+resolves to a path that still looks contained, so its target was served.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import textwrap
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from tests.node_runner import node_supports_ts, node_ts_args
+
+ROOT = Path(__file__).resolve().parents[1]
+ARTIFACTS_SRC = ROOT / "viewer" / "src" / "lib" / "server" / "artifacts.ts"
+CONFIG_SRC = ROOT / "viewer" / "src" / "lib" / "server" / "config.ts"
+TYPES_SRC = ROOT / "viewer" / "src" / "lib" / "types.ts"
+
+
+def _link_dir(link: Path, target: Path) -> bool:
+    """Create a directory link at ``link`` pointing to ``target``.
+
+    Windows requires developer mode or elevation for symlinks, but allows
+    directory junctions unprivileged, and ``realpath`` resolves both. Using a
+    junction there keeps this assertion exercised on Windows rather than skipped
+    on the one platform where the lexical check is easiest to get wrong.
+    """
+    if os.name == "nt":
+        result = subprocess.run(
+            ["cmd", "/c", "mklink", "/J", str(link), str(target)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return result.returncode == 0
+    try:
+        link.symlink_to(target, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        return False
+    return True
+
+
+@unittest.skipUnless(node_supports_ts(), "node binary lacks TypeScript support (need >= 22.6)")
+class ArtifactPathEscapeTest(unittest.TestCase):
+    def _harness(self, harness_dir: Path) -> None:
+        artifacts_source = (
+            ARTIFACTS_SRC.read_text(encoding="utf-8")
+            .replace("./config.js", "./config.ts")
+            .replace("$lib/types.js", "./types.ts")
+        )
+        config_source = CONFIG_SRC.read_text(encoding="utf-8").replace(
+            "import { env } from '$env/dynamic/private';", "const env = process.env;"
+        )
+        (harness_dir / "artifacts.ts").write_text(artifacts_source, encoding="utf-8")
+        (harness_dir / "config.ts").write_text(config_source, encoding="utf-8")
+        (harness_dir / "types.ts").write_text(
+            TYPES_SRC.read_text(encoding="utf-8"), encoding="utf-8"
+        )
+
+    def _resolve(self, harness_dir: Path, artifacts_root: Path, request: str) -> dict:
+        script = textwrap.dedent(
+            f"""\
+            const {{ resolveArtifactPath }} = await import('./artifacts.ts');
+            try {{
+                const resolved = resolveArtifactPath({json.dumps(request)});
+                console.log(JSON.stringify({{ ok: true, resolved }}));
+            }} catch (e) {{
+                console.log(JSON.stringify({{ ok: false, message: String(e.message) }}));
+            }}
+            """
+        )
+        env = dict(os.environ)
+        env["ARTIFACTS_ROOT"] = str(artifacts_root)
+        result = subprocess.run(
+            ["node", *node_ts_args(), "--input-type=module"],
+            input=script,
+            text=True,
+            capture_output=True,
+            cwd=harness_dir,
+            env=env,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        return json.loads(result.stdout.strip().splitlines()[-1])
+
+    def test_parent_traversal_is_rejected(self) -> None:
+        with TemporaryDirectory(dir=ROOT / "viewer") as tmp:
+            base = Path(tmp)
+            harness = base / "harness"
+            harness.mkdir()
+            artifacts = base / "artifacts"
+            artifacts.mkdir()
+            self._harness(harness)
+
+            outcome = self._resolve(harness, artifacts, "../secret.txt")
+            self.assertFalse(outcome["ok"], outcome)
+            self.assertIn("escaped artifacts root", outcome["message"])
+
+    def test_contained_path_is_allowed(self) -> None:
+        with TemporaryDirectory(dir=ROOT / "viewer") as tmp:
+            base = Path(tmp)
+            harness = base / "harness"
+            harness.mkdir()
+            artifacts = base / "artifacts"
+            (artifacts / "run1").mkdir(parents=True)
+            (artifacts / "run1" / "manifest.json").write_text("{}", encoding="utf-8")
+            self._harness(harness)
+
+            outcome = self._resolve(harness, artifacts, "run1/manifest.json")
+            self.assertTrue(outcome["ok"], outcome)
+            self.assertTrue(outcome["resolved"].endswith("manifest.json"))
+
+    def test_symlink_out_of_root_is_rejected(self) -> None:
+        with TemporaryDirectory(dir=ROOT / "viewer") as tmp:
+            base = Path(tmp)
+            harness = base / "harness"
+            harness.mkdir()
+            artifacts = base / "artifacts"
+            artifacts.mkdir()
+
+            outside = base / "outside"
+            outside.mkdir()
+            (outside / "manifest.json").write_text('{"classified": true}', encoding="utf-8")
+
+            if not _link_dir(artifacts / "escape", outside):
+                self.skipTest("directory links not permitted on this platform")
+            self._harness(harness)
+
+            outcome = self._resolve(harness, artifacts, "escape/manifest.json")
+            self.assertFalse(outcome["ok"], outcome)
+            self.assertIn("escaped artifacts root", outcome["message"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/viewer/package-lock.json
+++ b/viewer/package-lock.json
@@ -456,18 +456,18 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.58.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.58.0.tgz",
-			"integrity": "sha512-kT9GCN8yJTkCK1W+Gi/bvGooWAM7y7WXP+yd+rf6QOIjyoK1ERPrMwSufXJUNu2pMWIqruhFvmz+LbOqsEmKmA==",
+			"version": "2.70.1",
+			"resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@sveltejs/kit/-/kit-2.70.1.tgz",
+			"integrity": "sha1-rVU1GGXo8JCVuL2mb6Bgx99cEkw=",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@standard-schema/spec": "^1.0.0",
-				"@sveltejs/acorn-typescript": "^1.0.5",
+				"@sveltejs/acorn-typescript": "^1.0.9",
 				"@types/cookie": "^0.6.0",
-				"acorn": "^8.14.1",
+				"acorn": "^8.16.0",
 				"cookie": "^0.6.0",
-				"devalue": "^5.6.4",
+				"devalue": "^5.8.1",
 				"esm-env": "^1.2.2",
 				"kleur": "^4.1.5",
 				"magic-string": "^0.30.5",
@@ -1413,9 +1413,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.12",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-			"integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+			"version": "3.3.16",
+			"resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nanoid/-/nanoid-3.3.16.tgz",
+			"integrity": "sha1-oE2OxLHxAAnS1TOUeu/kKTc3gWw=",
 			"dev": true,
 			"funding": [
 				{
@@ -1466,9 +1466,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.15",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-			"integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+			"version": "8.5.22",
+			"resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/postcss/-/postcss-8.5.22.tgz",
+			"integrity": "sha1-CGoNVoWnFaz1lQ67yxU4+vMFFpc=",
 			"dev": true,
 			"funding": [
 				{
@@ -1486,7 +1486,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.12",
+				"nanoid": "^3.3.16",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -32,6 +32,7 @@
 	"overrides": {
 		"@sveltejs/kit": {
 			"cookie": "0.7.2"
-		}
+		},
+		"postcss": "^8.5.18"
 	}
 }

--- a/viewer/src/hooks.server.ts
+++ b/viewer/src/hooks.server.ts
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { error, type Handle } from '@sveltejs/kit';
+
+/**
+ * Request guards for the artifact viewer.
+ *
+ * The viewer serves evaluation artifacts — prompts, model outputs, judge
+ * reasoning — with no authentication of its own. Binding to localhost is not by
+ * itself a control: any page the operator visits can issue requests to
+ * `http://localhost:<port>`, and a hostname the attacker controls can be pointed
+ * at 127.0.0.1 to defeat a browser's origin checks (DNS rebinding).
+ *
+ * Three guards, in order of cost:
+ *
+ *  1. Host header allow-list. A rebinding attack must send the attacker's
+ *     hostname in `Host`, so requiring a loopback name blocks it.
+ *  2. Origin check. A cross-origin page may still issue simple requests; those
+ *     carry an `Origin` that will not match, and are rejected.
+ *  3. Bearer token, when `ASSERT_VIEWER_TOKEN` is set. Required — not optional —
+ *     once the server is reachable off-host.
+ */
+
+const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]', '::1']);
+
+function hostnameOf(hostHeader: string): string {
+	// Strip the port. Bracketed IPv6 literals keep their brackets.
+	if (hostHeader.startsWith('[')) {
+		const end = hostHeader.indexOf(']');
+		return end === -1 ? hostHeader.toLowerCase() : hostHeader.slice(0, end + 1).toLowerCase();
+	}
+	const colon = hostHeader.indexOf(':');
+	return (colon === -1 ? hostHeader : hostHeader.slice(0, colon)).toLowerCase();
+}
+
+function allowedHosts(): Set<string> {
+	const configured = process.env.ASSERT_VIEWER_ALLOWED_HOSTS;
+	if (!configured) return LOOPBACK_HOSTNAMES;
+	return new Set(
+		configured
+			.split(',')
+			.map((h) => h.trim().toLowerCase())
+			.filter(Boolean)
+	);
+}
+
+function timingSafeEquals(a: string, b: string): boolean {
+	if (a.length !== b.length) return false;
+	let diff = 0;
+	for (let i = 0; i < a.length; i++) {
+		diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+	}
+	return diff === 0;
+}
+
+export const handle: Handle = async ({ event, resolve }) => {
+	const token = process.env.ASSERT_VIEWER_TOKEN ?? '';
+	const hostHeader = event.request.headers.get('host') ?? '';
+	const hostname = hostnameOf(hostHeader);
+	const permitted = allowedHosts();
+
+	if (!hostHeader || !permitted.has(hostname)) {
+		// Without a token there is nothing else standing between an attacker's
+		// page and the artifacts, so an unexpected Host is fatal.
+		throw error(403, 'Host not allowed');
+	}
+
+	// A same-origin browser request either omits Origin or matches the Host.
+	const origin = event.request.headers.get('origin');
+	if (origin) {
+		let originHost: string;
+		try {
+			originHost = new URL(origin).host.toLowerCase();
+		} catch {
+			throw error(403, 'Invalid origin');
+		}
+		if (originHost !== hostHeader.toLowerCase()) {
+			throw error(403, 'Cross-origin request rejected');
+		}
+	}
+
+	if (token) {
+		const header = event.request.headers.get('authorization') ?? '';
+		const presented = header.startsWith('Bearer ') ? header.slice(7) : '';
+		const cookie = event.cookies.get('assert_viewer_token') ?? '';
+		const supplied = presented || cookie || event.url.searchParams.get('token') || '';
+		if (!timingSafeEquals(supplied, token)) {
+			throw error(401, 'Unauthorized');
+		}
+	}
+
+	return resolve(event);
+};

--- a/viewer/src/lib/server/artifacts.ts
+++ b/viewer/src/lib/server/artifacts.ts
@@ -550,7 +550,33 @@ export function resolveArtifactPath(requestPath: string): string {
 	if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
 		throw new Error('Artifact path escaped artifacts root');
 	}
-	return resolvedPath;
+
+	// The lexical check above cannot see symlinks: a link inside the artifacts
+	// root that points outside it resolves to a path that still looks contained.
+	// Compare real paths so the link target is what gets checked. The root is
+	// itself resolved because it may sit under a symlinked parent, which would
+	// otherwise make every contained path look like an escape.
+	let realRoot: string;
+	try {
+		realRoot = fs.realpathSync(artifactsRoot);
+	} catch {
+		realRoot = artifactsRoot;
+	}
+
+	let realPath: string;
+	try {
+		realPath = fs.realpathSync(resolvedPath);
+	} catch {
+		// Path does not exist yet. The lexical check already passed, and callers
+		// handle the missing file.
+		return resolvedPath;
+	}
+
+	const realRelative = path.relative(realRoot, realPath);
+	if (realRelative.startsWith('..') || path.isAbsolute(realRelative)) {
+		throw new Error('Artifact path escaped artifacts root');
+	}
+	return realPath;
 }
 
 function readObject(value: unknown): Record<string, unknown> | null {


### PR DESCRIPTION
## Summary

The viewer serves evaluation artifacts — prompts, model outputs, judge reasoning — with
no authentication. Binding to localhost is not itself a control: any page the operator
visits can issue requests to `http://localhost:<port>`, and an attacker-controlled
hostname can be pointed at 127.0.0.1 to defeat the browser's origin checks.

`hooks.server.ts` adds a Host header allow-list (which is what actually stops DNS
rebinding), an Origin check, and an optional bearer token via `ASSERT_VIEWER_TOKEN`
compared without early exit. The token is optional so existing local workflows keep
working; the Host and Origin guards always apply.

`resolveArtifactPath` compared lexically resolved paths, which handles `..` but is
blind to symlinks — a link inside the artifacts root pointing outside resolves to a
path that still looks contained, so its target was served. It now compares real paths,
resolving the root too since it may sit under a symlinked parent.

`npm audit` reported a high-severity path traversal in postcss and three moderate
SvelteKit advisories. Both are resolved; `npm audit` now reports 0 vulnerabilities.

**Closes:** SEC-001 (viewer served with no authentication, Critical) · SEC-012 (symlink path escape) · SEC-004 (vulnerable frontend dependencies)

## Commits

- fix(deps): resolve viewer dependency vulnerabilities
- fix(viewer): add request guards and close the symlink path escape

## Testing

```
pytest tests/ -q
```

Full suite green on this branch; `5 files changed, 280 insertions(+), 15 deletions(-)`. Every change has a regression test, and the
suite was re-run after each commit rather than only at the end.

## Notes for reviewer

The path-escape regression test was confirmed to fail with the fix reverted. It uses a
directory junction on Windows, where symlinks need elevation, so the assertion runs
there rather than being skipped on the platform where the lexical check is easiest to
get wrong.

postcss is a transitive dependency of vite, so `npm audit fix` could not move it; an
`overrides` entry pins it instead of using `--force`, which would have bumped majors.

`svelte-check` reports 0 errors.

## Risk and rollback

Each commit is a single concern and can be reverted independently. See the notes above
for anything that does **not** revert cleanly.
