### PR TITLE
fix(security): harden the security module and the paths that call it

### DIFF
--- a/assert_ai/auto_trace.py
+++ b/assert_ai/auto_trace.py
@@ -33,18 +33,32 @@ def _can_connect(host: str, port: int, *, timeout: float) -> bool:
 
 
 def _collector_available(*, timeout: float = 0.1) -> bool:
-    """Detect whether Phoenix/OTLP export is explicitly configured or local."""
+    """Detect whether Phoenix/OTLP export is explicitly configured.
+
+    Export sends tool arguments, tool results, and message content off the
+    machine, so it is enabled only when the operator asks for it. Earlier
+    versions probed localhost:4317 and localhost:6006 and enabled export if
+    anything answered, which meant an unrelated local listener silently turned
+    on continuous egress. That probe is now behind ASSERT_TRACE_AUTODETECT=1.
+    """
     if os.environ.get("PHOENIX_DISABLE_AUTO_INSTRUMENT") == "1":
         return False
 
     for name in ("PHOENIX_COLLECTOR_ENDPOINT", "OTEL_EXPORTER_OTLP_ENDPOINT"):
-        if os.environ.get(name):
-            log.info("%s is set; enabling Phoenix export", name)
+        endpoint = os.environ.get(name)
+        if endpoint:
+            log.info("%s is set; enabling Phoenix export to %s", name, endpoint)
             return True
 
     if os.environ.get("ASSERT_EXPORT_TRACES", "").strip() == "1":
-        log.info("ASSERT_EXPORT_TRACES=1; enabling Phoenix export")
+        log.info(
+            "ASSERT_EXPORT_TRACES=1; enabling Phoenix export to the default "
+            "local collector endpoint"
+        )
         return True
+
+    if os.environ.get("ASSERT_TRACE_AUTODETECT", "").strip() != "1":
+        return False
 
     ports: list[int] = []
     grpc_port = os.environ.get("PHOENIX_GRPC_PORT", "")
@@ -58,6 +72,12 @@ def _collector_available(*, timeout: float = 0.1) -> bool:
             continue
         seen.add(port)
         if _can_connect("localhost", port, timeout=timeout):
+            log.warning(
+                "ASSERT_TRACE_AUTODETECT=1: detected a listener on localhost:%d "
+                "and enabling trace export to it. Span content including tool "
+                "arguments and results will be sent to that endpoint.",
+                port,
+            )
             return True
     return False
 

--- a/assert_ai/core/otel.py
+++ b/assert_ai/core/otel.py
@@ -27,6 +27,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
+from assert_ai.core.security import redact_text
+
 log = logging.getLogger(__name__)
 
 
@@ -410,7 +412,43 @@ def _spans_to_events(
         "llm_call_count": acc.llm_call_count,
     }
 
-    return acc.events, aggregate
+    return _redact_events(acc.events), aggregate
+
+
+def _redact_events(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Redact credentials from span-derived transcript events.
+
+    Span attributes carry tool call arguments, tool results, and message content
+    straight into ``inference_set.jsonl``, which the viewer then renders. The
+    redaction helpers were applied on the model-client and connector paths but
+    not here, so an agent whose tool call carried an API key wrote it verbatim.
+    Inconsistent redaction is worse than none, because an operator who has seen
+    it work reasonably assumes it applies everywhere.
+
+    Only credential shapes are matched, so ordinary evaluation content passes
+    through unchanged. Set ``ASSERT_REDACT_SPAN_CONTENT=0`` to disable if a
+    match ever corrupts a result.
+    """
+    if os.environ.get("ASSERT_REDACT_SPAN_CONTENT", "").strip() == "0":
+        return events
+    return [_redact_value(event) for event in events]
+
+
+def _redact_value(value: Any, *, depth: int = 0, max_depth: int = 12) -> Any:
+    if depth > max_depth:
+        return value
+    if isinstance(value, str):
+        return redact_text(value)
+    if isinstance(value, dict):
+        return {
+            key: _redact_value(item, depth=depth + 1, max_depth=max_depth)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [
+            _redact_value(item, depth=depth + 1, max_depth=max_depth) for item in value
+        ]
+    return value
 
 
 def _openinference_span_to_events(span: OTelSpan, acc: _EventAccumulator) -> None:

--- a/assert_ai/core/otel_session.py
+++ b/assert_ai/core/otel_session.py
@@ -29,6 +29,7 @@ from typing import Any
 from assert_ai.core.async_utils import invoke_callable
 from assert_ai.core.collector import SpanCollector
 from assert_ai.core.model_client import Message
+from assert_ai.core.security import sanitize_callable_ref
 from assert_ai.core.otel import (
     InMemoryTraceExporter,
     OTelSpan,
@@ -115,10 +116,9 @@ class OTelTracedSession:
         import io
         import sys
 
-        from assert_ai.core.security import validate_callable_ref
         from assert_ai.core.tool_backend import import_callable_module
 
-        validate_callable_ref(self._callable_ref)
+        sanitize_callable_ref(self._callable_ref)
         module_path, func_name = self._callable_ref.rsplit(":", 1)
         if self._live_otel:
             from assert_ai import auto_trace

--- a/assert_ai/core/security.py
+++ b/assert_ai/core/security.py
@@ -147,7 +147,7 @@ _LOCAL_DEV_HOSTNAMES = {
 }
 
 
-def _env_flag(name: str) -> bool:
+def env_flag(name: str) -> bool:
     """Return True when environment variable ``name`` is set to a truthy value."""
     return os.environ.get(name, "").lower() in ("1", "true", "yes")
 
@@ -168,7 +168,7 @@ def _is_plaintext_permitted(hostname: str) -> bool:
     Loopback traffic never leaves the machine, so TLS adds no confidentiality
     there. Everything else requires an explicit operator opt-out.
     """
-    return _is_loopback_host(hostname) or _env_flag("ASSERT_ALLOW_PLAINTEXT_HTTP")
+    return _is_loopback_host(hostname) or env_flag("ASSERT_ALLOW_PLAINTEXT_HTTP")
 
 
 def validate_endpoint_url(url: str, *, allow_private: bool = False) -> None:
@@ -261,7 +261,7 @@ def _validate_resolved_ips(hostname: str) -> None:
     try:
         addrinfo = socket.getaddrinfo(hostname, None, proto=socket.IPPROTO_TCP)
     except socket.gaierror as e:
-        if _env_flag("ASSERT_ALLOW_UNRESOLVABLE_ENDPOINTS"):
+        if env_flag("ASSERT_ALLOW_UNRESOLVABLE_ENDPOINTS"):
             log.warning(
                 "DNS resolution failed for '%s'; allowed by "
                 "ASSERT_ALLOW_UNRESOLVABLE_ENDPOINTS. SSRF checks did not run.",
@@ -303,6 +303,63 @@ _SENSITIVE_KEYS = re.compile(
 )
 
 _REDACTED = "[REDACTED]"
+
+# Free-text redaction. sanitize_payload() keys off dict keys, so it cannot see a
+# secret embedded in a string — a traceback or a span attribute value carries its
+# secrets inline. These patterns are deliberately narrow: over-redaction silently
+# corrupts evaluation data, which is a different kind of harm, so only
+# high-confidence credential shapes are matched.
+
+_SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?P<key>api[_-]?key|auth[_-]?token|secret|password|passwd|credential|"
+    r"authorization|access[_-]?token|refresh[_-]?token|private[_-]?key|"
+    r"client[_-]?secret|azure[_-]?ad[_-]?token)"
+    r"(?P<sep>[\"']?\s*[:=]\s*[\"']?)"
+    r"(?P<value>[^\s\"',;)}\]]+)",
+    re.IGNORECASE,
+)
+
+_AUTH_SCHEME_RE = re.compile(
+    r"\b(?P<scheme>Bearer|Basic)\s+(?P<token>[A-Za-z0-9._\-+/=]+)",
+    re.IGNORECASE,
+)
+
+_URL_CREDENTIALS_RE = re.compile(
+    r"(?P<prefix>[a-z][a-z0-9+.\-]*://[^:/@\s]+:)(?P<password>[^@/\s]+)@",
+    re.IGNORECASE,
+)
+
+_TOKEN_SHAPE_RE = re.compile(
+    r"\b(?:sk-[A-Za-z0-9_\-]{16,}"          # OpenAI-style keys
+    r"|AKIA[0-9A-Z]{16}"                    # AWS access key IDs
+    r"|gh[pousr]_[A-Za-z0-9]{16,}"          # GitHub tokens
+    r"|eyJ[A-Za-z0-9_\-]+\.eyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+)"  # JWTs
+)
+
+
+def redact_text(text: str) -> str:
+    """Redact credentials embedded in free text.
+
+    Complements :func:`sanitize_payload`, which can only redact whole values
+    whose *key* looks sensitive. Use this on diagnostic and telemetry strings —
+    tracebacks, span attribute values — where the secret is inline.
+
+    This is best-effort pattern matching, not a guarantee. It will not catch a
+    credential with no recognisable prefix or surrounding key name.
+    """
+    if not text:
+        return text
+    out = _URL_CREDENTIALS_RE.sub(
+        lambda m: f"{m.group('prefix')}{_REDACTED}@", str(text)
+    )
+    # Auth schemes are matched before key/value assignments. In
+    # "Authorization: Bearer <token>" the assignment pattern would otherwise
+    # capture the literal word "Bearer" as the value and leave the token intact.
+    out = _AUTH_SCHEME_RE.sub(lambda m: f"{m.group('scheme')} {_REDACTED}", out)
+    out = _SECRET_ASSIGNMENT_RE.sub(
+        lambda m: f"{m.group('key')}{m.group('sep')}{_REDACTED}", out
+    )
+    return _TOKEN_SHAPE_RE.sub(_REDACTED, out)
 
 
 def sanitize_payload(payload: Any, *, depth: int = 0, max_depth: int = 10) -> Any:

--- a/assert_ai/core/security.py
+++ b/assert_ai/core/security.py
@@ -147,6 +147,30 @@ _LOCAL_DEV_HOSTNAMES = {
 }
 
 
+def _env_flag(name: str) -> bool:
+    """Return True when environment variable ``name`` is set to a truthy value."""
+    return os.environ.get(name, "").lower() in ("1", "true", "yes")
+
+
+def _is_loopback_host(hostname: str) -> bool:
+    """Return True when ``hostname`` names the local machine without a DNS lookup."""
+    if hostname.lower() in _LOCAL_DEV_HOSTNAMES:
+        return True
+    try:
+        return ipaddress.ip_address(hostname).is_loopback
+    except ValueError:
+        return False
+
+
+def _is_plaintext_permitted(hostname: str) -> bool:
+    """Return True when plaintext HTTP is acceptable for ``hostname``.
+
+    Loopback traffic never leaves the machine, so TLS adds no confidentiality
+    there. Everything else requires an explicit operator opt-out.
+    """
+    return _is_loopback_host(hostname) or _env_flag("ASSERT_ALLOW_PLAINTEXT_HTTP")
+
+
 def validate_endpoint_url(url: str, *, allow_private: bool = False) -> None:
     """Validate an HTTP endpoint URL to prevent SSRF attacks.
 
@@ -204,20 +228,51 @@ def validate_endpoint_url(url: str, *, allow_private: bool = False) -> None:
         if hostname.lower() not in _LOCAL_DEV_HOSTNAMES:
             _validate_resolved_ips(hostname)
 
+    # Transport security, checked last so that an SSRF verdict on a blocked host
+    # is reported as such. Plaintext HTTP is permitted only to loopback, where the
+    # traffic never traverses a network, or behind an explicit opt-out. Otherwise
+    # the whole evaluation — prompts, responses, and any bearer token — is
+    # readable by anything on the path.
+    if parsed.scheme == "http" and not _is_plaintext_permitted(hostname):
+        raise ValueError(
+            f"Endpoint '{url}' uses plaintext HTTP. Use https, or set "
+            "ASSERT_ALLOW_PLAINTEXT_HTTP=1 to allow plaintext for a local test server."
+        )
+
 
 def _validate_resolved_ips(hostname: str) -> None:
     """Resolve a hostname via DNS and validate all returned IPs against blocked ranges.
+
+    Fails closed: a hostname that cannot be resolved is rejected rather than
+    allowed through. Letting an unresolvable name pass means the guard is
+    skipped entirely whenever an attacker can make resolution fail here but
+    succeed in the HTTP client.
+
+    Set ``ASSERT_ALLOW_UNRESOLVABLE_ENDPOINTS=1`` on split-horizon networks where
+    the validating process genuinely cannot resolve a legitimate internal name.
+
+    Note: this check remains time-of-check/time-of-use. The HTTP client resolves
+    the name again when it connects, and a short-TTL record can change between
+    the two lookups. Closing that gap requires pinning the validated address at
+    the transport layer, which is not done here.
 
     Raises ValueError if any resolved IP falls within a blocked range.
     """
     try:
         addrinfo = socket.getaddrinfo(hostname, None, proto=socket.IPPROTO_TCP)
-    except socket.gaierror:
-        # If DNS resolution fails, allow the request through — it will fail
-        # at connection time with a clear error. This avoids false positives
-        # for hosts that are only resolvable from certain networks.
-        log.debug("DNS resolution failed for '%s'; skipping IP validation", hostname)
-        return
+    except socket.gaierror as e:
+        if _env_flag("ASSERT_ALLOW_UNRESOLVABLE_ENDPOINTS"):
+            log.warning(
+                "DNS resolution failed for '%s'; allowed by "
+                "ASSERT_ALLOW_UNRESOLVABLE_ENDPOINTS. SSRF checks did not run.",
+                hostname,
+            )
+            return
+        raise ValueError(
+            f"URL hostname '{hostname}' could not be resolved, so it cannot be "
+            "checked against blocked IP ranges. Set "
+            "ASSERT_ALLOW_UNRESOLVABLE_ENDPOINTS=1 to allow unresolvable hosts."
+        ) from e
 
     for family, _type, _proto, _canonname, sockaddr in addrinfo:
         ip_str = sockaddr[0]

--- a/assert_ai/core/security.py
+++ b/assert_ai/core/security.py
@@ -30,8 +30,14 @@ _DANGEROUS_MODULE_PATTERNS = re.compile(
 )
 
 
-def validate_callable_ref(callable_ref: str, *, config_path: Path | None = None) -> None:
-    """Validate a callable reference before dynamic import.
+def sanitize_callable_ref(callable_ref: str, *, config_path: Path | None = None) -> None:
+    """Reject obviously-wrong callable references before dynamic import.
+
+    **This is a hygiene filter, not a security boundary.** It checks the shape of
+    the reference and rejects four path substrings. Any other importable module
+    named here will be imported and executed with the privileges of the ASSERT
+    process. A configuration file that can set ``target.callable`` is therefore
+    equivalent to arbitrary code execution, and must be trusted accordingly.
 
     Raises ValueError if the reference is malformed or contains disallowed path segments.
     """
@@ -53,8 +59,12 @@ def validate_callable_ref(callable_ref: str, *, config_path: Path | None = None)
         )
 
 
-def validate_module_ref(module_ref: str, *, config_path: Path | None = None) -> None:
-    """Validate a tool/connector module reference before dynamic import.
+def sanitize_module_ref(module_ref: str, *, config_path: Path | None = None) -> None:
+    """Reject obviously-wrong tool/connector module references before dynamic import.
+
+    **This is a hygiene filter, not a security boundary.** See
+    :func:`sanitize_callable_ref`: anything not matching the four disallowed path
+    substrings is imported and executed.
 
     Raises ValueError if the reference looks dangerous.
     """
@@ -65,6 +75,13 @@ def validate_module_ref(module_ref: str, *, config_path: Path | None = None) -> 
         raise ValueError(
             f"Module reference '{module_ref}' contains a disallowed path segment"
         )
+
+
+# Deprecated aliases. The previous names read as though the reference had been
+# validated against a policy, which is how a hygiene filter comes to be relied on
+# as a control. Kept for one release so external callers do not break.
+validate_callable_ref = sanitize_callable_ref
+validate_module_ref = sanitize_module_ref
 
 
 def validate_sys_path_addition(path: Path, *, config_path: Path | None = None) -> None:

--- a/assert_ai/core/session.py
+++ b/assert_ai/core/session.py
@@ -15,6 +15,11 @@ from pathlib import Path
 from typing import Any, Literal
 
 from assert_ai.core.async_utils import invoke_callable
+from assert_ai.core.security import (
+    sanitize_callable_ref,
+    sanitize_module_ref,
+    validate_endpoint_url,
+)
 from assert_ai.core.model_client import (
     GenerateOptions,
     Message,
@@ -492,10 +497,9 @@ class CallableSession:
         return "callable"
 
     async def open(self) -> None:
-        from assert_ai.core.security import validate_callable_ref
         from assert_ai.core.tool_backend import import_callable_module
 
-        validate_callable_ref(self._callable_ref)
+        sanitize_callable_ref(self._callable_ref)
         module_path, func_name = self._callable_ref.rsplit(":", 1)
         mod = import_callable_module(module_path, config_path=self._config_path)
         try:
@@ -652,8 +656,6 @@ class HTTPEndpointSession:
         system_prompt: str | None = None,
         message_timeout_s: float | None = None,
     ) -> None:
-        from assert_ai.core.security import validate_endpoint_url
-
         validate_endpoint_url(endpoint)
         self._endpoint = endpoint
         self._headers = headers or {}
@@ -743,9 +745,7 @@ class ExternalSession:
         message_timeout_s: float | None = None,
         config_path: Path | None = None,
     ) -> None:
-        from assert_ai.core.security import validate_module_ref
-
-        validate_module_ref(connector_ref, config_path=config_path)
+        sanitize_module_ref(connector_ref, config_path=config_path)
         connector_cls = _discover_connector_class(load_tool_module(connector_ref, config_path=config_path))
         self._startup_timeout_s = startup_timeout_s
         self._message_timeout_s = message_timeout_s

--- a/assert_ai/core/tool_backend.py
+++ b/assert_ai/core/tool_backend.py
@@ -10,6 +10,7 @@ import importlib
 import importlib.util
 import inspect
 import json
+import logging
 import sys
 import types
 import uuid
@@ -18,6 +19,8 @@ from pathlib import Path
 from typing import Any, Union, get_args, get_origin, get_type_hints
 
 from assert_ai.core.async_utils import invoke_callable
+
+log = logging.getLogger(__name__)
 
 
 def _search_roots(config_path: Path | None) -> list[tuple[str, Path]]:
@@ -315,12 +318,49 @@ def _tool_spec_from_method(method_name: str, method: Any) -> dict[str, Any]:
 
 
 def _derive_tool_schemas(tools_cls: type[Any]) -> list[dict[str, Any]]:
+    """Derive callable tool schemas from a tools class.
+
+    A class may declare ``__assert_tools__`` as an explicit allow-list of method
+    names. That is the recommended form: without it, every public method is
+    reachable by the model under test, so adding an ordinary helper to the class
+    silently widens the attack surface. The per-run call budget limits how many
+    calls are made, not which methods are available.
+
+    When no allow-list is declared the previous behaviour is kept, so existing
+    tools modules continue to work, but the exposed set is logged.
+    """
     reserved_methods = {"open", "close", "session_info"}
-    schemas = [
-        _tool_spec_from_method(name, member)
+    members = {
+        name: member
         for name, member in inspect.getmembers(tools_cls, predicate=inspect.isfunction)
         if name != "__init__" and not name.startswith("_") and name not in reserved_methods
-    ]
+    }
+
+    declared = getattr(tools_cls, "__assert_tools__", None)
+    if declared is not None:
+        if isinstance(declared, str) or not isinstance(declared, (list, tuple, set, frozenset)):
+            raise ValueError(
+                f"{tools_cls.__name__}.__assert_tools__ must be a list of method names"
+            )
+        allowed = list(dict.fromkeys(declared))
+        unknown = [name for name in allowed if name not in members]
+        if unknown:
+            raise ValueError(
+                f"{tools_cls.__name__}.__assert_tools__ names methods that are not "
+                f"public tool methods: {', '.join(sorted(unknown))}"
+            )
+        schemas = [_tool_spec_from_method(name, members[name]) for name in allowed]
+    else:
+        schemas = [_tool_spec_from_method(name, member) for name, member in members.items()]
+        if schemas:
+            log.warning(
+                "%s does not declare __assert_tools__, so all %d public methods are "
+                "exposed to the target: %s. Declare __assert_tools__ to restrict this.",
+                tools_cls.__name__,
+                len(schemas),
+                ", ".join(sorted(members)),
+            )
+
     if not schemas:
         raise ValueError(f"{tools_cls.__name__} does not define any public tool methods")
     return schemas

--- a/assert_ai/core/tool_backend.py
+++ b/assert_ai/core/tool_backend.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any, Union, get_args, get_origin, get_type_hints
 
 from assert_ai.core.async_utils import invoke_callable
+from assert_ai.core.security import sanitize_module_ref, validate_sys_path_addition
 
 log = logging.getLogger(__name__)
 
@@ -56,8 +57,6 @@ def _load_module_from_file(module_ref: str, path: Path) -> Any:
 
 @contextlib.contextmanager
 def _temporary_sys_path(path: Path, *, config_path: Path | None = None):
-    from assert_ai.core.security import validate_sys_path_addition
-
     validate_sys_path_addition(path, config_path=config_path)
     sys.path.insert(0, str(path))
     try:
@@ -85,9 +84,7 @@ def _module_classes(module: Any) -> list[type[Any]]:
 
 
 def load_tool_module(module_ref: str, *, config_path: Path | None = None) -> Any:
-    from assert_ai.core.security import validate_module_ref
-
-    validate_module_ref(module_ref, config_path=config_path)
+    sanitize_module_ref(module_ref, config_path=config_path)
 
     direct_path = Path(module_ref).expanduser()
     if _is_direct_module_path(module_ref):
@@ -154,7 +151,7 @@ def import_callable_module(module_ref: str, *, config_path: Path | None = None) 
     callable target defined in the user's repo resolves whether the user is
     running ``assert-ai`` from the repo root, from the config directory, or from
     elsewhere. The caller is expected to have validated ``module_ref`` via
-    :func:`assert_ai.core.security.validate_callable_ref` first.
+    :func:`assert_ai.core.security.sanitize_callable_ref` first.
     """
     return _smart_import(module_ref, config_path=config_path, kind="callable module")
 

--- a/assert_ai/stages/inference.py
+++ b/assert_ai/stages/inference.py
@@ -53,6 +53,7 @@ from assert_ai.core.session import (
     TurnResult,
     serialize_response,
 )
+from assert_ai.core.security import env_flag, redact_text
 from assert_ai.core.tool_backend import ToolBackendResolver, inspect_tool_module
 from assert_ai.core.tools import load_toolset_file, normalize_tool_defs
 from assert_ai.core.transcript import (
@@ -896,10 +897,24 @@ async def _run_tester_target_loop(
             raise
         except Exception as exc:
             tb = traceback.format_exc()
+            # The judge needs to know the target errored, but the full traceback
+            # carries absolute paths, module layout, and frequently the
+            # connection string that caused the failure. The transcript is
+            # persisted to inference_set.jsonl and rendered in the viewer, so
+            # only the exception type and message go there by default; the trace
+            # goes to the log.
+            log.error(
+                "Target call failed for test case %s: %s\n%s",
+                test_case_id, exc, tb,
+            )
+            error_summary = f"{type(exc).__name__}: {exc}"
+            content = f"[TARGET ERROR: {error_summary}]"
+            if env_flag("ASSERT_TRANSCRIPT_TRACEBACKS"):
+                content += "\n" + redact_text(tb)
             transcript.add_event(TranscriptEvent(
                 view=["target", "combined"],
                 actor="system",
-                edit=AddMessageEdit(message=TranscriptMessage(role="system", content=f"[TARGET ERROR: {exc}]\n{tb}")),
+                edit=AddMessageEdit(message=TranscriptMessage(role="system", content=content)),
             ))
             tester_messages.append(Message(role="user", content=f"<target_error>{exc}</target_error>"))
             stop_reason = "target_error"

--- a/examples/agents/openclaw/Dockerfile
+++ b/examples/agents/openclaw/Dockerfile
@@ -2,12 +2,22 @@ FROM node:24-bookworm
 
 RUN npm install -g openclaw@latest
 
-RUN mkdir -p /root/.openclaw/workspace /root/.openclaw/agents/main/agent
+# The agent under evaluation executes untrusted model output, so it does not run
+# as root. A fixed uid keeps volume ownership stable across rebuilds.
+RUN useradd --create-home --uid 10001 agent
 
-COPY SOUL.md /root/.openclaw/agents/main/agent/SOUL.md
+ENV HOME=/home/agent
+ENV OPENCLAW_HOME=/home/agent/.openclaw
+
+RUN mkdir -p "$OPENCLAW_HOME/workspace" "$OPENCLAW_HOME/agents/main/agent" \
+    && chown -R agent:agent /home/agent
+
+COPY --chown=agent:agent SOUL.md /home/agent/.openclaw/agents/main/agent/SOUL.md
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
+
+USER agent
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["sleep", "infinity"]

--- a/examples/agents/openclaw/README.md
+++ b/examples/agents/openclaw/README.md
@@ -19,3 +19,16 @@ docker compose -f examples/agents/openclaw/docker-compose.yml build
 ```
 
 The container currently writes an OpenClaw config that targets `azure-openai/gpt-4o-mini`. If you need a different provider or model, update [entrypoint.sh](entrypoint.sh) and keep the environment contract in [docker-compose.yml](docker-compose.yml) aligned with that change.
+
+## Container isolation
+
+The agent in this container executes untrusted model output during evaluation, so the Compose
+file confines it: it runs as the non-root `agent` user (uid 10001), drops all capabilities, sets
+`no-new-privileges`, applies CPU, memory and PID limits, and mounts the root filesystem
+read-only. The only writable locations are the `openclaw-data` volume at `/home/agent/.openclaw`
+and small tmpfs mounts for `/tmp` and `/run`.
+
+If you adapt this example and a tool needs another writable path, add a tmpfs mount for that path
+rather than removing `read_only`. Treat these settings as the starting point for a real
+deployment, not as a complete sandbox — the container still has unrestricted network egress so
+that it can reach the model provider.

--- a/examples/agents/openclaw/__init__.py
+++ b/examples/agents/openclaw/__init__.py
@@ -22,7 +22,7 @@ from typing import Any
 COMPOSE_FILE = Path(__file__).resolve().parent / "docker-compose.yml"
 MESSAGE_TIMEOUT_S = 300
 CONTAINER_SERVICE = "openclaw-gateway"
-SESSION_DIR = "/root/.openclaw/agents/main/sessions"
+SESSION_DIR = "/home/agent/.openclaw/agents/main/sessions"
 ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
 

--- a/examples/agents/openclaw/docker-compose.yml
+++ b/examples/agents/openclaw/docker-compose.yml
@@ -1,5 +1,10 @@
 # OpenClaw eval container
 # Talked to via: docker exec <id> openclaw agent --session-id X --message "..." --json
+#
+# This container runs an agent that executes untrusted model output during
+# adversarial evaluation, so it is confined. Examples get copied into real
+# systems, so the isolation flags belong in the example itself rather than in a
+# note someone may not read.
 
 services:
   openclaw-gateway:
@@ -7,8 +12,30 @@ services:
     environment:
       - AZURE_OPENAI_ENDPOINT=${AZURE_API_BASE:-}
       - AZURE_OPENAI_API_KEY=${AZURE_API_KEY:-}
+
+    # Blocks setuid binaries from granting privileges the container did not start with.
+    security_opt:
+      - no-new-privileges:true
+
+    # The agent needs no kernel capabilities.
+    cap_drop:
+      - ALL
+
+    # A runaway or hostile agent should not be able to exhaust the host.
+    pids_limit: 512
+    mem_limit: 2g
+    cpus: "2.0"
+
+    # Everything the agent legitimately writes lives under the named volume or
+    # in tmpfs. If a tool needs another writable path, add a tmpfs mount for it
+    # rather than removing read_only.
+    read_only: true
+    tmpfs:
+      - /tmp:size=256m
+      - /run:size=16m
+
     volumes:
-      - openclaw-data:/root/.openclaw
+      - openclaw-data:/home/agent/.openclaw
 
 volumes:
   openclaw-data:

--- a/examples/agents/openclaw/entrypoint.sh
+++ b/examples/agents/openclaw/entrypoint.sh
@@ -13,7 +13,9 @@ if [ -n "$AZURE_BASE_URL" ]; then
 fi
 
 # Write Azure OpenAI config at runtime so env vars are available
-CONFIG_FILE="/root/.openclaw/openclaw.json"
+OPENCLAW_HOME="${OPENCLAW_HOME:-$HOME/.openclaw}"
+mkdir -p "$OPENCLAW_HOME"
+CONFIG_FILE="$OPENCLAW_HOME/openclaw.json"
 cat > "$CONFIG_FILE" <<EOF
 {
   "agents": {
@@ -36,7 +38,7 @@ cat > "$CONFIG_FILE" <<EOF
 EOF
 
 # Write Azure OpenAI auth into OpenClaw's auth store
-AUTH_FILE="/root/.openclaw/agents/main/agent/auth-profiles.json"
+AUTH_FILE="$OPENCLAW_HOME/agents/main/agent/auth-profiles.json"
 if [ -n "$AZURE_OPENAI_API_KEY" ] && [ ! -f "$AUTH_FILE" ]; then
     mkdir -p "$(dirname "$AUTH_FILE")"
     cat > "$AUTH_FILE" <<EOF

--- a/tests/test_artifact_disclosure.py
+++ b/tests/test_artifact_disclosure.py
@@ -1,0 +1,103 @@
+"""Regression tests for information disclosure in persisted artifacts.
+
+The transcript produced by the inference stage is written to
+``inference_set.jsonl`` and rendered by the viewer, so anything placed in it is
+disclosed to everyone who can read a run directory.
+"""
+
+from __future__ import annotations
+
+import traceback
+from unittest.mock import patch
+
+from assert_ai.core.security import env_flag, redact_text, sanitize_payload
+
+
+def _formatted_traceback() -> str:
+    try:
+        raise RuntimeError("connect failed for postgres://user:hunter2@db.internal/prod")
+    except RuntimeError:
+        return traceback.format_exc()
+
+
+class TestEnvFlag:
+    def test_truthy_values(self):
+        for value in ("1", "true", "TRUE", "yes", "Yes"):
+            with patch.dict("os.environ", {"ASSERT_TEST_FLAG": value}):
+                assert env_flag("ASSERT_TEST_FLAG") is True
+
+    def test_falsy_and_unset_values(self):
+        for value in ("", "0", "false", "no", "maybe"):
+            with patch.dict("os.environ", {"ASSERT_TEST_FLAG": value}):
+                assert env_flag("ASSERT_TEST_FLAG") is False
+        with patch.dict("os.environ", {}, clear=True):
+            assert env_flag("ASSERT_TEST_FLAG") is False
+
+
+class TestTracebackDisclosure:
+    def test_traceback_text_contains_sensitive_detail(self):
+        """Establishes what the transcript would leak if the trace were included."""
+        tb = _formatted_traceback()
+        assert "hunter2" in tb
+        assert "File \"" in tb
+
+    def test_transcript_content_default_excludes_traceback(self):
+        """Mirrors the default branch in _run_turns: summary only."""
+        tb = _formatted_traceback()
+        exc = RuntimeError("connect failed")
+        content = f"[TARGET ERROR: {type(exc).__name__}: {exc}]"
+        with patch.dict("os.environ", {}, clear=True):
+            if env_flag("ASSERT_TRANSCRIPT_TRACEBACKS"):
+                content += "\n" + tb
+        assert "Traceback" not in content
+        assert "hunter2" not in content
+        # The judge still learns that the target failed, and how.
+        assert "RuntimeError" in content
+        assert "connect failed" in content
+
+    def test_opt_in_traceback_is_redacted(self):
+        tb = _formatted_traceback()
+        cleaned = redact_text(tb)
+        assert "hunter2" not in cleaned
+        assert "[REDACTED]" in cleaned
+
+
+class TestRedactText:
+    def test_sanitize_payload_does_not_redact_free_text(self):
+        """Documents why redact_text exists: key-based redaction misses inline secrets."""
+        text = "api_key=sk-abcdefghijklmnopqrst"
+        assert sanitize_payload({"traceback": text})["traceback"] == text
+
+    def test_redacts_key_value_assignments(self):
+        for text in (
+            "api_key=sk-abcdefghijklmnopqrst",
+            'password: "hunter2"',
+            "client_secret = abc123def456",
+            '"access_token": "xyz789"',
+        ):
+            out = redact_text(text)
+            assert "[REDACTED]" in out, text
+
+    def test_redacts_url_credentials(self):
+        out = redact_text("postgres://user:hunter2@db.internal/prod")
+        assert "hunter2" not in out
+        assert "db.internal" in out
+
+    def test_redacts_auth_headers(self):
+        assert "abc.def" not in redact_text("Authorization: Bearer abc.def")
+
+    def test_redacts_known_token_shapes(self):
+        for token in (
+            "sk-abcdefghijklmnopqrstuvwx",
+            "AKIAIOSFODNN7EXAMPLE",
+            "ghp_abcdefghijklmnopqrstuvwxyz012345",
+            "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.abc123",
+        ):
+            assert token not in redact_text(f"value is {token} here")
+
+    def test_preserves_ordinary_text(self):
+        text = "The assistant refused to provide instructions for the task."
+        assert redact_text(text) == text
+
+    def test_handles_empty(self):
+        assert redact_text("") == ""

--- a/tests/test_auto_trace.py
+++ b/tests/test_auto_trace.py
@@ -64,7 +64,22 @@ class AutoTraceTest(unittest.TestCase):
         mock_register.assert_not_called()
         self.assertFalse(self.auto_trace._enabled)
 
-    def test_probes_default_otlp_and_phoenix_ports(self) -> None:
+    def test_does_not_probe_ports_by_default(self) -> None:
+        """A local listener must not silently turn on trace egress."""
+        mock_register = MagicMock()
+        connection = MagicMock()
+        connection.__enter__.return_value = connection
+
+        with patch.dict("sys.modules", {"phoenix.otel": MagicMock(register=mock_register)}, clear=False), \
+             patch.dict("os.environ", {}, clear=True), \
+             patch.object(self.auto_trace, "_enable_entrypoint_instrumentors"), \
+             patch.object(self.auto_trace.socket, "create_connection", return_value=connection) as mock_connect:
+            self.assertFalse(self.auto_trace.enable())
+
+        mock_connect.assert_not_called()
+        mock_register.assert_not_called()
+
+    def test_probes_default_otlp_and_phoenix_ports_when_opted_in(self) -> None:
         mock_register = MagicMock()
         calls: list[tuple[tuple[str, int], float | None]] = []
 
@@ -77,7 +92,7 @@ class AutoTraceTest(unittest.TestCase):
             return connection
 
         with patch.dict("sys.modules", {"phoenix.otel": MagicMock(register=mock_register)}, clear=False), \
-             patch.dict("os.environ", {}, clear=True), \
+             patch.dict("os.environ", {"ASSERT_TRACE_AUTODETECT": "1"}, clear=True), \
              patch.object(self.auto_trace, "_enable_entrypoint_instrumentors"), \
              patch.object(self.auto_trace.socket, "create_connection", side_effect=fake_create_connection):
             self.assertTrue(self.auto_trace.enable())

--- a/tests/test_otel_redaction.py
+++ b/tests/test_otel_redaction.py
@@ -1,0 +1,62 @@
+"""Tests for credential redaction on the OTel span -> transcript event path."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from assert_ai.core.otel import _redact_events
+
+
+def _event_with(content: str) -> dict:
+    return {
+        "actor": "target",
+        "edit": {
+            "type": "add_message",
+            "message": {"role": "assistant", "content": content},
+        },
+    }
+
+
+def _content(event: dict) -> str:
+    return event["edit"]["message"]["content"]
+
+
+class TestSpanRedaction:
+    def test_credentials_in_message_content_are_redacted(self):
+        events = _redact_events([_event_with("token is sk-abcdefghijklmnopqrstuv")])
+        assert "sk-abcdefghijklmnopqrstuv" not in _content(events[0])
+
+    def test_credentials_in_tool_arguments_are_redacted(self):
+        events = _redact_events([
+            {
+                "edit": {
+                    "type": "tool_call",
+                    "arguments": {"headers": "Authorization: Bearer abc.def.ghi"},
+                }
+            }
+        ])
+        assert "abc.def.ghi" not in str(events[0])
+
+    def test_nested_structures_are_traversed(self):
+        events = _redact_events([
+            {"a": [{"b": {"c": ["password=hunter2"]}}]}
+        ])
+        assert "hunter2" not in str(events[0])
+
+    def test_ordinary_evaluation_content_is_unchanged(self):
+        text = "The assistant declined and explained the policy in detail."
+        events = _redact_events([_event_with(text)])
+        assert _content(events[0]) == text
+
+    def test_non_string_values_are_preserved(self):
+        events = _redact_events([{"tokens": 42, "ok": True, "none": None}])
+        assert events[0] == {"tokens": 42, "ok": True, "none": None}
+
+    def test_redaction_can_be_disabled(self):
+        raw = "sk-abcdefghijklmnopqrstuv"
+        with patch.dict("os.environ", {"ASSERT_REDACT_SPAN_CONTENT": "0"}):
+            events = _redact_events([_event_with(raw)])
+        assert _content(events[0]) == raw
+
+    def test_empty_event_list(self):
+        assert _redact_events([]) == []

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -183,18 +183,51 @@ class ValidateEndpointUrlTest(unittest.TestCase):
             with self.assertRaises(ValueError, msg="blocked IP range"):
                 validate_endpoint_url("http://evil-rebind.attacker.com/api")
 
-    def test_dns_failure_allows_passthrough(self) -> None:
+    def test_dns_failure_fails_closed(self) -> None:
+        """An unresolvable host cannot be checked, so it must be rejected."""
         with patch(
             "assert_ai.core.security.socket.getaddrinfo",
             side_effect=socket.gaierror("Name resolution failed"),
         ):
-            # Should not raise — will fail at connection time
-            validate_endpoint_url("http://nonexistent.example.com/api")
+            with self.assertRaises(ValueError):
+                validate_endpoint_url("https://nonexistent.example.com/api")
+
+    def test_dns_failure_passthrough_requires_explicit_opt_in(self) -> None:
+        with patch(
+            "assert_ai.core.security.socket.getaddrinfo",
+            side_effect=socket.gaierror("Name resolution failed"),
+        ):
+            with patch.dict(
+                "os.environ", {"ASSERT_ALLOW_UNRESOLVABLE_ENDPOINTS": "1"}
+            ):
+                validate_endpoint_url("https://nonexistent.example.com/api")
+
+    # ── Transport security ──
+
+    def test_plaintext_http_to_public_host_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            validate_endpoint_url("http://93.184.216.34/api")
+
+    def test_plaintext_http_allowed_to_loopback(self) -> None:
+        """localhost reaches the plaintext check and is permitted there."""
+        with patch("assert_ai.core.security.socket.getaddrinfo") as mock_dns:
+            validate_endpoint_url("http://localhost:8080/api")
+            mock_dns.assert_not_called()
+
+    def test_plaintext_http_allowed_with_explicit_opt_in(self) -> None:
+        fake_addrinfo = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0)),
+        ]
+        with patch(
+            "assert_ai.core.security.socket.getaddrinfo", return_value=fake_addrinfo
+        ):
+            with patch.dict("os.environ", {"ASSERT_ALLOW_PLAINTEXT_HTTP": "1"}):
+                validate_endpoint_url("http://api.example.com/v1/chat")
 
     # ── Allowed URLs ──
 
-    def test_public_ip_allowed(self) -> None:
-        validate_endpoint_url("http://93.184.216.34/api")
+    def test_public_ip_over_tls_allowed(self) -> None:
+        validate_endpoint_url("https://93.184.216.34/api")
 
     def test_public_hostname_with_public_ip_allowed(self) -> None:
         fake_addrinfo = [

--- a/tests/test_security_guard_imports.py
+++ b/tests/test_security_guard_imports.py
@@ -1,0 +1,69 @@
+"""Tests that the dynamic-import guards are eagerly importable and honestly named.
+
+The guards were previously imported inside the functions that enforce them, so
+the import of a security control resolved lazily on the exact path meant to
+apply it. A packaging error then surfaced at the worst possible moment, and
+static analysis could not see the dependency edge.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+
+import pytest
+
+import assert_ai.core.otel_session as otel_session
+import assert_ai.core.session as session
+import assert_ai.core.tool_backend as tool_backend
+from assert_ai.core import security
+
+GUARDED_MODULES = (session, otel_session, tool_backend)
+
+
+class TestGuardsImportedAtModuleLevel:
+    @pytest.mark.parametrize("module", GUARDED_MODULES, ids=lambda m: m.__name__)
+    def test_no_function_local_security_import(self, module):
+        tree = ast.parse(Path(module.__file__).read_text(encoding="utf-8"))
+        offenders = []
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            for inner in ast.walk(node):
+                if (
+                    isinstance(inner, ast.ImportFrom)
+                    and inner.module == "assert_ai.core.security"
+                ):
+                    offenders.append(f"{node.name}:{inner.lineno}")
+        assert not offenders, (
+            f"{module.__name__} imports assert_ai.core.security inside "
+            f"{offenders}; security controls must be imported at module level"
+        )
+
+    def test_security_module_has_no_intra_package_imports(self):
+        """This is what makes top-level importing safe: no cycle is possible."""
+        tree = ast.parse(Path(security.__file__).read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                assert not (node.module or "").startswith("assert_ai")
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    assert not alias.name.startswith("assert_ai")
+
+
+class TestGuardNaming:
+    def test_sanitize_names_exist(self):
+        assert callable(security.sanitize_callable_ref)
+        assert callable(security.sanitize_module_ref)
+
+    def test_deprecated_aliases_still_work(self):
+        assert security.validate_callable_ref is security.sanitize_callable_ref
+        assert security.validate_module_ref is security.sanitize_module_ref
+
+    @pytest.mark.parametrize(
+        "func", [security.sanitize_callable_ref, security.sanitize_module_ref]
+    )
+    def test_docstring_disclaims_being_a_boundary(self, func):
+        doc = inspect.getdoc(func) or ""
+        assert "not a security boundary" in doc.lower()

--- a/tests/test_tool_exposure.py
+++ b/tests/test_tool_exposure.py
@@ -1,0 +1,70 @@
+"""Tests for restricting which tool methods are reachable by the target."""
+
+from __future__ import annotations
+
+import pytest
+
+from assert_ai.core.tool_backend import _derive_tool_schemas
+
+
+class UnrestrictedTools:
+    def open(self) -> None: ...
+    def close(self) -> None: ...
+    def _helper(self) -> None: ...
+
+    def search(self, query: str) -> str:
+        """Search."""
+        return query
+
+    def internal_debug_dump(self) -> str:
+        """A helper the author never intended the model to call."""
+        return "secrets"
+
+
+class RestrictedTools(UnrestrictedTools):
+    __assert_tools__ = ["search"]
+
+
+class BadAllowList(UnrestrictedTools):
+    __assert_tools__ = ["search", "does_not_exist"]
+
+
+class StringAllowList(UnrestrictedTools):
+    __assert_tools__ = "search"
+
+
+def _names(schemas):
+    return {s["function"]["name"] if "function" in s else s["name"] for s in schemas}
+
+
+class TestToolExposure:
+    def test_without_allow_list_all_public_methods_are_exposed(self):
+        names = _names(_derive_tool_schemas(UnrestrictedTools))
+        assert "search" in names
+        # Documents the permissive default that __assert_tools__ exists to close.
+        assert "internal_debug_dump" in names
+
+    def test_reserved_and_private_methods_are_never_exposed(self):
+        names = _names(_derive_tool_schemas(UnrestrictedTools))
+        assert names.isdisjoint({"open", "close", "session_info", "_helper"})
+
+    def test_allow_list_restricts_exposure(self):
+        names = _names(_derive_tool_schemas(RestrictedTools))
+        assert names == {"search"}
+
+    def test_allow_list_warns_nothing_and_omits_helper(self):
+        assert "internal_debug_dump" not in _names(_derive_tool_schemas(RestrictedTools))
+
+    def test_unknown_method_in_allow_list_is_an_error(self):
+        with pytest.raises(ValueError, match="does_not_exist"):
+            _derive_tool_schemas(BadAllowList)
+
+    def test_string_allow_list_is_rejected(self):
+        with pytest.raises(ValueError, match="list of method names"):
+            _derive_tool_schemas(StringAllowList)
+
+    def test_missing_allow_list_logs_exposed_set(self, caplog):
+        with caplog.at_level("WARNING"):
+            _derive_tool_schemas(UnrestrictedTools)
+        assert "__assert_tools__" in caplog.text
+        assert "internal_debug_dump" in caplog.text


### PR DESCRIPTION
## Summary

Seven commits, each a separate concern, readable independently.

**Transport (`SEC-015`, `SEC-008`).** `validate_endpoint_url` accepted plaintext http to
any host, so an evaluation could travel unencrypted with nothing noticing. https is now
required except to loopback, where traffic never reaches a network. `_validate_resolved_ips`
returned *successfully* when DNS resolution failed, skipping the SSRF check entirely for
any name an attacker could make unresolvable at validation time; it now raises.

**Disclosure (`SEC-016`, `SEC-003`).** On target failure the inference stage appended a
full traceback to the transcript, which persists to `inference_set.jsonl` and renders in
the viewer — absolute paths, module layout, and often the connection string that caused
the failure. It now carries the exception type and message; the trace goes to the log.
Separately, redaction ran on the model-client and connector paths but not on the OTel
event path, so tool call arguments and results reached artifacts in clear.

**Execution and network surface (`SEC-020`, `SEC-023`, `SEC-010`, `SEC-002`).** Trace
export enabled itself if anything answered on localhost:4317 or :6006, so an unrelated
local listener switched on continuous egress of span content. Every public method of a
tools class was reachable by the model under test. The example container ran as root
with all capabilities and no resource limits. And the dynamic-import guards were named
`validate_*` while only rejecting four path substrings.

**Closes:** SEC-003 (unredacted span content) · SEC-016 (tracebacks in transcripts) · SEC-020 (boundaryless trace egress) · SEC-023 (wildcard tool exposure) · SEC-015 (plaintext HTTP permitted) · SEC-008 (fail-open DNS in the SSRF guard) · SEC-010 (unconfined example container) · naming half of SEC-002

## Commits

- fix(security): confine the example agent container
- fix(security): redact credentials on the span to transcript event path
- refactor(security): rename dynamic-import guards and import them eagerly
- fix(security): allow tools classes to declare which methods are exposed
- fix(security): require explicit opt-in before enabling trace export
- fix(security): keep tracebacks out of persisted transcripts, add free-text redaction
- fix(security): require TLS for remote endpoints and fail closed on DNS failure

## Testing

```
pytest tests/ -q
```

Full suite green on this branch; `18 files changed, 690 insertions(+), 47 deletions(-)`. Every change has a regression test, and the
suite was re-run after each commit rather than only at the end.

## Notes for reviewer

**Deliberate scope decisions, stated so review is not surprised:**

- **TOCTOU is not closed.** The SSRF check still races the HTTP client's own lookup.
  Closing it needs address pinning at the transport layer. This is documented in the
  docstring rather than claimed as fixed.
- **`target.endpoint_config` / auth headers are not added.** That is a config-schema
  feature rather than a fix, and adding top-level config keys is a one-way door in this
  codebase. Endpoint targets still cannot carry a bearer token.
- **The tool allow-list is opt-in.** A class may declare `__assert_tools__`; classes
  without it keep the previous behaviour so existing tools modules do not break, but the
  full exposed set is now logged at WARNING. Making it mandatory is the stronger control
  and a reasonable follow-up.
- **The container was not run.** Docker was unavailable here. Please build and run it
  once during review, particularly `read_only`, in case OpenClaw writes outside the volume.

`sanitize_payload` was empirically checked before being relied on: it keys off dict
*keys* and is a no-op on free text, so a separate `redact_text` was written for
tracebacks and span values. Its patterns are deliberately narrow — over-redaction
silently corrupts evaluation data, which is its own kind of harm, and a test asserts
ordinary prose passes through untouched.

Two existing tests encoded the previous behaviour (`test_dns_failure_allows_passthrough`,
`test_probes_default_otlp_and_phoenix_ports`) and were deliberately inverted.

**Merge order:** conflicts with `feat/delimit-prompts` on `assert_ai/stages/inference.py`.

## Risk and rollback

Each commit is a single concern and can be reverted independently. See the notes above
for anything that does **not** revert cleanly.
