### PR TITLE
feat(artifacts): verify, preserve, and attribute evaluation artifacts

### DIFF
--- a/assert_ai/core/artifact_cache.py
+++ b/assert_ai/core/artifact_cache.py
@@ -44,6 +44,7 @@ from pathlib import Path
 from typing import Any
 
 from assert_ai.core.io import PROMPTS_DIR, write_json
+from assert_ai.core.io import file_sha256 as _file_sha256
 
 
 log = logging.getLogger(__name__)
@@ -652,8 +653,10 @@ def hash_payload(payload: Any) -> str:
     return hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
 
 
-def file_sha256(path: Path) -> str:
-    return hashlib.sha256(path.read_bytes()).hexdigest()
+# Re-exported so existing callers keep working. The implementation lives in
+# core.io, reads in chunks rather than loading the whole file, and is shared
+# with the artifact provenance sidecars so both compute the digest identically.
+file_sha256 = _file_sha256
 
 
 def _stage_descriptor(

--- a/assert_ai/core/artifact_cache.py
+++ b/assert_ai/core/artifact_cache.py
@@ -293,7 +293,7 @@ def activate_latest_artifacts(ctx: dict[str, Any]) -> None:
             else resolved_metadata_path
         )
         metadata = _load_json_object(metadata_path)
-        if metadata and _metadata_outputs_exist(stage_name, artifact_dir, metadata):
+        if metadata and _metadata_outputs_valid(stage_name, artifact_dir, metadata):
             output_paths = _metadata_output_paths(stage_name, artifact_dir, metadata)
             # If the original ref's path entries pointed at locations that no
             # longer exist, rebuild the ref with the resolved on-disk paths so
@@ -808,7 +808,7 @@ def _latest_matching_metadata(
             continue
         hashes = metadata.get("hashes")
         if isinstance(hashes, dict) and hashes.get("input_hash") == input_hash:
-            if _metadata_outputs_exist(stage_name, version_dir, metadata):
+            if _metadata_outputs_valid(stage_name, version_dir, metadata):
                 matches.append((version_dir.name, metadata))
     return matches[-1] if matches else None
 
@@ -821,7 +821,7 @@ def _recover_latest_valid_version(
 
     for version_dir in reversed(_iter_version_dirs(stage_root)):
         metadata = _load_json_object(version_dir / ARTIFACT_METADATA_FILE)
-        if metadata and _metadata_outputs_exist(stage_name, version_dir, metadata):
+        if metadata and _metadata_outputs_valid(stage_name, version_dir, metadata):
             return version_dir.name, version_dir, metadata
     return None
 
@@ -839,14 +839,26 @@ def _is_safe_artifact_basename(filename: Any) -> bool:
     return True
 
 
-def _metadata_outputs_exist(
+def _metadata_outputs_valid(
     stage_name: str, version_dir: Path, metadata: dict[str, Any]
 ) -> bool:
-    """Return True iff every expected output file for ``stage_name`` exists.
+    """Return True iff every expected output for ``stage_name`` exists and is intact.
 
     Uses the merged path map from :func:`_metadata_output_paths` so a partial
     or missing ``metadata['files']`` cannot trick the cache into activating a
     half-written artifact (or one that is missing the primary output file).
+
+    Existence alone is not enough. ``finalize_artifact_plan`` records a sha256
+    for every output in ``file_hashes``, but nothing compared them on the way
+    back in, so a cached artifact altered after it was written — by an
+    interrupted run, a stray editor save, or anyone with write access to the
+    suite directory — was reused as though it were the computed result, and the
+    scores derived from it looked legitimate.
+
+    A mismatch is treated as a cache miss rather than an error: the stage
+    recomputes, which is the outcome the operator wanted anyway. Set
+    ``ASSERT_SKIP_CACHE_VERIFY=1`` to skip hashing if it is too slow on very
+    large artifacts, accepting that the cache is then unverified.
     """
 
     output_paths = _metadata_output_paths(stage_name, version_dir, metadata)
@@ -856,6 +868,43 @@ def _metadata_outputs_exist(
     for key in expected_keys:
         path = output_paths.get(key)
         if path is None or not path.exists():
+            return False
+
+    if os.environ.get("ASSERT_SKIP_CACHE_VERIFY", "").lower() in ("1", "true", "yes"):
+        return True
+
+    file_hashes = metadata.get("file_hashes")
+    if not isinstance(file_hashes, dict):
+        # Written by a version that predates hash recording. Nothing to verify
+        # against, so fall back to the existence check rather than discarding a
+        # cache the user legitimately built.
+        return True
+
+    for key in expected_keys:
+        recorded = file_hashes.get(key)
+        if not isinstance(recorded, str):
+            continue
+        path = output_paths.get(key)
+        if path is None:
+            continue
+        try:
+            actual = file_sha256(path)
+        except OSError as e:
+            log.warning(
+                "Artifact cache: cannot read '%s' to verify it (%s); treating as a miss",
+                path,
+                e,
+            )
+            return False
+        if actual != recorded:
+            log.warning(
+                "Artifact cache: '%s' does not match the hash recorded when it was "
+                "created (expected %s, found %s). The artifact changed after caching, "
+                "so it will be recomputed instead of reused.",
+                path,
+                recorded[:12],
+                actual[:12],
+            )
             return False
     return True
 

--- a/assert_ai/core/config_model.py
+++ b/assert_ai/core/config_model.py
@@ -281,8 +281,12 @@ class RunManifest:
 
     def to_dict(self) -> dict[str, Any]:
         empty_collection_keys = {"artifact_versions", "stage_timings"}
-        return {
+        payload = {
             k: v
             for k, v in asdict(self).items()
             if v is not None and not (k in empty_collection_keys and not v)
         }
+        # Self-describing, so an older reader can tell it is looking at a
+        # manifest it may not fully understand.
+        payload["schema_version"] = 1
+        return payload

--- a/assert_ai/core/io.py
+++ b/assert_ai/core/io.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import logging
+import hashlib
 import os
 import re
 import tempfile
@@ -29,34 +30,73 @@ ARTIFACT_SCHEMA_VERSION = 1
 _SCHEMA_SIDECAR_SUFFIX = ".schema.json"
 
 
+def assert_version() -> str:
+    """Return the installed assert-ai version, or 'unknown' if unavailable.
+
+    Read from package metadata rather than hardcoded, so a provenance record
+    cannot claim a version the running code is not.
+    """
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+
+        return version("assert-ai")
+    except Exception:  # noqa: BLE001 - provenance must never fail a stage
+        return "unknown"
+
+
 def write_artifact_schema(
     artifact_path: Path,
     *,
     artifact: str,
     version: int = ARTIFACT_SCHEMA_VERSION,
+    produced_by: Dict[str, Any] | None = None,
 ) -> Path:
-    """Record the schema version of a JSONL artifact in a sidecar file.
+    """Record schema version and provenance for an artifact in a sidecar file.
+
+    Two problems share one fix.
 
     Only ``metrics.json`` carried a ``schema_version``; the primary artifacts did
     not, so one produced by a newer ASSERT is consumed silently by an older
-    viewer or analysis script. For a tool whose output is meant to be durable
-    evaluation evidence, the artifacts should say what they are.
+    viewer or analysis script.
+
+    Separately, stages hand work to each other through files and no stage can
+    tell whether its input came from the previous stage, from a cache hit, or
+    from someone editing the file. Recording which stage and model produced an
+    artifact, together with a digest of its bytes, lets a consumer answer that.
 
     A sidecar is used rather than a header line inside the JSONL. A header would
     be read as a data record by any reader that does not know about it -
     including the previous version of ASSERT - which turns a version stamp into
     a corrupt first row. A sidecar is ignored harmlessly instead.
     """
+    payload: Dict[str, Any] = {
+        "artifact": artifact,
+        "schema_version": version,
+    }
+    try:
+        payload["content_sha256"] = file_sha256(artifact_path)
+    except OSError:
+        # A digest is useful, not essential; never fail a stage over it.
+        log.debug("Could not hash %s for its provenance sidecar", artifact_path)
+    if produced_by:
+        payload["produced_by"] = produced_by
+
     sidecar = artifact_path.with_name(artifact_path.name + _SCHEMA_SIDECAR_SUFFIX)
-    write_json(
-        sidecar,
-        {"artifact": artifact, "schema_version": version},
-    )
+    write_json(sidecar, payload)
     return sidecar
 
 
-def read_artifact_schema_version(artifact_path: Path) -> int | None:
-    """Return the recorded schema version for an artifact, if there is one."""
+def file_sha256(path: Path) -> str:
+    """Return the hex sha256 of a file, read in chunks."""
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def read_artifact_sidecar(artifact_path: Path) -> Dict[str, Any] | None:
+    """Return the parsed provenance sidecar for an artifact, if there is one."""
     sidecar = artifact_path.with_name(artifact_path.name + _SCHEMA_SIDECAR_SUFFIX)
     if not sidecar.exists():
         return None
@@ -64,8 +104,45 @@ def read_artifact_schema_version(artifact_path: Path) -> int | None:
         payload = json.loads(sidecar.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return None
-    version = payload.get("schema_version") if isinstance(payload, dict) else None
+    return payload if isinstance(payload, dict) else None
+
+
+def read_artifact_schema_version(artifact_path: Path) -> int | None:
+    """Return the recorded schema version for an artifact, if there is one."""
+    payload = read_artifact_sidecar(artifact_path)
+    if payload is None:
+        return None
+    version = payload.get("schema_version")
     return version if isinstance(version, int) else None
+
+
+def verify_artifact_provenance(artifact_path: Path) -> bool:
+    """Warn when an artifact's bytes differ from what its producer recorded.
+
+    Returns True when the artifact matches, or when there is nothing to check
+    against - an unstamped artifact predates this and must stay readable.
+    """
+    payload = read_artifact_sidecar(artifact_path)
+    if payload is None:
+        return True
+    recorded = payload.get("content_sha256")
+    if not isinstance(recorded, str):
+        return True
+    try:
+        actual = file_sha256(artifact_path)
+    except OSError:
+        return True
+    if actual == recorded:
+        return True
+    producer = payload.get("produced_by") or {}
+    log.warning(
+        "%s does not match the digest recorded when %s produced it. The file "
+        "changed after it was written; results derived from it describe "
+        "something other than that stage's output.",
+        artifact_path.name,
+        producer.get("stage") or "the producing stage",
+    )
+    return False
 
 
 def check_artifact_schema(artifact_path: Path) -> bool:

--- a/assert_ai/core/io.py
+++ b/assert_ai/core/io.py
@@ -10,6 +10,7 @@ import logging
 import os
 import re
 import tempfile
+from datetime import datetime, timezone
 from importlib.resources import files as _resource_files
 from importlib.resources.abc import Traversable
 from pathlib import Path
@@ -19,6 +20,127 @@ from typing import Any, Dict, Iterable
 log = logging.getLogger(__name__)
 
 BASE_DIR = Path(__file__).resolve().parents[2]
+
+# Version of the primary artifact contracts: taxonomy.json, test_set.jsonl,
+# inference_set.jsonl, scores.jsonl, manifest.json. Bump when a change would
+# make an older reader misinterpret an artifact rather than merely miss a field.
+ARTIFACT_SCHEMA_VERSION = 1
+
+_SCHEMA_SIDECAR_SUFFIX = ".schema.json"
+
+
+def write_artifact_schema(
+    artifact_path: Path,
+    *,
+    artifact: str,
+    version: int = ARTIFACT_SCHEMA_VERSION,
+) -> Path:
+    """Record the schema version of a JSONL artifact in a sidecar file.
+
+    Only ``metrics.json`` carried a ``schema_version``; the primary artifacts did
+    not, so one produced by a newer ASSERT is consumed silently by an older
+    viewer or analysis script. For a tool whose output is meant to be durable
+    evaluation evidence, the artifacts should say what they are.
+
+    A sidecar is used rather than a header line inside the JSONL. A header would
+    be read as a data record by any reader that does not know about it -
+    including the previous version of ASSERT - which turns a version stamp into
+    a corrupt first row. A sidecar is ignored harmlessly instead.
+    """
+    sidecar = artifact_path.with_name(artifact_path.name + _SCHEMA_SIDECAR_SUFFIX)
+    write_json(
+        sidecar,
+        {"artifact": artifact, "schema_version": version},
+    )
+    return sidecar
+
+
+def read_artifact_schema_version(artifact_path: Path) -> int | None:
+    """Return the recorded schema version for an artifact, if there is one."""
+    sidecar = artifact_path.with_name(artifact_path.name + _SCHEMA_SIDECAR_SUFFIX)
+    if not sidecar.exists():
+        return None
+    try:
+        payload = json.loads(sidecar.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    version = payload.get("schema_version") if isinstance(payload, dict) else None
+    return version if isinstance(version, int) else None
+
+
+def check_artifact_schema(artifact_path: Path) -> bool:
+    """Warn when an artifact was written by an incompatible ASSERT version.
+
+    Returns True when the artifact is safe to read. An artifact with no recorded
+    version predates the stamp and is assumed compatible, so existing runs keep
+    working.
+    """
+    version = read_artifact_schema_version(artifact_path)
+    if version is None or version == ARTIFACT_SCHEMA_VERSION:
+        return True
+    if version > ARTIFACT_SCHEMA_VERSION:
+        log.warning(
+            "%s was written with artifact schema v%d but this ASSERT understands "
+            "v%d. Fields may be missing or mean something different; read the "
+            "results with care.",
+            artifact_path.name, version, ARTIFACT_SCHEMA_VERSION,
+        )
+    else:
+        log.warning(
+            "%s uses artifact schema v%d, older than this ASSERT's v%d.",
+            artifact_path.name, version, ARTIFACT_SCHEMA_VERSION,
+        )
+    return False
+
+
+def archive_artifact(path: Path, *, reason: str) -> Path | None:
+    """Move a stale artifact aside instead of deleting it.
+
+    Resume and ``--force-stage`` previously called ``unlink()`` on
+    ``inference_set.jsonl`` and ``scores.jsonl``. Those files are the evaluation
+    evidence - every transcript, every verdict - and a config hash mismatch is
+    not always the operator's intention. Deleting them outright means an
+    accidental edit costs a full re-run, and the fact that anything was
+    destroyed is not recorded anywhere.
+
+    The file is renamed to ``<name>.<UTC timestamp>.bak`` beside the original
+    and the new path is logged. Returns the backup path, or ``None`` when the
+    file did not exist.
+
+    Backups are never pruned automatically, because pruning evidence is the
+    behaviour being fixed. Set ``ASSERT_DISCARD_STALE_ARTIFACTS=1`` to restore
+    the previous delete-outright behaviour.
+    """
+    if not path.exists():
+        return None
+
+    if os.environ.get("ASSERT_DISCARD_STALE_ARTIFACTS", "").lower() in ("1", "true", "yes"):
+        path.unlink()
+        log.info("Discarded %s (%s); ASSERT_DISCARD_STALE_ARTIFACTS is set", path, reason)
+        return None
+
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
+    backup = path.with_name(f"{path.name}.{stamp}.bak")
+    suffix = 1
+    while backup.exists():
+        backup = path.with_name(f"{path.name}.{stamp}.{suffix}.bak")
+        suffix += 1
+
+    try:
+        path.rename(backup)
+    except OSError as e:
+        # Preserving the file is best-effort. Failing the stage because a backup
+        # could not be written would be worse than proceeding, but the operator
+        # needs to know the evidence is about to go.
+        log.warning(
+            "Could not preserve %s as a backup (%s); removing it instead (%s)",
+            path, e, reason,
+        )
+        path.unlink(missing_ok=True)
+        return None
+
+    log.info("Preserved %s as %s (%s)", path.name, backup.name, reason)
+    return backup
 
 
 def resolve_path(path: str | Path) -> Path:

--- a/assert_ai/stages/inference.py
+++ b/assert_ai/stages/inference.py
@@ -34,6 +34,7 @@ from assert_ai.core.io import (
     INFERENCE_SET_FILE,
     append_jsonl_row,
     archive_artifact,
+    assert_version,
     get_permissible_flag,
     load_jsonl,
     load_prompt_text,
@@ -1379,7 +1380,16 @@ async def run(ctx: dict[str, Any], raw_cfg: dict[str, Any]) -> dict[str, Any]:
         target_model = target_obj.model.name or ""
     inference_set_out = Path(result["inference_set_path"])
     if inference_set_out.exists():
-        write_artifact_schema(inference_set_out, artifact="inference_set")
+        write_artifact_schema(
+            inference_set_out,
+            artifact="inference_set",
+            produced_by={
+                "stage": "inference",
+                "assert_version": assert_version(),
+                "target_model": target_model,
+                "run_id": str(ctx.get("run_id") or ""),
+            },
+        )
     return {
         "inference_set_path": result["inference_set_path"],
         "test_set_artifact_version": test_set_artifact_ref,

--- a/assert_ai/stages/inference.py
+++ b/assert_ai/stages/inference.py
@@ -33,12 +33,14 @@ from assert_ai.core.config_model import (
 from assert_ai.core.io import (
     INFERENCE_SET_FILE,
     append_jsonl_row,
+    archive_artifact,
     get_permissible_flag,
     load_jsonl,
     load_prompt_text,
     load_test_cases,
     normalize_test_case_rows,
     resolve_path,
+    write_artifact_schema,
     write_jsonl,
     row_factors,
 )
@@ -78,12 +80,11 @@ _JUDGE_ARTIFACTS_TO_CLEAN = ("scores.jsonl", ".judge_config_hash")
 
 
 def _remove_stale_judge_artifacts(run_dir: Path) -> None:
-    """Remove judge-stage outputs that depend on the inference data being replaced."""
+    """Move judge-stage outputs aside when the inference data they describe is replaced."""
     for name in _JUDGE_ARTIFACTS_TO_CLEAN:
         path = run_dir / name
         if path.exists():
-            log.info("[inference] Removing stale %s from %s", name, run_dir)
-            path.unlink()
+            archive_artifact(path, reason="inference data replaced")
 
 
 _VERSIONED_ARTIFACT_RE = re.compile(r"^v\d{4}$")
@@ -1069,16 +1070,16 @@ async def run_inference(
             # don't trust the hash because regenerated upstream artifacts may
             # be byte-identical (deterministic test-case generation, no stratification
             # dimensions, etc.) which would otherwise leave the cache intact.
-            inference_set_path.unlink()
+            archive_artifact(inference_set_path, reason="stage forced")
             _remove_stale_judge_artifacts(out_dir)
         else:
             # Check that existing inference rows were produced with the same config.
             stored_hash = config_hash_path.read_text(encoding="utf-8").strip() if config_hash_path.exists() else None
             if stored_hash is not None and stored_hash != config_hash:
                 log.warning(
-                    f"Inference config changed since last run - discarding {inference_set_path} and starting fresh"
+                    f"Inference config changed since last run - replacing {inference_set_path} and starting fresh"
                 )
-                inference_set_path.unlink()
+                archive_artifact(inference_set_path, reason="inference config changed")
                 _remove_stale_judge_artifacts(out_dir)
             else:
                 for row in load_jsonl(inference_set_path):
@@ -1376,6 +1377,9 @@ async def run(ctx: dict[str, Any], raw_cfg: dict[str, Any]) -> dict[str, Any]:
     target_model = ""
     if target_obj and target_obj.model:
         target_model = target_obj.model.name or ""
+    inference_set_out = Path(result["inference_set_path"])
+    if inference_set_out.exists():
+        write_artifact_schema(inference_set_out, artifact="inference_set")
     return {
         "inference_set_path": result["inference_set_path"],
         "test_set_artifact_version": test_set_artifact_ref,

--- a/assert_ai/stages/judge.py
+++ b/assert_ai/stages/judge.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 
 from assert_ai.config import resolve_stage_paths
 from assert_ai.core.io import SCORES_FILE, INFERENCE_SET_FILE, row_factors
-from assert_ai.core.io import append_jsonl_row, archive_artifact, load_jsonl, load_prompt_text, resolve_path, write_artifact_schema
+from assert_ai.core.io import append_jsonl_row, archive_artifact, assert_version, load_jsonl, load_prompt_text, resolve_path, write_artifact_schema
 from assert_ai.core.judge import (
     build_judge_contract,
     infer_judge_status,
@@ -520,7 +520,15 @@ async def run(ctx: dict[str, Any], raw_cfg: dict[str, Any]) -> dict[str, str]:
     )
     scores_out = Path(result["scores_path"])
     if scores_out.exists():
-        write_artifact_schema(scores_out, artifact="scores")
+        write_artifact_schema(
+            scores_out,
+            artifact="scores",
+            produced_by={
+                "stage": "judge",
+                "assert_version": assert_version(),
+                "run_id": str(ctx.get("run_id") or ""),
+            },
+        )
     return {
         "scores_path": result["scores_path"],
         "_summary": {

--- a/assert_ai/stages/judge.py
+++ b/assert_ai/stages/judge.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 
 from assert_ai.config import resolve_stage_paths
 from assert_ai.core.io import SCORES_FILE, INFERENCE_SET_FILE, row_factors
-from assert_ai.core.io import append_jsonl_row, load_jsonl, load_prompt_text, resolve_path
+from assert_ai.core.io import append_jsonl_row, archive_artifact, load_jsonl, load_prompt_text, resolve_path, write_artifact_schema
 from assert_ai.core.judge import (
     build_judge_contract,
     infer_judge_status,
@@ -364,14 +364,14 @@ async def run_judge(
             # rather than relying on a hash mismatch; regenerated upstream
             # inference rows may produce byte-identical scores under stable
             # judge config, which would otherwise leave the cache intact.
-            scores_path.unlink()
+            archive_artifact(scores_path, reason="stage forced")
         else:
             stored_hash = config_hash_path.read_text(encoding="utf-8").strip() if config_hash_path.exists() else None
             if stored_hash is not None and stored_hash != config_hash:
                 log.warning(
-                    f"Judge config or inference set changed since last run - discarding {scores_path} and starting fresh"
+                    f"Judge config or inference set changed since last run - replacing {scores_path} and starting fresh"
                 )
-                scores_path.unlink()
+                archive_artifact(scores_path, reason="judge config or inference set changed")
             else:
                 for prior in load_jsonl(scores_path):
                     sid = prior.get("test_case_id")
@@ -518,6 +518,9 @@ async def run(ctx: dict[str, Any], raw_cfg: dict[str, Any]) -> dict[str, str]:
         forced=bool(ctx.get("_stage_forced", False)),
         heartbeat=ctx.get("_heartbeat") if isinstance(ctx, dict) else None,
     )
+    scores_out = Path(result["scores_path"])
+    if scores_out.exists():
+        write_artifact_schema(scores_out, artifact="scores")
     return {
         "scores_path": result["scores_path"],
         "_summary": {

--- a/assert_ai/stages/systematize.py
+++ b/assert_ai/stages/systematize.py
@@ -16,7 +16,7 @@ from assert_ai.core.config_model import (
     DEFAULT_SYSTEMATIZE_MAX_TOKENS,
     DEFAULT_SYSTEMATIZE_TEMPERATURE,
 )
-from assert_ai.core.io import load_prompt_text, write_json
+from assert_ai.core.io import ARTIFACT_SCHEMA_VERSION, load_prompt_text, write_json
 from assert_ai.core.model_client import GenerateOptions, Message, generate_structured
 
 BASE_DIR = Path(__file__).resolve().parents[2]
@@ -128,6 +128,9 @@ async def run_systematize(
 
     save_path.mkdir(parents=True, exist_ok=True)
     taxonomy_path = save_path / "taxonomy.json"
+    # Self-describing, so a future change to the taxonomy contract is visible to
+    # an older viewer or analysis script rather than silently misread.
+    taxonomy_json.setdefault("schema_version", ARTIFACT_SCHEMA_VERSION)
     write_json(taxonomy_path, taxonomy_json)
 
     return {

--- a/assert_ai/stages/test_set.py
+++ b/assert_ai/stages/test_set.py
@@ -34,6 +34,7 @@ from assert_ai.core.io import (
     normalize_test_case_rows,
     resolve_path,
     slugify,
+    write_artifact_schema,
     write_jsonl,
 )
 from assert_ai.core.model_client import (
@@ -1176,6 +1177,7 @@ async def run_test_set(
     errored_count = sum(int(r.get("errored_count", 0)) for r in results)
     all_records = normalize_test_case_rows(all_records)
     write_jsonl(out_path, all_records)
+    write_artifact_schema(out_path, artifact="test_set")
 
     # --- Coverage check -------------------------------------------------------
     # Warn when generated test cases don't cover all taxonomy categories.

--- a/tests/test_artifact_cache_integrity.py
+++ b/tests/test_artifact_cache_integrity.py
@@ -1,0 +1,103 @@
+"""Tests that a cached artifact altered after creation is not silently reused.
+
+``finalize_artifact_plan`` records a sha256 for every output, but the cache
+previously activated a version on an existence check alone, so an artifact
+changed after it was written was reused as though it were the computed result.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+import pytest
+
+from assert_ai.core.artifact_cache import (
+    _OUTPUT_FILES,
+    _metadata_outputs_valid,
+    file_sha256,
+)
+
+STAGE = "systematize"
+
+
+def _stage_output_keys() -> list[str]:
+    return list(_OUTPUT_FILES.get(STAGE, {}).keys())
+
+
+def _build_version_dir(root: Path, *, content: str = '{"ok": true}\n') -> dict:
+    """Create a version dir with every expected output and matching hashes."""
+    version_dir = root / "v0001"
+    version_dir.mkdir(parents=True)
+
+    files: dict[str, str] = {}
+    file_hashes: dict[str, str] = {}
+    for key, filename in _OUTPUT_FILES[STAGE].items():
+        path = version_dir / filename
+        path.write_text(content, encoding="utf-8")
+        files[key] = filename
+        file_hashes[key] = file_sha256(path)
+
+    metadata = {"files": files, "file_hashes": file_hashes}
+    (version_dir / "artifact.json").write_text(json.dumps(metadata), encoding="utf-8")
+    return {"version_dir": version_dir, "metadata": metadata}
+
+
+@pytest.mark.skipif(not _stage_output_keys(), reason="stage has no declared outputs")
+class TestArtifactCacheVerification:
+    def test_intact_artifact_is_accepted(self):
+        with TemporaryDirectory() as tmp:
+            built = _build_version_dir(Path(tmp))
+            assert _metadata_outputs_valid(
+                STAGE, built["version_dir"], built["metadata"]
+            )
+
+    def test_missing_output_is_rejected(self):
+        with TemporaryDirectory() as tmp:
+            built = _build_version_dir(Path(tmp))
+            key = _stage_output_keys()[0]
+            (built["version_dir"] / _OUTPUT_FILES[STAGE][key]).unlink()
+            assert not _metadata_outputs_valid(
+                STAGE, built["version_dir"], built["metadata"]
+            )
+
+    def test_tampered_output_is_rejected(self):
+        with TemporaryDirectory() as tmp:
+            built = _build_version_dir(Path(tmp))
+            key = _stage_output_keys()[0]
+            target = built["version_dir"] / _OUTPUT_FILES[STAGE][key]
+            target.write_text('{"ok": false, "tampered": true}\n', encoding="utf-8")
+            assert not _metadata_outputs_valid(
+                STAGE, built["version_dir"], built["metadata"]
+            )
+
+    def test_tampering_is_logged(self, caplog):
+        with TemporaryDirectory() as tmp:
+            built = _build_version_dir(Path(tmp))
+            key = _stage_output_keys()[0]
+            target = built["version_dir"] / _OUTPUT_FILES[STAGE][key]
+            target.write_text("tampered\n", encoding="utf-8")
+            with caplog.at_level("WARNING"):
+                _metadata_outputs_valid(STAGE, built["version_dir"], built["metadata"])
+            assert "does not match the hash recorded" in caplog.text
+
+    def test_metadata_without_hashes_falls_back_to_existence(self):
+        """Artifacts from before hash recording must stay usable."""
+        with TemporaryDirectory() as tmp:
+            built = _build_version_dir(Path(tmp))
+            metadata = dict(built["metadata"])
+            metadata.pop("file_hashes")
+            assert _metadata_outputs_valid(STAGE, built["version_dir"], metadata)
+
+    def test_verification_can_be_skipped(self):
+        with TemporaryDirectory() as tmp:
+            built = _build_version_dir(Path(tmp))
+            key = _stage_output_keys()[0]
+            target = built["version_dir"] / _OUTPUT_FILES[STAGE][key]
+            target.write_text("tampered\n", encoding="utf-8")
+            with patch.dict("os.environ", {"ASSERT_SKIP_CACHE_VERIFY": "1"}):
+                assert _metadata_outputs_valid(
+                    STAGE, built["version_dir"], built["metadata"]
+                )

--- a/tests/test_artifact_preservation.py
+++ b/tests/test_artifact_preservation.py
@@ -1,0 +1,146 @@
+"""Tests for artifact preservation on resume and for schema stamping.
+
+Resume and --force-stage previously deleted inference_set.jsonl and
+scores.jsonl outright. Those files are the evaluation evidence, and a config
+hash mismatch is not always what the operator intended.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from assert_ai.core.io import (
+    ARTIFACT_SCHEMA_VERSION,
+    archive_artifact,
+    check_artifact_schema,
+    read_artifact_schema_version,
+    write_artifact_schema,
+)
+
+
+class TestArchiveArtifact:
+    def test_missing_file_returns_none(self):
+        with TemporaryDirectory() as tmp:
+            assert archive_artifact(Path(tmp) / "absent.jsonl", reason="x") is None
+
+    def test_file_is_preserved_not_deleted(self):
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "inference_set.jsonl"
+            path.write_text('{"a": 1}\n', encoding="utf-8")
+
+            backup = archive_artifact(path, reason="config changed")
+
+            assert backup is not None
+            assert not path.exists()
+            assert backup.exists()
+            assert backup.read_text(encoding="utf-8") == '{"a": 1}\n'
+
+    def test_backup_sits_beside_the_original(self):
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "scores.jsonl"
+            path.write_text("x", encoding="utf-8")
+            backup = archive_artifact(path, reason="r")
+            assert backup.parent == path.parent
+            assert backup.name.startswith("scores.jsonl.")
+            assert backup.name.endswith(".bak")
+
+    def test_repeated_archives_do_not_overwrite_each_other(self):
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "scores.jsonl"
+            backups = []
+            for i in range(3):
+                path.write_text(f"run{i}", encoding="utf-8")
+                backups.append(archive_artifact(path, reason="r"))
+            assert len({b.name for b in backups}) == 3
+            assert {b.read_text(encoding="utf-8") for b in backups} == {
+                "run0",
+                "run1",
+                "run2",
+            }
+
+    def test_backup_path_is_logged(self, caplog):
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "scores.jsonl"
+            path.write_text("x", encoding="utf-8")
+            with caplog.at_level("INFO"):
+                archive_artifact(path, reason="config changed")
+            assert "Preserved" in caplog.text
+            assert "config changed" in caplog.text
+
+    def test_opt_out_restores_delete_behaviour(self):
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "scores.jsonl"
+            path.write_text("x", encoding="utf-8")
+            with patch.dict("os.environ", {"ASSERT_DISCARD_STALE_ARTIFACTS": "1"}):
+                assert archive_artifact(path, reason="r") is None
+            assert not path.exists()
+            assert not list(Path(tmp).glob("*.bak"))
+
+    def test_rename_failure_still_removes_and_warns(self, caplog):
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "scores.jsonl"
+            path.write_text("x", encoding="utf-8")
+            with patch.object(Path, "rename", side_effect=OSError("locked")):
+                with caplog.at_level("WARNING"):
+                    assert archive_artifact(path, reason="r") is None
+            assert "Could not preserve" in caplog.text
+            assert not path.exists()
+
+
+class TestArtifactSchema:
+    def test_sidecar_records_version(self):
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "scores.jsonl"
+            path.write_text("{}\n", encoding="utf-8")
+            sidecar = write_artifact_schema(path, artifact="scores")
+
+            assert sidecar.name == "scores.jsonl.schema.json"
+            payload = json.loads(sidecar.read_text(encoding="utf-8"))
+            assert payload["artifact"] == "scores"
+            assert payload["schema_version"] == ARTIFACT_SCHEMA_VERSION
+
+    def test_sidecar_does_not_alter_the_artifact(self):
+        """A header line would be read as a data row by any older reader."""
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "scores.jsonl"
+            original = '{"test_case_id": "a"}\n{"test_case_id": "b"}\n'
+            path.write_text(original, encoding="utf-8")
+            write_artifact_schema(path, artifact="scores")
+            assert path.read_text(encoding="utf-8") == original
+
+    def test_unstamped_artifact_is_treated_as_compatible(self):
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "scores.jsonl"
+            path.write_text("{}\n", encoding="utf-8")
+            assert read_artifact_schema_version(path) is None
+            assert check_artifact_schema(path) is True
+
+    def test_newer_schema_warns(self, caplog):
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "scores.jsonl"
+            path.write_text("{}\n", encoding="utf-8")
+            write_artifact_schema(
+                path, artifact="scores", version=ARTIFACT_SCHEMA_VERSION + 1
+            )
+            with caplog.at_level("WARNING"):
+                assert check_artifact_schema(path) is False
+            assert "understands" in caplog.text
+
+    def test_corrupt_sidecar_is_ignored(self):
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "scores.jsonl"
+            path.write_text("{}\n", encoding="utf-8")
+            path.with_name(path.name + ".schema.json").write_text(
+                "not json", encoding="utf-8"
+            )
+            assert read_artifact_schema_version(path) is None
+            assert check_artifact_schema(path) is True
+
+    def test_manifest_carries_schema_version(self):
+        from assert_ai.core.config_model import RunManifest
+
+        payload = RunManifest(started_at="2026-01-01T00:00:00Z").to_dict()
+        assert payload["schema_version"] == 1

--- a/tests/test_artifact_preservation.py
+++ b/tests/test_artifact_preservation.py
@@ -15,8 +15,10 @@ from unittest.mock import patch
 from assert_ai.core.io import (
     ARTIFACT_SCHEMA_VERSION,
     archive_artifact,
+    assert_version,
     check_artifact_schema,
     read_artifact_schema_version,
+    verify_artifact_provenance,
     write_artifact_schema,
 )
 
@@ -144,3 +146,60 @@ class TestArtifactSchema:
 
         payload = RunManifest(started_at="2026-01-01T00:00:00Z").to_dict()
         assert payload["schema_version"] == 1
+
+
+class TestArtifactProvenance:
+    def test_records_producing_stage_and_version(self):
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "scores.jsonl"
+            path.write_text("{}\n", encoding="utf-8")
+            sidecar = write_artifact_schema(
+                path,
+                artifact="scores",
+                produced_by={"stage": "judge", "assert_version": "9.9.9"},
+            )
+            payload = json.loads(sidecar.read_text(encoding="utf-8"))
+            assert payload["produced_by"]["stage"] == "judge"
+            assert payload["produced_by"]["assert_version"] == "9.9.9"
+            assert len(payload["content_sha256"]) == 64
+
+    def test_untouched_artifact_verifies(self):
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "scores.jsonl"
+            path.write_text('{"a": 1}\n', encoding="utf-8")
+            write_artifact_schema(path, artifact="scores")
+            assert verify_artifact_provenance(path) is True
+
+    def test_edited_artifact_fails_verification(self):
+        """A stage cannot otherwise tell its input from an edited file."""
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "scores.jsonl"
+            path.write_text('{"policy_violation": true}\n', encoding="utf-8")
+            write_artifact_schema(
+                path, artifact="scores", produced_by={"stage": "judge"}
+            )
+
+            path.write_text('{"policy_violation": false}\n', encoding="utf-8")
+            assert verify_artifact_provenance(path) is False
+
+    def test_edit_is_reported_with_the_producing_stage(self, caplog):
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "scores.jsonl"
+            path.write_text("a", encoding="utf-8")
+            write_artifact_schema(
+                path, artifact="scores", produced_by={"stage": "judge"}
+            )
+            path.write_text("b", encoding="utf-8")
+            with caplog.at_level("WARNING"):
+                verify_artifact_provenance(path)
+            assert "judge" in caplog.text
+
+    def test_unstamped_artifact_still_verifies(self):
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "scores.jsonl"
+            path.write_text("{}\n", encoding="utf-8")
+            assert verify_artifact_provenance(path) is True
+
+    def test_version_is_read_from_package_metadata(self):
+        """A provenance record must not be able to claim a version it is not."""
+        assert assert_version() != "unknown"


### PR DESCRIPTION
## Summary

Three commits.

**Cache integrity.** `finalize_artifact_plan` records a sha256 for every output, but the
cache activated a version on an existence check alone. An artifact altered after it was
written — by an interrupted run, a stray editor save, or anyone with write access to the
suite directory — was reused as though it were the computed result, and every score
derived from it looked legitimate. A mismatch is now a cache miss, so the stage
recomputes, which is what the operator wanted anyway.

**Preservation.** Resume and `--force-stage` called `unlink()` on `inference_set.jsonl`
and `scores.jsonl`. Those files are the evaluation evidence, and a config hash mismatch
is not always what the operator intended, so an accidental edit cost a full re-run with
no record that anything had been destroyed. They are now renamed aside with a timestamp.

**Provenance.** Stages hand work to each other through files, and no stage could tell
whether its input came from the previous stage, a cache hit, or someone editing the
file. A sidecar now records the producing stage, the assert-ai version, the run id, and
a digest of the artifact's bytes.

**Closes:** SEC-005 (cache reused without integrity verification) · SEC-021 (implicit inter-stage trust) · AP-010 (no schema version) · AP-013 (destructive resume)

## Commits

- feat(artifacts): record artifact provenance across stage boundaries
- fix(artifacts): preserve stale artifacts on resume and stamp a schema version
- fix(cache): verify artifact hashes before reusing a cached stage

## Testing

```
pytest tests/ -q
```

Full suite green on this branch; `9 files changed, 612 insertions(+), 19 deletions(-)`. Every change has a regression test, and the
suite was re-run after each commit rather than only at the end.

## Notes for reviewer

**The schema stamp is a sidecar, not a header line, and that is deliberate.** A version
header inside a JSONL file would be parsed as a *data record* by any reader that does not
know about it — including the previous version of ASSERT — so the stamp would corrupt the
first row on revert. A sidecar is ignored harmlessly instead.

Backups are never pruned automatically, because pruning evidence is the behaviour being
fixed. `ASSERT_DISCARD_STALE_ARTIFACTS=1` restores the previous delete.

Artifacts with no stamp predate this and are still treated as compatible, so existing
runs keep working.

`core.artifact_cache` had its own `file_sha256` that read whole files into memory; both
now share one chunked implementation so the cache digest and the provenance digest cannot
drift apart.

## Risk and rollback

Each commit is a single concern and can be reverted independently. See the notes above
for anything that does **not** revert cleanly.
