### PR TITLE
fix(otel): harden direct GenAI extraction

### DIFF
--- a/assert_ai/core/otel.py
+++ b/assert_ai/core/otel.py
@@ -571,7 +571,7 @@ def _genai_model_span_to_events(span: OTelSpan, acc: _EventAccumulator) -> None:
     for tc in _merge_tool_call_carriers(attr_tool_calls, event_tool_calls):
         acc.emit_tool_call(tc["name"], tc["args"], "", tc.get("call_id"))
     for call_id, result in event_results:
-        acc.bind_tool_result(call_id, result)
+        acc.bind_tool_result(call_id, result, hold_if_unbound=False)
 
 
 def _genai_agent_span_to_events(span: OTelSpan, acc: _EventAccumulator) -> None:
@@ -588,7 +588,7 @@ def _genai_agent_span_to_events(span: OTelSpan, acc: _EventAccumulator) -> None:
     for tc in _merge_tool_call_carriers(attr_tool_calls, event_tool_calls):
         acc.emit_tool_call(tc["name"], tc["args"], "", tc.get("call_id"))
     for call_id, result in event_results:
-        acc.bind_tool_result(call_id, result)
+        acc.bind_tool_result(call_id, result, hold_if_unbound=False)
 
 
 def _genai_tool_span_to_events(span: OTelSpan, acc: _EventAccumulator) -> None:

--- a/assert_ai/core/otel.py
+++ b/assert_ai/core/otel.py
@@ -568,7 +568,7 @@ def _genai_model_span_to_events(span: OTelSpan, acc: _EventAccumulator) -> None:
 
     # Tool calls requested in the model's messages/choice become tool_call edits;
     # results carried as gen_ai.tool.message events bind to them by id.
-    for tc in [*attr_tool_calls, *event_tool_calls]:
+    for tc in _merge_tool_call_carriers(attr_tool_calls, event_tool_calls):
         acc.emit_tool_call(tc["name"], tc["args"], "", tc.get("call_id"))
     for call_id, result in event_results:
         acc.bind_tool_result(call_id, result)
@@ -585,7 +585,7 @@ def _genai_agent_span_to_events(span: OTelSpan, acc: _EventAccumulator) -> None:
         _, attr_tool_calls = _genai_messages_content(attrs.get(_OPENCLAW_OUTPUT_MESSAGES_KEY))
     _, event_tool_calls, event_results = _genai_extract_events(span.events)
 
-    for tc in [*attr_tool_calls, *event_tool_calls]:
+    for tc in _merge_tool_call_carriers(attr_tool_calls, event_tool_calls):
         acc.emit_tool_call(tc["name"], tc["args"], "", tc.get("call_id"))
     for call_id, result in event_results:
         acc.bind_tool_result(call_id, result)
@@ -594,7 +594,7 @@ def _genai_agent_span_to_events(span: OTelSpan, acc: _EventAccumulator) -> None:
 def _genai_tool_span_to_events(span: OTelSpan, acc: _EventAccumulator) -> None:
     attrs = span.attributes
     tool_name = attrs.get(_GENAI_TOOL_NAME_KEY) or span.name
-    call_id = attrs.get(_GENAI_TOOL_CALL_ID_KEY)
+    call_id = _safe_tool_call_id(attrs.get(_GENAI_TOOL_CALL_ID_KEY))
 
     # Args/result: generic gen_ai opt-in attrs first, vendor enrichment as a
     # graceful fallback for content fidelity.
@@ -1035,38 +1035,31 @@ def _merge_tool_call_carriers(
     attr_tool_calls: list[dict[str, Any]],
     event_tool_calls: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
-    """Deduplicate the same call across attribute and event carriers only.
+    """Deduplicate equivalent attribute/event carriers with multiplicity.
 
-    Repeated call ids across separate spans/turns remain intact. Calls repeated
-    within one carrier also remain intact because only event calls that mirror
-    an attribute call are removed.
+    Repeated calls within one carrier and across separate spans/turns remain
+    intact. An event call is removed only when an attribute call in the same
+    span has the same id, name, and arguments.
     """
-    attr_ids = {
-        call_id
-        for call in attr_tool_calls
-        if (call_id := _safe_tool_call_id(call.get("call_id")))
-    }
-    attr_without_ids = {
-        (
+    def _fingerprint(call: dict[str, Any]) -> tuple[str | None, str, str]:
+        return (
+            _safe_tool_call_id(call.get("call_id")),
             str(call.get("name") or "tool"),
             json.dumps(call.get("args", {}), sort_keys=True, default=str),
         )
-        for call in attr_tool_calls
-        if _safe_tool_call_id(call.get("call_id")) is None
-    }
+
+    unmatched_attr_counts: dict[tuple[str | None, str, str], int] = {}
+    for call in attr_tool_calls:
+        fingerprint = _fingerprint(call)
+        unmatched_attr_counts[fingerprint] = unmatched_attr_counts.get(fingerprint, 0) + 1
 
     merged = list(attr_tool_calls)
     for call in event_tool_calls:
-        call_id = _safe_tool_call_id(call.get("call_id"))
-        if call_id and call_id in attr_ids:
+        fingerprint = _fingerprint(call)
+        remaining = unmatched_attr_counts.get(fingerprint, 0)
+        if remaining > 0:
+            unmatched_attr_counts[fingerprint] = remaining - 1
             continue
-        if call_id is None:
-            signature = (
-                str(call.get("name") or "tool"),
-                json.dumps(call.get("args", {}), sort_keys=True, default=str),
-            )
-            if signature in attr_without_ids:
-                continue
         merged.append(call)
     return merged
 
@@ -1090,7 +1083,7 @@ def _span_requested_tool_calls_for_serialization(
     span: OTelSpan,
     *,
     max_content_chars: int,
-    results_by_id: dict[str, list[Any]] | None = None,
+    assigned_results: dict[tuple[str, int], Any] | None = None,
 ) -> list[dict[str, Any]]:
     """GenAI model/agent-requested tool calls for tree/chunked serialization."""
     if span.convention != "gen_ai" or span.kind == "TOOL":
@@ -1106,15 +1099,15 @@ def _span_requested_tool_calls_for_serialization(
     _, event_tool_calls, event_results = _genai_extract_events(span.events)
     tool_calls = _merge_tool_call_carriers(attr_tool_calls, event_tool_calls)
 
-    if results_by_id is None:
-        results_by_id = {}
+    local_results_by_id: dict[str, list[Any]] = {}
+    if assigned_results is None:
         for call_id, result in event_results:
             safe_id = _safe_tool_call_id(call_id)
             if safe_id:
-                results_by_id.setdefault(safe_id, []).append(result)
+                local_results_by_id.setdefault(safe_id, []).append(result)
 
     serialized: list[dict[str, Any]] = []
-    for call in tool_calls:
+    for call_index, call in enumerate(tool_calls):
         item: dict[str, Any] = {
             "name": call.get("name") or "tool",
             "arguments": _truncate_tool_args(
@@ -1125,10 +1118,15 @@ def _span_requested_tool_calls_for_serialization(
         call_id = _safe_tool_call_id(call.get("call_id"))
         if call_id:
             item["tool_call_id"] = call_id
-            pending_results = results_by_id.get(call_id, [])
-            if pending_results:
+            assigned_key = (span.span_id, call_index)
+            if assigned_results is not None and assigned_key in assigned_results:
                 item["tool_result"] = _truncate_content(
-                    pending_results.pop(0),
+                    assigned_results[assigned_key],
+                    max_content_chars,
+                )
+            elif assigned_results is None and local_results_by_id.get(call_id):
+                item["tool_result"] = _truncate_content(
+                    local_results_by_id[call_id].pop(0),
                     max_content_chars,
                 )
         serialized.append(item)
@@ -1234,27 +1232,45 @@ def _truncate_tool_args(value: Any, max_content_chars: int) -> Any:
     return {"raw": serialized[:max_content_chars]}
 
 
-def _collect_genai_tool_results(
+def _assign_genai_tool_results(
     spans: list[OTelSpan],
-) -> dict[str, list[Any]]:
-    """Collect result queues across spans for TREE/CHUNKED correlation."""
-    results_by_id: dict[str, list[Any]] = {}
+) -> dict[tuple[str, int], Any]:
+    """Assign results to chronological requests before tree serialization.
+
+    Results that arrive before any request with the same id are intentionally
+    ignored so a standalone completed execution cannot seed a later unrelated
+    request whose runtime reused the id.
+    """
+    pending_requests: dict[str, list[tuple[str, int]]] = {}
+    assigned_results: dict[tuple[str, int], Any] = {}
+
     for span in sorted(spans, key=lambda item: item.start_time_ns):
+        for call_index, call in enumerate(_span_requested_tool_calls(span)):
+            call_id = _safe_tool_call_id(call.get("call_id"))
+            if call_id:
+                pending_requests.setdefault(call_id, []).append(
+                    (span.span_id, call_index)
+                )
+
         _, _, event_results = _genai_extract_events(span.events)
         event_ids: set[str] = set()
         for call_id, result in event_results:
             safe_id = _safe_tool_call_id(call_id)
             if not safe_id:
                 continue
-            results_by_id.setdefault(safe_id, []).append(result)
+            pending = pending_requests.get(safe_id, [])
+            if pending:
+                assigned_results[pending.pop(0)] = result
             event_ids.add(safe_id)
 
         if span.convention == "gen_ai" and span.kind == "TOOL":
             call_id = _span_tool_call_id(span)
             result = _span_tool_result(span)
             if call_id and call_id not in event_ids and result:
-                results_by_id.setdefault(call_id, []).append(result)
-    return results_by_id
+                pending = pending_requests.get(call_id, [])
+                if pending:
+                    assigned_results[pending.pop(0)] = result
+    return assigned_results
 
 
 # ── Span validation ───────────────────────────────────────────────
@@ -1876,7 +1892,7 @@ class SpanNode:
         include_input: bool = False,
         include_output: bool = True,
         max_content_chars: int = 500,
-        _tool_results_by_id: dict[str, list[Any]] | None = None,
+        _assigned_tool_results: dict[tuple[str, int], Any] | None = None,
     ) -> dict[str, Any]:
         """Serialize to a judge-friendly dict with selective field inclusion."""
         d: dict[str, Any] = {
@@ -1903,7 +1919,7 @@ class SpanNode:
         requested_tool_calls = _span_requested_tool_calls_for_serialization(
             self.span,
             max_content_chars=max_content_chars,
-            results_by_id=_tool_results_by_id,
+            assigned_results=_assigned_tool_results,
         )
         if requested_tool_calls:
             d["tool_calls"] = requested_tool_calls
@@ -1921,7 +1937,7 @@ class SpanNode:
                     include_input=include_input,
                     include_output=include_output,
                     max_content_chars=max_content_chars,
-                    _tool_results_by_id=_tool_results_by_id,
+                    _assigned_tool_results=_assigned_tool_results,
                 )
                 for c in self.children
             ]
@@ -2026,6 +2042,36 @@ def extract_for_judge(
         "agent_spans": len([s for s in spans if s.kind == "AGENT"]),
     }
 
+    def _fit_representation_to_budget(serializer: Any) -> list[dict[str, Any]]:
+        budget_chars = max(0, max_tokens_budget * 4)
+        if budget_chars == 0:
+            metadata["representation_truncated"] = True
+            return []
+
+        content_chars = max(0, max_content_chars)
+        representation = serializer(content_chars)
+        for _ in range(8):
+            serialized_size = len(json.dumps(representation, default=str))
+            if serialized_size <= budget_chars:
+                return representation
+            if content_chars == 0:
+                break
+            ratio = budget_chars / serialized_size
+            content_chars = max(
+                0,
+                min(content_chars - 1, int(content_chars * ratio * 0.9)),
+            )
+            representation = serializer(content_chars)
+
+        if len(json.dumps(representation, default=str)) <= budget_chars:
+            return representation
+
+        metadata["representation_truncated"] = True
+        marker = [{"truncated": True, "span_count": len(spans)}]
+        if len(json.dumps(marker)) <= budget_chars:
+            return marker
+        return []
+
     if mode == ExtractionMode.FLAT:
         events, aggregate = _spans_to_events(spans)
         compressed = compress_trace_for_judge(events, max_events=50)
@@ -2037,26 +2083,18 @@ def extract_for_judge(
         metadata["max_depth"] = max((r.depth for r in tree), default=0)
         # Selective serialization — strip LLM input messages (redundant accumulated context)
         def _serialize_tree(content_chars: int) -> list[dict[str, Any]]:
-            results_by_id = _collect_genai_tool_results(spans)
+            assigned_results = _assign_genai_tool_results(spans)
             return [
                 root.to_dict(
                     include_input=False,
                     include_output=True,
                     max_content_chars=content_chars,
-                    _tool_results_by_id=results_by_id,
+                    _assigned_tool_results=assigned_results,
                 )
                 for root in tree
             ]
 
-        tree_data = _serialize_tree(max_content_chars)
-        # Estimate token size and truncate if needed
-        serialized = json.dumps(tree_data)
-        est_tokens = len(serialized) // 4  # rough estimate: 4 chars per token
-        if est_tokens > max_tokens_budget:
-            # Reduce content chars proportionally
-            ratio = max_tokens_budget / est_tokens
-            reduced_chars = max(16, int(max_content_chars * ratio))
-            tree_data = _serialize_tree(reduced_chars)
+        tree_data = _fit_representation_to_budget(_serialize_tree)
         return {"mode": mode, "representation": tree_data, "metadata": metadata}
 
     if mode == ExtractionMode.CHUNKED:
@@ -2065,7 +2103,7 @@ def extract_for_judge(
         metadata["max_depth"] = max((r.depth for r in tree), default=0)
 
         def _serialize_chunks(content_chars: int) -> list[dict[str, Any]]:
-            results_by_id = _collect_genai_tool_results(spans)
+            assigned_results = _assign_genai_tool_results(spans)
             return [
                 {
                     "agent": _span_node_name(root.span),
@@ -2075,19 +2113,13 @@ def extract_for_judge(
                         include_input=False,
                         include_output=True,
                         max_content_chars=content_chars,
-                        _tool_results_by_id=results_by_id,
+                        _assigned_tool_results=assigned_results,
                     ),
                 }
                 for root in tree
             ]
 
-        chunks = _serialize_chunks(max_content_chars)
-        serialized = json.dumps(chunks)
-        est_tokens = len(serialized) // 4
-        if est_tokens > max_tokens_budget:
-            ratio = max_tokens_budget / est_tokens
-            reduced_chars = max(16, int(max_content_chars * ratio))
-            chunks = _serialize_chunks(reduced_chars)
+        chunks = _fit_representation_to_budget(_serialize_chunks)
         return {"mode": mode, "representation": chunks, "metadata": metadata}
 
     raise ValueError(f"Unknown extraction mode: {mode}")

--- a/assert_ai/core/otel.py
+++ b/assert_ai/core/otel.py
@@ -658,7 +658,7 @@ def _genai_extract_events(
             tool_calls.extend(_extract_tool_calls(message))
 
         elif name == _GENAI_TOOL_MESSAGE_EVENT:
-            call_id = (
+            call_id = _safe_tool_call_id(
                 attrs.get("id")
                 or attrs.get("tool_call_id")
                 or attrs.get(_GENAI_TOOL_CALL_ID_KEY)
@@ -712,8 +712,18 @@ def _normalize_tool_call(value: Any) -> dict[str, Any] | None:
     return {
         "name": name or "tool",
         "args": _genai_tool_args(raw_args),
-        "call_id": value.get("id") or value.get("call_id") or value.get("tool_call_id"),
+        "call_id": _safe_tool_call_id(
+            value.get("id") or value.get("call_id") or value.get("tool_call_id")
+        ),
     }
+
+
+def _safe_tool_call_id(value: Any) -> str | None:
+    """Return a hashable call id, degrading malformed telemetry to no id."""
+    if value is None or isinstance(value, (dict, list, set, tuple)):
+        return None
+    text = str(value)
+    return text or None
 
 
 def _coerce_json(value: Any) -> Any:
@@ -905,8 +915,9 @@ def _messages_text(value: Any, *, roles: set[str | None] | None = None) -> str:
         if not isinstance(msg, dict):
             continue
         role = msg.get("role")
-        if roles is not None and role not in roles:
-            continue
+        if roles is not None:
+            if not isinstance(role, (str, type(None))) or role not in roles:
+                continue
         text = _message_text(msg)
         if text:
             texts.append(text)
@@ -993,7 +1004,7 @@ def _span_tool_name(span: OTelSpan) -> str:
 
 def _span_tool_call_id(span: OTelSpan) -> str | None:
     if span.convention == "gen_ai":
-        return span.attributes.get(_GENAI_TOOL_CALL_ID_KEY)
+        return _safe_tool_call_id(span.attributes.get(_GENAI_TOOL_CALL_ID_KEY))
     return None
 
 
@@ -1020,6 +1031,46 @@ def _span_tool_result(span: OTelSpan) -> str:
     return span.attributes.get(_OUTPUT_VALUE_KEY, "") or ""
 
 
+def _merge_tool_call_carriers(
+    attr_tool_calls: list[dict[str, Any]],
+    event_tool_calls: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Deduplicate the same call across attribute and event carriers only.
+
+    Repeated call ids across separate spans/turns remain intact. Calls repeated
+    within one carrier also remain intact because only event calls that mirror
+    an attribute call are removed.
+    """
+    attr_ids = {
+        call_id
+        for call in attr_tool_calls
+        if (call_id := _safe_tool_call_id(call.get("call_id")))
+    }
+    attr_without_ids = {
+        (
+            str(call.get("name") or "tool"),
+            json.dumps(call.get("args", {}), sort_keys=True, default=str),
+        )
+        for call in attr_tool_calls
+        if _safe_tool_call_id(call.get("call_id")) is None
+    }
+
+    merged = list(attr_tool_calls)
+    for call in event_tool_calls:
+        call_id = _safe_tool_call_id(call.get("call_id"))
+        if call_id and call_id in attr_ids:
+            continue
+        if call_id is None:
+            signature = (
+                str(call.get("name") or "tool"),
+                json.dumps(call.get("args", {}), sort_keys=True, default=str),
+            )
+            if signature in attr_without_ids:
+                continue
+        merged.append(call)
+    return merged
+
+
 def _span_requested_tool_calls(span: OTelSpan) -> list[dict[str, Any]]:
     """Tool calls requested from GenAI model/agent messages/events."""
     if span.convention != "gen_ai" or span.kind == "TOOL":
@@ -1032,13 +1083,14 @@ def _span_requested_tool_calls(span: OTelSpan) -> list[dict[str, Any]]:
             span.attributes.get(_OPENCLAW_OUTPUT_MESSAGES_KEY)
         )
     _, event_tool_calls, _ = _genai_extract_events(span.events)
-    return [*attr_tool_calls, *event_tool_calls]
+    return _merge_tool_call_carriers(attr_tool_calls, event_tool_calls)
 
 
 def _span_requested_tool_calls_for_serialization(
     span: OTelSpan,
     *,
     max_content_chars: int,
+    results_by_id: dict[str, list[Any]] | None = None,
 ) -> list[dict[str, Any]]:
     """GenAI model/agent-requested tool calls for tree/chunked serialization."""
     if span.convention != "gen_ai" or span.kind == "TOOL":
@@ -1052,18 +1104,25 @@ def _span_requested_tool_calls_for_serialization(
             span.attributes.get(_OPENCLAW_OUTPUT_MESSAGES_KEY)
         )
     _, event_tool_calls, event_results = _genai_extract_events(span.events)
+    tool_calls = _merge_tool_call_carriers(attr_tool_calls, event_tool_calls)
 
-    results_by_id: dict[str, list[Any]] = {}
-    for call_id, result in event_results:
-        results_by_id.setdefault(call_id, []).append(result)
+    if results_by_id is None:
+        results_by_id = {}
+        for call_id, result in event_results:
+            safe_id = _safe_tool_call_id(call_id)
+            if safe_id:
+                results_by_id.setdefault(safe_id, []).append(result)
 
     serialized: list[dict[str, Any]] = []
-    for call in [*attr_tool_calls, *event_tool_calls]:
+    for call in tool_calls:
         item: dict[str, Any] = {
             "name": call.get("name") or "tool",
-            "arguments": call.get("args", {}),
+            "arguments": _truncate_tool_args(
+                call.get("args", {}),
+                max_content_chars,
+            ),
         }
-        call_id = call.get("call_id")
+        call_id = _safe_tool_call_id(call.get("call_id"))
         if call_id:
             item["tool_call_id"] = call_id
             pending_results = results_by_id.get(call_id, [])
@@ -1166,7 +1225,36 @@ def _truncate_tool_args(value: Any, max_content_chars: int) -> Any:
         truncated = dict(value)
         truncated["raw"] = value["raw"][:max_content_chars]
         return truncated
-    return value
+    try:
+        serialized = json.dumps(value, sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        serialized = str(value)
+    if len(serialized) <= max_content_chars:
+        return value
+    return {"raw": serialized[:max_content_chars]}
+
+
+def _collect_genai_tool_results(
+    spans: list[OTelSpan],
+) -> dict[str, list[Any]]:
+    """Collect result queues across spans for TREE/CHUNKED correlation."""
+    results_by_id: dict[str, list[Any]] = {}
+    for span in sorted(spans, key=lambda item: item.start_time_ns):
+        _, _, event_results = _genai_extract_events(span.events)
+        event_ids: set[str] = set()
+        for call_id, result in event_results:
+            safe_id = _safe_tool_call_id(call_id)
+            if not safe_id:
+                continue
+            results_by_id.setdefault(safe_id, []).append(result)
+            event_ids.add(safe_id)
+
+        if span.convention == "gen_ai" and span.kind == "TOOL":
+            call_id = _span_tool_call_id(span)
+            result = _span_tool_result(span)
+            if call_id and call_id not in event_ids and result:
+                results_by_id.setdefault(call_id, []).append(result)
+    return results_by_id
 
 
 # ── Span validation ───────────────────────────────────────────────
@@ -1663,7 +1751,7 @@ def extract_trajectory_inputs(
                     pending_requested_call_ids,
                     span,
                 )
-            else:
+            elif span.convention == "gen_ai":
                 node = _span_node_name(span)
                 if node and node not in node_path:
                     node_path.append(node)
@@ -1788,6 +1876,7 @@ class SpanNode:
         include_input: bool = False,
         include_output: bool = True,
         max_content_chars: int = 500,
+        _tool_results_by_id: dict[str, list[Any]] | None = None,
     ) -> dict[str, Any]:
         """Serialize to a judge-friendly dict with selective field inclusion."""
         d: dict[str, Any] = {
@@ -1814,6 +1903,7 @@ class SpanNode:
         requested_tool_calls = _span_requested_tool_calls_for_serialization(
             self.span,
             max_content_chars=max_content_chars,
+            results_by_id=_tool_results_by_id,
         )
         if requested_tool_calls:
             d["tool_calls"] = requested_tool_calls
@@ -1831,6 +1921,7 @@ class SpanNode:
                     include_input=include_input,
                     include_output=include_output,
                     max_content_chars=max_content_chars,
+                    _tool_results_by_id=_tool_results_by_id,
                 )
                 for c in self.children
             ]
@@ -1945,48 +2036,58 @@ def extract_for_judge(
         tree = build_span_tree(spans)
         metadata["max_depth"] = max((r.depth for r in tree), default=0)
         # Selective serialization — strip LLM input messages (redundant accumulated context)
-        tree_data = [
-            root.to_dict(
-                include_input=False,
-                include_output=True,
-                max_content_chars=max_content_chars,
-            )
-            for root in tree
-        ]
+        def _serialize_tree(content_chars: int) -> list[dict[str, Any]]:
+            results_by_id = _collect_genai_tool_results(spans)
+            return [
+                root.to_dict(
+                    include_input=False,
+                    include_output=True,
+                    max_content_chars=content_chars,
+                    _tool_results_by_id=results_by_id,
+                )
+                for root in tree
+            ]
+
+        tree_data = _serialize_tree(max_content_chars)
         # Estimate token size and truncate if needed
         serialized = json.dumps(tree_data)
         est_tokens = len(serialized) // 4  # rough estimate: 4 chars per token
         if est_tokens > max_tokens_budget:
             # Reduce content chars proportionally
             ratio = max_tokens_budget / est_tokens
-            reduced_chars = max(100, int(max_content_chars * ratio))
-            tree_data = [
-                root.to_dict(
-                    include_input=False,
-                    include_output=True,
-                    max_content_chars=reduced_chars,
-                )
-                for root in tree
-            ]
+            reduced_chars = max(16, int(max_content_chars * ratio))
+            tree_data = _serialize_tree(reduced_chars)
         return {"mode": mode, "representation": tree_data, "metadata": metadata}
 
     if mode == ExtractionMode.CHUNKED:
         # Evaluate per agent boundary
         tree = build_span_tree(spans)
         metadata["max_depth"] = max((r.depth for r in tree), default=0)
-        chunks: list[dict[str, Any]] = []
-        for root in tree:
-            chunk = {
-                "agent": _span_node_name(root.span),
-                "type": root.span.kind,
-                "span_count": root.size,
-                "tree": root.to_dict(
-                    include_input=False,
-                    include_output=True,
-                    max_content_chars=max_content_chars,
-                ),
-            }
-            chunks.append(chunk)
+
+        def _serialize_chunks(content_chars: int) -> list[dict[str, Any]]:
+            results_by_id = _collect_genai_tool_results(spans)
+            return [
+                {
+                    "agent": _span_node_name(root.span),
+                    "type": root.span.kind,
+                    "span_count": root.size,
+                    "tree": root.to_dict(
+                        include_input=False,
+                        include_output=True,
+                        max_content_chars=content_chars,
+                        _tool_results_by_id=results_by_id,
+                    ),
+                }
+                for root in tree
+            ]
+
+        chunks = _serialize_chunks(max_content_chars)
+        serialized = json.dumps(chunks)
+        est_tokens = len(serialized) // 4
+        if est_tokens > max_tokens_budget:
+            ratio = max_tokens_budget / est_tokens
+            reduced_chars = max(16, int(max_content_chars * ratio))
+            chunks = _serialize_chunks(reduced_chars)
         return {"mode": mode, "representation": chunks, "metadata": metadata}
 
     raise ValueError(f"Unknown extraction mode: {mode}")

--- a/tests/test_otel_genai.py
+++ b/tests/test_otel_genai.py
@@ -1210,6 +1210,293 @@ class TestGenAIDirectExtractionFollowup(unittest.TestCase):
         self.assertEqual(row["model"], "oi-model")
         self.assertEqual(SpanNode(span).to_dict()["output"], "openinference output")
 
+    def test_openinference_non_llm_spans_do_not_change_trajectory_node_path(self):
+        from assert_ai.core.otel import extract_trajectory_inputs
+
+        llm = self._span(
+            kind="LLM",
+            span_id="oi_llm",
+            start=0,
+            attrs={
+                "openinference.span.kind": "LLM",
+                "input.value": "hello",
+                "output.value": "world",
+                "langgraph.node": "planner",
+            },
+        )
+        wrapper = self._span(
+            kind="CHAIN",
+            span_id="oi_wrapper",
+            start=1_000,
+            attrs={
+                "openinference.span.kind": "CHAIN",
+                "langgraph.node": "wrapper",
+            },
+        )
+
+        row = extract_trajectory_inputs([llm, wrapper])[0]
+        self.assertEqual(json.loads(row["node_path"]), ["planner"])
+
+    def test_dual_carrier_tool_request_is_emitted_once(self):
+        from assert_ai.core.otel import extract_trajectory_inputs, SpanNode
+
+        tool_call = {
+            "id": "call_dual",
+            "type": "function",
+            "function": {
+                "name": "lookup",
+                "arguments": json.dumps({"q": "weather"}),
+            },
+        }
+        event = {
+            "name": "gen_ai.choice",
+            "attributes": [{"key": "message", "value": {"stringValue": json.dumps({
+                "role": "assistant",
+                "tool_calls": [tool_call],
+            })}}],
+        }
+        span = self._span(
+            kind="LLM",
+            span_id="dual_carrier",
+            attrs={
+                "gen_ai.operation.name": "chat",
+                "gen_ai.input.messages": json.dumps([
+                    {"role": "user", "content": "look it up"}
+                ]),
+                "gen_ai.output.messages": json.dumps([
+                    {"role": "assistant", "tool_calls": [tool_call]}
+                ]),
+            },
+            events=[event],
+        )
+
+        trajectory_calls = json.loads(
+            extract_trajectory_inputs([span])[0]["tool_calls"]
+        )
+        tree_calls = SpanNode(span).to_dict()["tool_calls"]
+        self.assertEqual(
+            trajectory_calls,
+            [{"name": "lookup", "arguments": {"q": "weather"}}],
+        )
+        self.assertEqual(len(tree_calls), 1)
+        self.assertEqual(tree_calls[0]["tool_call_id"], "call_dual")
+
+    def test_tree_correlates_tool_result_across_spans(self):
+        from assert_ai.core.otel import extract_for_judge, ExtractionMode
+
+        request_event = {
+            "name": "gen_ai.choice",
+            "attributes": [{"key": "message", "value": {"stringValue": json.dumps({
+                "role": "assistant",
+                "tool_calls": [{
+                    "id": "call_cross",
+                    "type": "function",
+                    "function": {
+                        "name": "lookup",
+                        "arguments": json.dumps({"q": "weather"}),
+                    },
+                }],
+            })}}],
+        }
+        result_event = {
+            "name": "gen_ai.tool.message",
+            "attributes": [
+                {"key": "id", "value": {"stringValue": "call_cross"}},
+                {"key": "content", "value": {"stringValue": "sunny"}},
+            ],
+        }
+        root = self._span(
+            kind="AGENT",
+            span_id="root",
+            attrs={"gen_ai.operation.name": "invoke_agent"},
+        )
+        request = self._span(
+            kind="LLM",
+            span_id="request",
+            parent="root",
+            start=1_000,
+            attrs={"gen_ai.operation.name": "chat"},
+            events=[request_event],
+        )
+        result = self._span(
+            kind="AGENT",
+            span_id="result",
+            parent="root",
+            start=2_000,
+            attrs={"gen_ai.operation.name": "invoke_agent"},
+            events=[result_event],
+        )
+
+        tree = extract_for_judge(
+            [root, request, result],
+            mode=ExtractionMode.TREE,
+        )["representation"][0]
+        request_node = next(
+            child for child in tree["children"] if child["span_id"] == "request"
+        )
+        self.assertEqual(request_node["tool_calls"][0]["tool_result"], "sunny")
+
+        chunk = extract_for_judge(
+            [root, request, result],
+            mode=ExtractionMode.CHUNKED,
+        )["representation"][0]["tree"]
+        chunk_request = next(
+            child for child in chunk["children"] if child["span_id"] == "request"
+        )
+        self.assertEqual(chunk_request["tool_calls"][0]["tool_result"], "sunny")
+
+    def test_tree_preserves_repeated_call_ids_and_result_fifo_across_spans(self):
+        from assert_ai.core.otel import extract_for_judge, ExtractionMode
+
+        def request(span_id, start, query):
+            return self._span(
+                kind="LLM",
+                span_id=span_id,
+                parent="root_fifo",
+                start=start,
+                attrs={"gen_ai.operation.name": "chat"},
+                events=[{
+                    "name": "gen_ai.choice",
+                    "attributes": [{"key": "message", "value": {"stringValue": json.dumps({
+                        "role": "assistant",
+                        "tool_calls": [{
+                            "id": "dup",
+                            "type": "function",
+                            "function": {
+                                "name": "lookup",
+                                "arguments": json.dumps({"q": query}),
+                            },
+                        }],
+                    })}}],
+                }],
+            )
+
+        def result(span_id, start, content):
+            return self._span(
+                kind="AGENT",
+                span_id=span_id,
+                parent="root_fifo",
+                start=start,
+                attrs={"gen_ai.operation.name": "invoke_agent"},
+                events=[{
+                    "name": "gen_ai.tool.message",
+                    "attributes": [
+                        {"key": "id", "value": {"stringValue": "dup"}},
+                        {"key": "content", "value": {"stringValue": content}},
+                    ],
+                }],
+            )
+
+        spans = [
+            self._span(
+                kind="AGENT",
+                span_id="root_fifo",
+                attrs={"gen_ai.operation.name": "invoke_agent"},
+            ),
+            request("request_1", 1_000, "first"),
+            request("request_2", 2_000, "second"),
+            result("result_1", 3_000, "first-result"),
+            result("result_2", 4_000, "second-result"),
+        ]
+
+        tree = extract_for_judge(
+            spans,
+            mode=ExtractionMode.TREE,
+        )["representation"][0]
+        request_nodes = [
+            child for child in tree["children"]
+            if child["span_id"].startswith("request_")
+        ]
+        self.assertEqual(
+            [node["tool_calls"][0]["tool_result"] for node in request_nodes],
+            ["first-result", "second-result"],
+        )
+
+    def test_malformed_roles_and_call_ids_do_not_abort_extraction(self):
+        from assert_ai.core.otel import (
+            extract_span_inputs,
+            extract_trajectory_inputs,
+            SpanNode,
+        )
+
+        span = self._span(
+            kind="LLM",
+            span_id="malformed",
+            attrs={
+                "gen_ai.operation.name": "chat",
+                "gen_ai.input.messages": json.dumps([
+                    {"role": [], "content": "hello"}
+                ]),
+                "gen_ai.output.messages": json.dumps([{
+                    "role": "assistant",
+                    "tool_calls": [{
+                        "id": ["bad-id"],
+                        "type": "function",
+                        "function": {
+                            "name": "lookup",
+                            "arguments": json.dumps({"q": "weather"}),
+                        },
+                    }],
+                }]),
+            },
+            events=[{
+                "name": "gen_ai.tool.message",
+                "attributes": [
+                    {"key": "id", "value": {"arrayValue": {
+                        "values": [{"stringValue": "bad-id"}]
+                    }}},
+                    {"key": "content", "value": {"stringValue": "sunny"}},
+                ],
+            }],
+        )
+
+        self.assertEqual(extract_span_inputs([span])[0]["query"], "hello")
+        calls = json.loads(extract_trajectory_inputs([span])[0]["tool_calls"])
+        self.assertEqual(calls[0]["name"], "lookup")
+        self.assertEqual(len(SpanNode(span).to_dict()["tool_calls"]), 1)
+
+    def test_tree_truncates_structured_tool_arguments(self):
+        from assert_ai.core.otel import SpanNode, extract_for_judge, ExtractionMode
+
+        huge_args = {"payload": "x" * 20_000}
+        span = self._span(
+            kind="LLM",
+            span_id="large_args",
+            attrs={
+                "gen_ai.operation.name": "chat",
+                "gen_ai.output.messages": json.dumps([{
+                    "role": "assistant",
+                    "tool_calls": [{
+                        "id": "call_large",
+                        "type": "function",
+                        "function": {
+                            "name": "submit",
+                            "arguments": json.dumps(huge_args),
+                        },
+                    }],
+                }]),
+            },
+        )
+
+        serialized_call = SpanNode(span).to_dict(max_content_chars=50)["tool_calls"][0]
+        self.assertLessEqual(len(json.dumps(serialized_call["arguments"])), 70)
+
+        result = extract_for_judge(
+            [span],
+            mode=ExtractionMode.TREE,
+            max_tokens_budget=100,
+            max_content_chars=500,
+        )
+        self.assertLess(len(json.dumps(result["representation"])), 2_000)
+
+        chunked = extract_for_judge(
+            [span],
+            mode=ExtractionMode.CHUNKED,
+            max_tokens_budget=100,
+            max_content_chars=20_000,
+        )
+        self.assertLess(len(json.dumps(chunked["representation"])), 2_000)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_otel_genai.py
+++ b/tests/test_otel_genai.py
@@ -1402,7 +1402,7 @@ class TestGenAIDirectExtractionFollowup(unittest.TestCase):
         self.assertEqual(chunk_request["tool_calls"][0]["tool_result"], "sunny")
 
     def test_result_before_request_does_not_seed_reused_call_id(self):
-        from assert_ai.core.otel import extract_for_judge, ExtractionMode
+        from assert_ai.core.otel import extract_for_judge, ExtractionMode, _spans_to_events
 
         def result_event(content):
             return {
@@ -1462,6 +1462,15 @@ class TestGenAIDirectExtractionFollowup(unittest.TestCase):
             if child["span_id"] == "reused_request"
         )
         self.assertEqual(request_node["tool_calls"][0]["tool_result"], "fresh")
+
+        flat_events, _ = _spans_to_events(
+            [root, stale_result, request, fresh_result]
+        )
+        flat_calls = [
+            event["edit"] for event in flat_events
+            if event.get("edit", {}).get("type") == "tool_call"
+        ]
+        self.assertEqual([call["tool_result"] for call in flat_calls], ["fresh"])
 
     def test_tree_result_assignment_uses_chronology_not_depth_first_order(self):
         from assert_ai.core.otel import extract_for_judge, ExtractionMode

--- a/tests/test_otel_genai.py
+++ b/tests/test_otel_genai.py
@@ -1238,7 +1238,7 @@ class TestGenAIDirectExtractionFollowup(unittest.TestCase):
         self.assertEqual(json.loads(row["node_path"]), ["planner"])
 
     def test_dual_carrier_tool_request_is_emitted_once(self):
-        from assert_ai.core.otel import extract_trajectory_inputs, SpanNode
+        from assert_ai.core.otel import extract_trajectory_inputs, SpanNode, _spans_to_events
 
         tool_call = {
             "id": "call_dual",
@@ -1280,6 +1280,62 @@ class TestGenAIDirectExtractionFollowup(unittest.TestCase):
         )
         self.assertEqual(len(tree_calls), 1)
         self.assertEqual(tree_calls[0]["tool_call_id"], "call_dual")
+        flat_calls = [
+            item for item in _spans_to_events([span])[0]
+            if item.get("edit", {}).get("type") == "tool_call"
+        ]
+        self.assertEqual(len(flat_calls), 1)
+
+    def test_dual_carrier_same_id_with_different_payload_preserves_both(self):
+        from assert_ai.core.otel import extract_trajectory_inputs, SpanNode, _spans_to_events
+
+        attr_call = {
+            "id": "call_conflict",
+            "type": "function",
+            "function": {
+                "name": "lookup",
+                "arguments": json.dumps({"q": "weather"}),
+            },
+        }
+        event_call = {
+            "id": "call_conflict",
+            "type": "function",
+            "function": {
+                "name": "lookup",
+                "arguments": json.dumps({"q": "news"}),
+            },
+        }
+        span = self._span(
+            kind="LLM",
+            span_id="conflicting_carriers",
+            attrs={
+                "gen_ai.operation.name": "chat",
+                "gen_ai.output.messages": json.dumps([
+                    {"role": "assistant", "tool_calls": [attr_call]}
+                ]),
+            },
+            events=[{
+                "name": "gen_ai.choice",
+                "attributes": [{"key": "message", "value": {"stringValue": json.dumps({
+                    "role": "assistant",
+                    "tool_calls": [event_call],
+                })}}],
+            }],
+        )
+
+        trajectory_calls = json.loads(
+            extract_trajectory_inputs([span])[0]["tool_calls"]
+        )
+        self.assertEqual(
+            [call["arguments"]["q"] for call in trajectory_calls],
+            ["weather", "news"],
+        )
+        self.assertEqual(len(SpanNode(span).to_dict()["tool_calls"]), 2)
+        flat_calls = [
+            item for item in _spans_to_events([span])[0]
+            if item.get("edit", {}).get("type") == "tool_call"
+        ]
+        self.assertEqual(len(flat_calls), 2)
 
     def test_tree_correlates_tool_result_across_spans(self):
         from assert_ai.core.otel import extract_for_judge, ExtractionMode
@@ -1345,14 +1401,76 @@ class TestGenAIDirectExtractionFollowup(unittest.TestCase):
         )
         self.assertEqual(chunk_request["tool_calls"][0]["tool_result"], "sunny")
 
-    def test_tree_preserves_repeated_call_ids_and_result_fifo_across_spans(self):
+    def test_result_before_request_does_not_seed_reused_call_id(self):
         from assert_ai.core.otel import extract_for_judge, ExtractionMode
 
-        def request(span_id, start, query):
+        def result_event(content):
+            return {
+                "name": "gen_ai.tool.message",
+                "attributes": [
+                    {"key": "id", "value": {"stringValue": "reused"}},
+                    {"key": "content", "value": {"stringValue": content}},
+                ],
+            }
+
+        root = self._span(
+            kind="AGENT",
+            span_id="root_reused",
+            attrs={"gen_ai.operation.name": "invoke_agent"},
+        )
+        stale_result = self._span(
+            kind="AGENT",
+            span_id="stale_result",
+            parent="root_reused",
+            start=1,
+            attrs={"gen_ai.operation.name": "invoke_agent"},
+            events=[result_event("stale")],
+        )
+        request = self._span(
+            kind="LLM",
+            span_id="reused_request",
+            parent="root_reused",
+            start=2,
+            attrs={"gen_ai.operation.name": "chat"},
+            events=[{
+                "name": "gen_ai.choice",
+                "attributes": [{"key": "message", "value": {"stringValue": json.dumps({
+                    "role": "assistant",
+                    "tool_calls": [{
+                        "id": "reused",
+                        "type": "function",
+                        "function": {"name": "lookup", "arguments": "{}"},
+                    }],
+                })}}],
+            }],
+        )
+        fresh_result = self._span(
+            kind="AGENT",
+            span_id="fresh_result",
+            parent="root_reused",
+            start=3,
+            attrs={"gen_ai.operation.name": "invoke_agent"},
+            events=[result_event("fresh")],
+        )
+
+        tree = extract_for_judge(
+            [root, stale_result, request, fresh_result],
+            mode=ExtractionMode.TREE,
+        )["representation"][0]
+        request_node = next(
+            child for child in tree["children"]
+            if child["span_id"] == "reused_request"
+        )
+        self.assertEqual(request_node["tool_calls"][0]["tool_result"], "fresh")
+
+    def test_tree_result_assignment_uses_chronology_not_depth_first_order(self):
+        from assert_ai.core.otel import extract_for_judge, ExtractionMode
+
+        def request(span_id, parent, start, query):
             return self._span(
                 kind="LLM",
                 span_id=span_id,
-                parent="root_fifo",
+                parent=parent,
                 start=start,
                 attrs={"gen_ai.operation.name": "chat"},
                 events=[{
@@ -1393,23 +1511,39 @@ class TestGenAIDirectExtractionFollowup(unittest.TestCase):
                 span_id="root_fifo",
                 attrs={"gen_ai.operation.name": "invoke_agent"},
             ),
-            request("request_1", 1_000, "first"),
-            request("request_2", 2_000, "second"),
-            result("result_1", 3_000, "first-result"),
-            result("result_2", 4_000, "second-result"),
+            self._span(
+                kind="AGENT",
+                span_id="container",
+                parent="root_fifo",
+                start=1,
+                attrs={"gen_ai.operation.name": "invoke_agent"},
+            ),
+            request("request_sibling", "root_fifo", 2, "sibling"),
+            request("request_nested", "container", 100, "nested"),
+            result("result_1", 200, "sibling-result"),
+            result("result_2", 300, "nested-result"),
         ]
 
         tree = extract_for_judge(
             spans,
             mode=ExtractionMode.TREE,
         )["representation"][0]
-        request_nodes = [
-            child for child in tree["children"]
-            if child["span_id"].startswith("request_")
-        ]
+        container = next(
+            child for child in tree["children"] if child["span_id"] == "container"
+        )
+        sibling = next(
+            child for child in tree["children"] if child["span_id"] == "request_sibling"
+        )
+        nested = next(
+            child for child in container["children"] if child["span_id"] == "request_nested"
+        )
         self.assertEqual(
-            [node["tool_calls"][0]["tool_result"] for node in request_nodes],
-            ["first-result", "second-result"],
+            sibling["tool_calls"][0]["tool_result"],
+            "sibling-result",
+        )
+        self.assertEqual(
+            nested["tool_calls"][0]["tool_result"],
+            "nested-result",
         )
 
     def test_malformed_roles_and_call_ids_do_not_abort_extraction(self):
@@ -1417,6 +1551,7 @@ class TestGenAIDirectExtractionFollowup(unittest.TestCase):
             extract_span_inputs,
             extract_trajectory_inputs,
             SpanNode,
+            _spans_to_events,
         )
 
         span = self._span(
@@ -1455,6 +1590,21 @@ class TestGenAIDirectExtractionFollowup(unittest.TestCase):
         self.assertEqual(calls[0]["name"], "lookup")
         self.assertEqual(len(SpanNode(span).to_dict()["tool_calls"]), 1)
 
+        malformed_tool = self._span(
+            kind="TOOL",
+            span_id="malformed_tool",
+            attrs={
+                "gen_ai.operation.name": "execute_tool",
+                "gen_ai.tool.name": "lookup",
+                "gen_ai.tool.call.id": ["bad-tool-id"],
+                "gen_ai.tool.call.arguments": json.dumps({"q": "weather"}),
+                "gen_ai.tool.call.result": "sunny",
+            },
+        )
+        flat_events, _ = _spans_to_events([malformed_tool])
+        self.assertEqual(len(flat_events), 1)
+        self.assertNotIn("tool_call_id", flat_events[0]["edit"])
+
     def test_tree_truncates_structured_tool_arguments(self):
         from assert_ai.core.otel import SpanNode, extract_for_judge, ExtractionMode
 
@@ -1487,7 +1637,7 @@ class TestGenAIDirectExtractionFollowup(unittest.TestCase):
             max_tokens_budget=100,
             max_content_chars=500,
         )
-        self.assertLess(len(json.dumps(result["representation"])), 2_000)
+        self.assertLessEqual(len(json.dumps(result["representation"])), 400)
 
         chunked = extract_for_judge(
             [span],
@@ -1495,7 +1645,38 @@ class TestGenAIDirectExtractionFollowup(unittest.TestCase):
             max_tokens_budget=100,
             max_content_chars=20_000,
         )
-        self.assertLess(len(json.dumps(chunked["representation"])), 2_000)
+        self.assertLessEqual(len(json.dumps(chunked["representation"])), 400)
+
+        many_spans = [
+            self._span(
+                kind="LLM",
+                span_id=f"large_args_{index}",
+                start=index,
+                attrs={
+                    "gen_ai.operation.name": "chat",
+                    "gen_ai.output.messages": json.dumps([{
+                        "role": "assistant",
+                        "tool_calls": [{
+                            "id": f"call_large_{index}",
+                            "type": "function",
+                            "function": {
+                                "name": "submit",
+                                "arguments": json.dumps(huge_args),
+                            },
+                        }],
+                    }]),
+                },
+            )
+            for index in range(8)
+        ]
+        many = extract_for_judge(
+            many_spans,
+            mode=ExtractionMode.TREE,
+            max_tokens_budget=200,
+            max_content_chars=20_000,
+        )
+        self.assertLessEqual(len(json.dumps(many["representation"])), 800)
+        self.assertTrue(many["metadata"].get("representation_truncated"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Restores existing OpenInference trajectory behavior while keeping GenAI agent-node extraction.
- Deduplicates equivalent tool requests emitted through both GenAI message attributes and span events across FLAT, trajectory, TREE, and CHUNKED consumers without collapsing conflicting payloads or legitimate repeated IDs.
- Assigns cross-span tool results to chronological requests before tree serialization, preserving repeated-ID FIFO even when tree order differs.
- Prevents unmatched event results from seeding later requests that reuse the same ID in FLAT, TREE, and CHUNKED modes.
- Makes malformed roles and call IDs degrade safely instead of aborting extraction.
- Bounds structured tool arguments and enforces the final serialized judge budget for both TREE and CHUNKED output, with an explicit truncation marker when fixed structure cannot fit.

Follow-up to #249.

Fixes #241.

## Tests
- `python -m py_compile assert_ai/core/otel.py tests/test_otel_genai.py`
- `python -m pytest tests/test_otel_genai.py::TestGenAIDirectExtractionFollowup -q` — 16 passed
- `python -m pytest tests/test_otel_genai.py tests/test_framework_agnostic.py -q` — 174 passed, 1 skipped
- `python -m pytest tests/ -q` — 1215 passed, 19 skipped, 1 warning, 474 subtests passed
- `git diff --check`


