### PR TITLE
docs(readme): recommend pip upgrade before install

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,15 @@ From the natural language specification, the ASSERT pipeline derives behavior ca
 ### Quick install
 
 ```bash
+python -m pip install --upgrade pip      # requires pip >= 24.1
 pip install -e ".[otel,langgraph]"       # install
 cp .env.example .env                     # add your provider key
 assert-ai run --config examples/travel_planner_langgraph/eval_config.yaml
 ```
+
+The pip upgrade is required on fresh devcontainers/base images: older pip
+(< 24.1) crashes with `InvalidVersion: 'hosting'` while resolving one of the
+Azure transitive dependencies' PEP 508 markers.
 
 ### Add a CI safety gate
 


### PR DESCRIPTION
## Summary

Fresh devcontainers (Ubuntu / `mcr.microsoft.com` base images) ship pip < 24.1, which crashes with `InvalidVersion: 'hosting'` while resolving one of the Azure transitive markers pulled in via `langchain-azure-ai`. `docs/getting-started.md` already prepends `python -m pip install --upgrade pip`; the front-page **Quick install** did not, so anyone copy-pasting from `README.md` hits the failure.

## What changed

- `README.md` — Quick install now leads with `python -m pip install --upgrade pip` (matching the getting-started docs).
- Added a one-line note under the code block that names the exact failure (`InvalidVersion: 'hosting'`) so users Googling the error land on the fix.

## Why not pin a dep instead

The root cause lives in the vendored `packaging` library inside older pip, not in any ASSERT-controlled requirement. `pyproject.toml` has no way to enforce a minimum pip. Docs is the correct level.

## Repro

```
Collecting assert-ai==0.1.0
Collecting langchain-openai>=0.3
Collecting langchain-azure-ai>=0.1
ERROR: Exception:
Traceback (most recent call last):
  File ".../pip/_vendor/packaging/markers.py", line 183, in _eval_op
    return spec.contains(lhs, prereleases=True)
  ...
pip._vendor.packaging.version.InvalidVersion: Invalid version: 'hosting'
```

Reported from a fresh devcontainer install.
