### PR TITLE
fix(init): emit YAML block scalars for multi-line strings and non-ASCII

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -40,22 +40,14 @@ jobs:
           cache-dependency-path: viewer/package-lock.json
 
       - name: Install Python dependencies
-        # Deliberately does NOT install the `otel` extra. `otel` pulls in
-        # `arize-phoenix`, which registers a `pytest11` entry point whose
-        # import chain runs `phoenix.trace.dsl.filter` at pytest collection
-        # time. Recent phoenix releases (19.18+) declare a frozen dataclass
-        # with a `mappingproxy` default there, which Python 3.11's dataclass
-        # machinery rejects, taking down every test job that has phoenix
-        # installed — including our own unit tests, which don't use phoenix.
-        #
-        # The base `dependencies` already ship `opentelemetry-api` / `-sdk`
-        # (all the `otel` demos need at import time), and
-        # `assert_ai.auto_trace.enable(...)` guards its `phoenix.otel`
-        # import behind a collector-availability probe, so smoke tests that
-        # instantiate the incident-triage agent still work without phoenix
-        # in the install set.
+        # The `otel` extra is required because tests/test_incident_triage_smoke.py
+        # imports examples/incident_triage_agent/agent.py, which imports
+        # opentelemetry at module load time (target.trace.backend: otel). Demo
+        # examples like that one ship as part of the unit-test surface, so the
+        # CI install set has to include the demo's optional extras even though
+        # core ASSERT doesn't need them.
         run: |
-          python -m pip install -e ".[dev]"
+          python -m pip install -e ".[dev,otel]"
 
       - name: Install viewer npm dependencies
         # tests/test_viewer_*.py shell out to `node` against viewer TypeScript

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -40,14 +40,22 @@ jobs:
           cache-dependency-path: viewer/package-lock.json
 
       - name: Install Python dependencies
-        # The `otel` extra is required because tests/test_incident_triage_smoke.py
-        # imports examples/incident_triage_agent/agent.py, which imports
-        # opentelemetry at module load time (target.trace.backend: otel). Demo
-        # examples like that one ship as part of the unit-test surface, so the
-        # CI install set has to include the demo's optional extras even though
-        # core ASSERT doesn't need them.
+        # Deliberately does NOT install the `otel` extra. `otel` pulls in
+        # `arize-phoenix`, which registers a `pytest11` entry point whose
+        # import chain runs `phoenix.trace.dsl.filter` at pytest collection
+        # time. Recent phoenix releases (19.18+) declare a frozen dataclass
+        # with a `mappingproxy` default there, which Python 3.11's dataclass
+        # machinery rejects, taking down every test job that has phoenix
+        # installed — including our own unit tests, which don't use phoenix.
+        #
+        # The base `dependencies` already ship `opentelemetry-api` / `-sdk`
+        # (all the `otel` demos need at import time), and
+        # `assert_ai.auto_trace.enable(...)` guards its `phoenix.otel`
+        # import behind a collector-availability probe, so smoke tests that
+        # instantiate the incident-triage agent still work without phoenix
+        # in the install set.
         run: |
-          python -m pip install -e ".[dev,otel]"
+          python -m pip install -e ".[dev]"
 
       - name: Install viewer npm dependencies
         # tests/test_viewer_*.py shell out to `node` against viewer TypeScript

--- a/assert_ai/cli.py
+++ b/assert_ai/cli.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import difflib
 import json
+import sys
 
 from datetime import datetime, timezone
 from pathlib import Path
@@ -1992,7 +1993,29 @@ def library_show(name: str, kind: str | None, as_json: bool):
         _echo_json(data)
         return
 
-    click.echo(dump_yaml(data).rstrip())
+    _write_stdout_utf8(dump_yaml(data))
+
+
+def _write_stdout_utf8(payload: str) -> None:
+    """Write ``payload`` to stdout as UTF-8 bytes.
+
+    ``click.echo`` re-encodes the payload with ``sys.stdout.encoding``, which
+    on Windows defaults to the ANSI code page (usually cp1252) for redirected
+    stdout. Non-ASCII characters like ``日本語`` then raise
+    ``UnicodeEncodeError``. Writing bytes directly through ``sys.stdout.buffer``
+    bypasses that re-encoding so a preset's on-disk YAML matches what
+    ``assert-ai init`` writes on any platform.
+
+    Falls back to ``click.echo`` when ``sys.stdout`` has no ``buffer`` (for
+    example under ``pytest``'s ``capsys`` fixture, which wraps stdout in a
+    ``TextIO`` without a binary layer).
+    """
+    buffer = getattr(sys.stdout, "buffer", None)
+    if buffer is None:
+        click.echo(payload, nl=False)
+        return
+    buffer.write(payload.encode("utf-8"))
+    buffer.flush()
 
 
 if __name__ == "__main__":

--- a/assert_ai/cli.py
+++ b/assert_ai/cli.py
@@ -21,6 +21,7 @@ from rich.table import Table
 from assert_ai.core.config_model import DEFAULT_INFERENCE_CONCURRENCY
 from assert_ai.core.io import load_json, load_jsonl, get_permissible_flag, row_behavior
 from assert_ai.core.judge import get_verdict_dimension, infer_judge_status, is_valid_event_flag
+from assert_ai.core.yaml_io import dump_yaml
 from assert_ai.display import label_metric, label_run_status, label_stage, label_stage_status, label_status
 from assert_ai.logging_config import configure_logging
 from assert_ai.results import (
@@ -1882,7 +1883,7 @@ def library_show(name: str, kind: str | None, as_json: bool):
         _echo_json(data)
         return
 
-    click.echo(yaml.dump(data, default_flow_style=False, sort_keys=False).rstrip())
+    click.echo(dump_yaml(data).rstrip())
 
 
 if __name__ == "__main__":

--- a/assert_ai/core/yaml_io.py
+++ b/assert_ai/core/yaml_io.py
@@ -34,8 +34,21 @@ class BlockStyleDumper(yaml.SafeDumper):
     """SafeDumper that picks the literal block style for multi-line strings."""
 
 
+# YAML 1.1 treats these code points as line breaks when they appear literally
+# in plain or single-quoted scalars: on reload they fold to a single space
+# (or terminate the scalar), so ``allow_unicode=True`` alone is not
+# round-trip safe for them. Force double-quoted style so PyYAML emits the
+# escape sequences (``\N``, ``\L``, ``\P``) that survive a round trip.
+_LINE_BREAK_CONTROL_CHARS = ("\u0085", "\u2028", "\u2029")
+
+
 def _represent_str(dumper: yaml.SafeDumper, value: str) -> yaml.Node:
-    style = "|" if "\n" in value else None
+    if any(ch in value for ch in _LINE_BREAK_CONTROL_CHARS):
+        style: str | None = '"'
+    elif "\n" in value:
+        style = "|"
+    else:
+        style = None
     return dumper.represent_scalar("tag:yaml.org,2002:str", value, style=style)
 
 

--- a/assert_ai/core/yaml_io.py
+++ b/assert_ai/core/yaml_io.py
@@ -1,0 +1,57 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Shared YAML emission helpers for ASSERT.
+
+`assert-ai init` and the ACS eval-config generator both emit YAML that
+lands in a customer's repository and gets read/edited by humans. PyYAML's
+default emission uses double-quoted flow scalars for strings containing
+newlines or non-ASCII characters, which produces unreadable rows like
+``description: "line one\\nline two \\u2014 dash"``.
+
+This module provides a single ``dump_yaml`` entry point that:
+
+- Uses a block-scalar (``|``) representer for any string containing a
+  newline, so multi-line ``description`` / ``context`` / ``rubric``
+  fields render as literal blocks instead of quoted scalars.
+- Sets ``allow_unicode=True`` so em-dashes and other non-ASCII text are
+  emitted verbatim rather than as ``\\uXXXX`` escapes.
+- Keeps ``default_flow_style=False`` and ``sort_keys=False`` so the
+  emitted mapping preserves author key order.
+
+Call ``dump_yaml(data)`` anywhere ``yaml.dump(data, default_flow_style=False,
+sort_keys=False)`` was previously used to emit a config file.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import yaml
+
+
+class BlockStyleDumper(yaml.SafeDumper):
+    """SafeDumper that picks the literal block style for multi-line strings."""
+
+
+def _represent_str(dumper: yaml.SafeDumper, value: str) -> yaml.Node:
+    style = "|" if "\n" in value else None
+    return dumper.represent_scalar("tag:yaml.org,2002:str", value, style=style)
+
+
+BlockStyleDumper.add_representer(str, _represent_str)
+
+
+def dump_yaml(data: Any) -> str:
+    """Dump ``data`` as YAML using block scalars for multi-line strings.
+
+    Equivalent to ``yaml.dump(data, Dumper=BlockStyleDumper,
+    default_flow_style=False, sort_keys=False, allow_unicode=True)``.
+    """
+    return yaml.dump(
+        data,
+        Dumper=BlockStyleDumper,
+        default_flow_style=False,
+        sort_keys=False,
+        allow_unicode=True,
+    )

--- a/assert_ai/init/_context.py
+++ b/assert_ai/init/_context.py
@@ -10,9 +10,8 @@ import logging
 from pathlib import Path
 from typing import Any
 
-import yaml
-
 from assert_ai.core.io import load_prompt_text
+from assert_ai.core.yaml_io import dump_yaml
 from assert_ai.library.loader import discover, load_preset
 
 log = logging.getLogger(__name__)
@@ -116,7 +115,7 @@ def _build_behavior_section(behavior_name: str | None) -> str:
     except ValueError as exc:
         log.warning("Could not load behavior preset: %s", exc)
         return ""
-    dumped = yaml.dump(preset, default_flow_style=False, sort_keys=False)
+    dumped = dump_yaml(preset)
     return (
         f"## Selected Behavior Preset: {behavior_name}\n\n"
         f"```yaml\n{dumped}```\n"
@@ -132,7 +131,7 @@ def _build_judge_section(judge_name: str | None) -> str:
     except ValueError as exc:
         log.warning("Could not load judge preset: %s", exc)
         return ""
-    dumped = yaml.dump(preset, default_flow_style=False, sort_keys=False)
+    dumped = dump_yaml(preset)
     return (
         f"## Selected Judge Preset: {judge_name}\n\n"
         f"```yaml\n{dumped}```\n"

--- a/assert_ai/init/_design_agent.py
+++ b/assert_ai/init/_design_agent.py
@@ -35,6 +35,7 @@ from assert_ai.core.model_client import (
     LLMProviderError,
     LLMRateLimitError,
 )
+from assert_ai.core.yaml_io import dump_yaml
 
 log = logging.getLogger(__name__)
 
@@ -438,7 +439,7 @@ def run_design_loop(
 def _normalize_yaml(yaml_str: str) -> str:
     """Roundtrip through PyYAML for consistent formatting."""
     data = yaml.safe_load(yaml_str)
-    return yaml.dump(data, default_flow_style=False, sort_keys=False)
+    return dump_yaml(data)
 
 
 def _save_draft(yaml_str: str, errors: list[str], console: Console) -> None:

--- a/assert_ai/init/_emit.py
+++ b/assert_ai/init/_emit.py
@@ -12,6 +12,8 @@ from pathlib import Path
 
 import yaml
 
+from assert_ai.core.yaml_io import dump_yaml
+
 log = logging.getLogger(__name__)
 
 
@@ -29,7 +31,7 @@ def emit_config(yaml_content: str, output: Path, *, force: bool = False) -> None
 
     # Normalize formatting.
     data = yaml.safe_load(yaml_content)
-    normalized = yaml.dump(data, default_flow_style=False, sort_keys=False)
+    normalized = dump_yaml(data)
 
     # Ensure trailing newline.
     if not normalized.endswith("\n"):

--- a/assert_ai/integrations/acs/eval_config.py
+++ b/assert_ai/integrations/acs/eval_config.py
@@ -18,6 +18,8 @@ from typing import Any, Iterable
 
 import yaml
 
+from assert_ai.core.yaml_io import dump_yaml
+
 DEFAULT_MODEL = "azure/gpt-4o-mini"
 
 _POINT_ORDER = (
@@ -263,19 +265,7 @@ def write_eval_config(
 
 
 def _dump_eval_config_yaml(config: dict[str, Any]) -> str:
-    return yaml.dump(config, Dumper=_EvalConfigDumper, sort_keys=False)
-
-
-class _EvalConfigDumper(yaml.SafeDumper):
-    pass
-
-
-def _represent_str(dumper: yaml.SafeDumper, value: str) -> yaml.Node:
-    style = "|" if "\n" in value else None
-    return dumper.represent_scalar("tag:yaml.org,2002:str", value, style=style)
-
-
-_EvalConfigDumper.add_representer(str, _represent_str)
+    return dump_yaml(config)
 
 
 def _judge_dimensions() -> dict[str, dict[str, Any]]:

--- a/tests/test_library_show_stdout.py
+++ b/tests/test_library_show_stdout.py
@@ -1,0 +1,96 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for ``assert-ai library show`` stdout encoding.
+
+The command emits YAML with ``allow_unicode=True`` so em-dashes and CJK
+render verbatim. When stdout is a text stream whose encoding cannot
+represent those characters (Windows ANSI code pages, ``PYTHONIOENCODING``
+set to ``ascii`` or ``cp1252``), a naive ``click.echo`` re-encodes the
+payload and raises ``UnicodeEncodeError``. ``_write_stdout_utf8`` writes
+UTF-8 bytes through ``sys.stdout.buffer`` to bypass that re-encoding, so
+the on-disk YAML produced by a redirected ``library show`` matches what
+``assert-ai init`` writes.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import shutil
+import subprocess
+import sys
+
+import click
+import pytest
+import yaml
+
+from assert_ai.cli import _write_stdout_utf8
+
+
+class _StdoutWithBuffer:
+    """Minimal stdout stub exposing a ``buffer`` attribute for byte writes."""
+
+    def __init__(self) -> None:
+        self.buffer = io.BytesIO()
+
+    def write(self, _text: str) -> int:  # pragma: no cover - guards the fast path
+        raise AssertionError("text write path used instead of buffer")
+
+
+class _StdoutWithoutBuffer:
+    """Minimal stdout stub with no binary layer, mirroring CliRunner streams."""
+
+    def __init__(self) -> None:
+        self.written: list[str] = []
+
+    def write(self, text: str) -> int:
+        self.written.append(text)
+        return len(text)
+
+    def flush(self) -> None:
+        return None
+
+
+def test_write_stdout_utf8_uses_buffer_when_available(monkeypatch) -> None:
+    """Bytes go through ``sys.stdout.buffer`` verbatim, no re-encoding."""
+    stub = _StdoutWithBuffer()
+    monkeypatch.setattr(sys, "stdout", stub)
+    _write_stdout_utf8("preset: 日本語\n")
+    assert stub.buffer.getvalue() == "preset: 日本語\n".encode("utf-8")
+
+
+def test_write_stdout_utf8_falls_back_when_no_buffer(monkeypatch) -> None:
+    """Text streams without ``.buffer`` (Click's CliRunner) still work."""
+    stub = _StdoutWithoutBuffer()
+    monkeypatch.setattr(sys, "stdout", stub)
+    # click.echo resolves its target via _default_text_stdout(); redirect that
+    # too so the fallback exercised here matches what CliRunner would see.
+    monkeypatch.setattr(click.utils, "_default_text_stdout", lambda: stub)
+    _write_stdout_utf8("preset: hello\n")
+    assert "".join(stub.written) == "preset: hello\n"
+
+
+@pytest.mark.skipif(
+    shutil.which("assert-ai") is None,
+    reason="assert-ai console script not installed in this environment",
+)
+def test_library_show_survives_ascii_stdout_encoding() -> None:
+    """End-to-end regression: a preset with an em-dash prints as valid UTF-8
+    even when ``PYTHONIOENCODING=ascii`` would make ``click.echo`` raise."""
+    env = {**os.environ, "PYTHONIOENCODING": "ascii"}
+    # ``stereotyping`` is a bundled behavior preset that contains em-dashes.
+    # Passing ``--kind behavior`` explicitly keeps the regression stable across
+    # library reshuffles that move presets between kinds.
+    result = subprocess.run(
+        ["assert-ai", "library", "show", "stereotyping", "--kind", "behavior"],
+        env=env,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr.decode("utf-8", errors="replace")
+    doc = yaml.safe_load(result.stdout.decode("utf-8"))
+    assert doc["name"] == "stereotyping"
+    # Confirm the em-dash actually survived to the output, i.e. the guard is
+    # doing something (a broken guard could still exit 0 by silently stripping).
+    assert "—" in result.stdout.decode("utf-8")

--- a/tests/test_yaml_io.py
+++ b/tests/test_yaml_io.py
@@ -73,3 +73,25 @@ def test_nested_mapping_uses_block_style() -> None:
     assert "behavior:" in out
     assert "  description: |" in out
     assert "{" not in out
+
+
+def test_line_break_control_chars_round_trip() -> None:
+    """U+0085, U+2028, U+2029 fold to a space under plain/single-quoted YAML
+    with ``allow_unicode=True``; forcing double-quoted style preserves them."""
+    for ch in ("\u0085", "\u2028", "\u2029"):
+        # Single-line: string is only the control char surrounded by ASCII.
+        single = {"x": f"a{ch}b"}
+        assert yaml.safe_load(dump_yaml(single)) == single, (
+            f"single-line round trip failed for U+{ord(ch):04X}"
+        )
+        # Multi-line: control char sits inside an already-multi-line scalar.
+        multi = {"x": f"line one\nl{ch}ne two"}
+        assert yaml.safe_load(dump_yaml(multi)) == multi, (
+            f"multi-line round trip failed for U+{ord(ch):04X}"
+        )
+
+
+def test_line_break_control_chars_use_double_quoted_style() -> None:
+    """Sanity check: the guard picks double-quoted, not block scalar."""
+    out = dump_yaml({"x": "a\u0085b"})
+    assert 'x: "a\\Nb"' in out

--- a/tests/test_yaml_io.py
+++ b/tests/test_yaml_io.py
@@ -1,0 +1,75 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for assert_ai.core.yaml_io.dump_yaml.
+
+These check the two properties the emitter used to lose:
+
+- multi-line strings are emitted as literal block scalars (``|``),
+  not as double-quoted flow scalars with escaped ``\\n``.
+- non-ASCII characters (em-dashes, curly quotes, CJK) are emitted
+  verbatim, not as ``\\uXXXX`` escapes.
+"""
+
+from __future__ import annotations
+
+import yaml
+
+from assert_ai.core.yaml_io import dump_yaml
+
+
+def test_multiline_string_uses_block_scalar() -> None:
+    data = {"description": "line one\nline two\nline three"}
+    out = dump_yaml(data)
+    assert "description: |" in out
+    assert "\\n" not in out
+    # Roundtrip preserves the string exactly.
+    assert yaml.safe_load(out)["description"] == data["description"]
+
+
+def test_single_line_string_stays_plain() -> None:
+    data = {"name": "single_line_value"}
+    out = dump_yaml(data)
+    # No block indicator for single-line values.
+    assert "name: single_line_value" in out
+    assert "name: |" not in out
+
+
+def test_non_ascii_emitted_verbatim() -> None:
+    data = {"context": "em—dash and “curly quotes” and 日本語"}
+    out = dump_yaml(data)
+    assert "—" in out
+    assert "“" in out
+    assert "日本語" in out
+    assert "\\u" not in out
+    assert yaml.safe_load(out)["context"] == data["context"]
+
+
+def test_multiline_with_unicode_uses_block_scalar_and_verbatim() -> None:
+    data = {"rubric": "step 1 — describe\nstep 2 — evaluate"}
+    out = dump_yaml(data)
+    assert "rubric: |" in out
+    assert "—" in out
+    assert "\\n" not in out
+    assert "\\u" not in out
+
+
+def test_key_order_is_preserved() -> None:
+    data = {"z": 1, "m": 2, "a": 3}
+    out = dump_yaml(data)
+    lines = [line for line in out.splitlines() if line and not line.startswith(" ")]
+    assert lines == ["z: 1", "m: 2", "a: 3"]
+
+
+def test_nested_mapping_uses_block_style() -> None:
+    data = {
+        "behavior": {
+            "name": "grounded",
+            "description": "line one\nline two",
+        }
+    }
+    out = dump_yaml(data)
+    # Nested mapping is emitted in block style, not inline flow style.
+    assert "behavior:" in out
+    assert "  description: |" in out
+    assert "{" not in out


### PR DESCRIPTION
## Summary

`assert-ai init` currently calls `yaml.dump(...)` with `default_flow_style=False` but without `allow_unicode=True` and without a block-scalar representer, so long strings emit as **double-quoted flow scalars with `\n` and `\uXXXX` escapes**. Behavior YAMLs land in customer repos and get read/edited by humans, so the current output (see [example on wire-assert-ci demo](https://github.com/responsibleai/assert-ai-action/tree/main/eval-demo-repo) — files with `description: "line one\nline two"` and `\u2014`) is nearly unreadable and diffs poorly.

## What changed

Consolidates all YAML emission through a new `assert_ai.core.yaml_io.dump_yaml()`:

- **Block-scalar for multi-line strings** — any string containing `\n` renders as `|` literal block, so `behavior.description`, `context`, judge dimension descriptions, and rubrics are readable.
- **`allow_unicode=True`** — em-dashes, curly quotes, CJK stay verbatim instead of becoming `\uXXXX`.
- Keeps `default_flow_style=False` + `sort_keys=False` so author key order is preserved.

Wires the helper into every existing emitter:

| File | Change |
|---|---|
| `assert_ai/core/yaml_io.py` | New shared helper + `BlockStyleDumper` |
| `assert_ai/init/_emit.py` | Atomic writer → `dump_yaml(data)` |
| `assert_ai/init/_context.py` | Preset dumps in LLM-facing prompts → `dump_yaml(preset)` |
| `assert_ai/init/_design_agent.py` | `_normalize_yaml` used for interactive drafts + `eval.draft.yaml` |
| `assert_ai/integrations/acs/eval_config.py` | Delete duplicate `_EvalConfigDumper` / `_represent_str`; keep `_dump_eval_config_yaml` as thin wrapper |
| `assert_ai/cli.py` | `assert-ai preset show` uses the same helper |

## Tests

`tests/test_yaml_io.py` — 6 new focused tests:

- multi-line string uses `|`
- single-line stays plain
- non-ASCII emitted verbatim
- multi-line + non-ASCII combined
- key-order preservation
- nested-mapping block style

All 6 pass. Pre-existing `tests/test_acs_eval_config.py` (6 tests) still passes — the ACS eval-config generator is now backed by the same shared helper.

## Sanity check

Ran the fixed `emit_config` on a sample with multi-line rubrics and em-dashes:

```yaml
behavior:
  name: accurate_attribution
  description: |
    Multi-line description with an em—dash.
    Line two.
```

No `\n` escapes, no `\u2014`, em-dashes verbatim, `|` block style throughout.

## Notes

- The helper subclasses `yaml.SafeDumper`, so all safety guarantees of `safe_dump` are preserved.
- Existing files that were already flow-style don't need migration; PyYAML will read them fine — new files just emit better.
