### PR TITLE
fix(viewer): stop clipping eval results table and metric dropdown.

### DIFF
--- a/viewer/src/lib/PrimerDropdown.svelte
+++ b/viewer/src/lib/PrimerDropdown.svelte
@@ -36,6 +36,47 @@
   let highlightedIndex = $state(-1);
   let triggerButton: HTMLButtonElement;
   let menuList: HTMLUListElement;
+  // The menu is rendered with `position: fixed` and anchored to the trigger's
+  // viewport rect so it can escape any ancestor with a scroll/clip context
+  // (e.g. the `overflow-x-auto` wrapper around the evaluation-results table).
+  // An absolutely-positioned menu is clipped by such an ancestor and also
+  // inflates its scrollWidth, which spawns a stray horizontal scrollbar.
+  let menuStyle = $state('');
+
+  const VIEWPORT_MARGIN = 8;
+  const TRIGGER_GAP = 4;
+  const MIN_MENU_WIDTH = 192; // matches the 12rem min-width in CSS
+
+  function positionMenu() {
+    if (!triggerButton || !menuList) return;
+    const anchor = triggerButton.getBoundingClientRect();
+    const menu = menuList.getBoundingClientRect();
+
+    // Prefer left-aligned to the trigger; flip to right-aligned when that would
+    // overflow the viewport, then clamp so the menu is never off-screen.
+    let left = anchor.left;
+    if (left + menu.width > window.innerWidth - VIEWPORT_MARGIN) {
+      left = anchor.right - menu.width;
+    }
+    left = Math.max(
+      VIEWPORT_MARGIN,
+      Math.min(left, window.innerWidth - menu.width - VIEWPORT_MARGIN)
+    );
+
+    // Prefer opening downward; flip above the trigger only when there is room.
+    let top = anchor.bottom + TRIGGER_GAP;
+    const overflowsBottom = top + menu.height > window.innerHeight - VIEWPORT_MARGIN;
+    const fitsAbove = anchor.top - TRIGGER_GAP - menu.height >= VIEWPORT_MARGIN;
+    if (overflowsBottom && fitsAbove) {
+      top = anchor.top - TRIGGER_GAP - menu.height;
+    }
+    top = Math.max(VIEWPORT_MARGIN, top);
+
+    menuStyle =
+      `position: fixed; top: ${Math.round(top)}px; left: ${Math.round(left)}px; ` +
+      `min-width: ${Math.round(Math.max(MIN_MENU_WIDTH, anchor.width))}px;`;
+  }
+
 
   function handleSelect(value: string) {
     selected = value;
@@ -108,6 +149,28 @@
   });
 
   $effect(() => {
+    if (!open) {
+      menuStyle = '';
+      return;
+    }
+    // First pass positions from the pre-layout rect; the rAF pass corrects once
+    // the menu has been laid out at its final size.
+    positionMenu();
+    const frame = requestAnimationFrame(positionMenu);
+
+    const reposition = () => positionMenu();
+    // Capture phase so scrolling of any ancestor container is observed too.
+    window.addEventListener('scroll', reposition, true);
+    window.addEventListener('resize', reposition);
+
+    return () => {
+      cancelAnimationFrame(frame);
+      window.removeEventListener('scroll', reposition, true);
+      window.removeEventListener('resize', reposition);
+    };
+  });
+
+  $effect(() => {
     if (open && highlightedIndex >= 0 && menuList) {
       const items = menuList.querySelectorAll('[role="option"]');
       const item = items[highlightedIndex] as HTMLElement;
@@ -146,6 +209,7 @@
       bind:this={menuList}
       class="ActionList ActionMenu-list"
       role="listbox"
+      style={menuStyle}
       onkeydown={handleKeyDown}
       onblur={handleMenuBlur}
       tabindex={-1}

--- a/viewer/src/routes/suite/[suite_id]/+page.svelte
+++ b/viewer/src/routes/suite/[suite_id]/+page.svelte
@@ -819,7 +819,7 @@
 				<p class="text-sm text-text-secondary">No evaluation results yet.</p>
 			</div>
 		{:else}
-			<div class="overflow-hidden rounded-lg border border-border">
+			<div class="overflow-x-auto rounded-lg border border-border">
 				<table class="w-full text-left text-sm">
 					<thead>
 						<tr class="border-b border-border bg-surface">
@@ -833,7 +833,7 @@
 						<th class="px-3 py-2 text-xs font-medium text-text-muted">Run date</th>
 						<th class="px-3 py-2 text-xs font-medium text-text-muted">Run status</th>
 						{#each selectedMetricCols as colDim, colIdx (colIdx)}
-							<th class="w-32 px-3 py-2 text-left text-xs font-medium text-text-muted whitespace-nowrap">
+							<th class="metric-col px-3 py-2 text-left text-xs font-medium text-text-muted">
 								<PrimerDropdown
 									ariaLabel={`Metric column ${colIdx + 1}`}
 									selected={colDim ?? ''}
@@ -887,9 +887,9 @@
 											<svg class="h-3 w-3 transition-transform duration-150 {isExpanded ? 'rotate-90' : ''}" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M9 5l7 7-7 7"/></svg>
 										</button>
 									{/if}
-									<div class="min-w-0 flex flex-col">
-										<a href="/suite/{data.suite_id}/{run.prompt_run_id ?? run.audit_run_id ?? run.run_id}" class="text-sm font-medium text-interactive hover:underline">{run.run_id}</a>
-										<span class="font-mono text-[10px] text-text-muted truncate" title={runTarget(run)}>{runTarget(run)}</span>
+									<div class="flex min-w-0 max-w-[22rem] flex-col">
+										<a href="/suite/{data.suite_id}/{run.prompt_run_id ?? run.audit_run_id ?? run.run_id}" class="truncate text-sm font-medium text-interactive hover:underline">{run.run_id}</a>
+										<span class="truncate font-mono text-[10px] text-text-muted" title={runTarget(run)}>{runTarget(run)}</span>
 									</div>
 								</div>
 							</td>
@@ -1168,3 +1168,45 @@
 	{/if}
 </div>
 {/if}
+
+<style>
+	/* The metric columns are user-selectable dropdowns whose labels ("Impermissible
+	   behavior violated") are far wider than the column needs. PrimerDropdown's
+	   trigger is a fixed-height, nowrap button, so the label alone set the column
+	   width and pushed the trailing Total column out of the container. Let the
+	   label wrap inside a fixed-width header instead of truncating it, so the whole
+	   table fits without a horizontal scroll at the container's max width. */
+	.metric-col {
+		width: 10rem;
+		white-space: normal;
+	}
+
+	.metric-col :global(.ActionMenu) {
+		display: block;
+	}
+
+	.metric-col :global(button.ActionMenu-button) {
+		width: 100%;
+		height: auto;
+		min-height: 0;
+		align-items: flex-start;
+		padding: 0.25rem 0.5rem;
+		font-size: 0.75rem;
+		line-height: 1.25;
+		white-space: normal;
+	}
+
+	.metric-col :global(.ActionMenu-button-content) {
+		display: block;
+		min-width: 0;
+	}
+
+	.metric-col :global(.ActionMenu-button-value) {
+		white-space: normal;
+		overflow-wrap: anywhere;
+	}
+
+	.metric-col :global(.ActionMenu-button-chevron) {
+		margin-top: 1px;
+	}
+</style>


### PR DESCRIPTION
## Summary

Fixes the evaluation-results table on the suite page, where the right-hand columns were clipped rather than scrollable, and fixes the metric dropdown menus that the scroll-container fix then exposed as clipped.

## Motivation / linked issue

Closes #322.

The Total column was unreachable on **every** suite. Not just long metric names, and not just narrow monitors. The page container is Primer's `container-xl` (max 1280px), so usable width is ~1198px regardless of screen size, while the table rendered at 1331px. The wrapper used `overflow-hidden`, so that 133px simply disappeared with no scrollbar to recover it.

## Changes

- **`overflow-hidden` → `overflow-x-auto`** on the results-table wrapper, matching the pattern already used on the compare page. This is the safety net: no column can become unreachable again, whatever metrics a user selects.
- **Metric header labels now wrap inside a fixed 10rem column.** These were the main width driver. The `<th>` was declared `w-32`, but `PrimerDropdown`'s trigger is a fixed-height `white-space: nowrap` button, so `w-32` could never bind — "Impermissible behavior violated" alone forced the column to 285px. Wrapping brings the table to 1198px, exactly inside the container, without shortening any metric name. `labels.ts` is shared with other surfaces and is deliberately untouched.
- **Capped the run-target cell so its existing `truncate` applies.** The `truncate` class there was dead code: neither it nor `min-w-0` can bind inside an auto-layout `<td>`, which grows to max-content, so the full target string rendered every time. A `max-w` on an inner block element makes the truncation and its `title` tooltip work as originally intended.
- **`PrimerDropdown` menus now render `position: fixed`, anchored to the trigger's viewport rect.** Making the wrapper a scroll container exposed a second bug: an absolutely-positioned menu cannot escape an ancestor scroll context, so an open metric dropdown was cut off at 101px of overhang and its options were unreadable. It also inflated the wrapper's `scrollWidth` (1198 → 1300), producing a stray horizontal scrollbar whenever a menu was open. A fixed menu is neither clipped nor counted in an ancestor's scroll extent, so both symptoms resolve from one change.
- **Added the collision handling `PrimerDropdown` previously lacked**: horizontal flip to right-aligned, vertical flip above the trigger, viewport clamping, and repositioning on scroll/resize while open.

## Testing

- `npm run check`: 0 errors (6 warnings, all pre-existing in `routes/new/+page.svelte`).
- `npm run build`: passes.
- **Table layout**, headless browser, 5 suites × 3 viewports (1280/1440/1680): 15/15 have no unreachable column. Negative control against the pre-fix code: 15/15 failed, with 23–227px of overflow.
- **Dropdowns**, headless browser, 3 pages × 3 viewports: 15/15 render `position: fixed`, fully in-viewport, with unclipped option text. Negative control: all 15 were `absolute` before, 3 of them escaping the viewport entirely.
- Confirmed the stray horizontal scrollbar no longer appears while a menu is open.

## Checklist

- [X] Tests pass locally (`pytest` and/or viewer checks as applicable).
- [X] Docs updated if behavior or public API changed.
- [X] No secrets, credentials, or customer data committed.
- [X] No breaking change, or a `CHANGELOG.md` entry is included.