### PR TITLE
fix(sandbox): keep egress evidence outside target mount

### DIFF
--- a/assert_ai/integrations/sandbox/runtime.py
+++ b/assert_ai/integrations/sandbox/runtime.py
@@ -11,7 +11,8 @@ complementary process and network boundary for everything else:
 * a private Docker network with no gateway, so neither the host nor public
   internet is directly reachable;
 * a deny-by-default HTTP(S) proxy that records every proxy-aware egress attempt;
-* policy and mock files mounted read-only, with a separate writable output mount;
+* policy and mock files mounted read-only, with a separate writable target-output
+  mount and a host-only network-evidence ledger;
 * optional host-side model proxy, so a real provider credential never enters the
   container.
 
@@ -619,7 +620,13 @@ def start_container(
     # output, so make the mount writable without weakening any source/policy
     # mount. It is removed with the owning session.
     output_dir.chmod(0o777)
-    egress_log = output_dir / "egress.jsonl"
+    # The evaluated target may control every byte under its writable output
+    # mount. Keep proxy-generated evidence in a sibling host-only directory so
+    # the target cannot rewrite or delete the ledger ASSERT later consumes.
+    audit_dir = output_dir.parent / "audit"
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    audit_dir.chmod(0o700)
+    egress_log = audit_dir / "egress.jsonl"
     config_dir = output_dir.parent / "config"
     config_dir.mkdir(parents=True, exist_ok=True)
     config_dir.chmod(0o755)

--- a/examples/sandbox_action_mediation/README.md
+++ b/examples/sandbox_action_mediation/README.md
@@ -31,7 +31,8 @@ The stock container path applies:
   proxy-aware requests as `network_egress` evidence;
 - an automatically managed trusted relay that exposes only target ingress,
   audited egress, and optional model-proxy traffic to that private network;
-- read-only policy and mock mounts plus a separate writable output mount;
+- read-only policy and mock mounts, a writable target-output mount, and a
+  host-owned network-evidence ledger that is never mounted into the target;
 - optional host-side model credential routing. The container receives a random
   short-lived proxy token, never the provider credential.
 

--- a/tests/test_sandbox_runtime.py
+++ b/tests/test_sandbox_runtime.py
@@ -669,6 +669,19 @@ def test_docker_command_enforces_stock_containment_and_omits_real_credential(tmp
     assert audit_log == (tmp_path / "audit" / "egress.jsonl").resolve()
     assert not audit_log.is_relative_to(handle.output_dir)
     assert str(audit_log) not in target_command
+    # The ledger must sit outside *every* directory handed to the target, not
+    # just outside output_dir. Parse the real -v arguments so a future mount
+    # that happens to contain the audit directory fails here, on the ungated
+    # unit path, rather than only in the ASSERT_RUN_DOCKER_TESTS suite.
+    host_mount_sources = [
+        Path(value.split(":", 1)[0]).resolve()
+        for flag, value in zip(target_run, target_run[1:])
+        if flag == "-v"
+    ]
+    assert host_mount_sources, "expected the target container to receive host mounts"
+    assert not any(audit_log.is_relative_to(source) for source in host_mount_sources), (
+        f"egress ledger {audit_log} is inside a target mount: {host_mount_sources}"
+    )
     assert "--read-only" in target_run
     assert "--user" in target_run and "65534:65534" in target_run
     assert "--cap-drop" in target_run and "ALL" in target_run

--- a/tests/test_sandbox_runtime.py
+++ b/tests/test_sandbox_runtime.py
@@ -613,11 +613,13 @@ def test_docker_command_enforces_stock_containment_and_omits_real_credential(tmp
         def shutdown(self): pass
         def server_close(self): pass
 
-    monkeypatch.setattr(
-        sandbox_runtime,
-        "_start_egress_proxy",
-        lambda **kwargs: (Server(), SimpleNamespace(), 9100),
-    )
+    egress_proxy_args = {}
+
+    def fake_start_egress_proxy(**kwargs):
+        egress_proxy_args.update(kwargs)
+        return Server(), SimpleNamespace(), 9100
+
+    monkeypatch.setattr(sandbox_runtime, "_start_egress_proxy", fake_start_egress_proxy)
     monkeypatch.setattr(
         sandbox_runtime,
         "_start_model_proxy",
@@ -663,6 +665,10 @@ def test_docker_command_enforces_stock_containment_and_omits_real_credential(tmp
     )
     target_command = " ".join(target_run)
     relay_command = " ".join(relay_run)
+    audit_log = egress_proxy_args["audit_log"]
+    assert audit_log == (tmp_path / "audit" / "egress.jsonl").resolve()
+    assert not audit_log.is_relative_to(handle.output_dir)
+    assert str(audit_log) not in target_command
     assert "--read-only" in target_run
     assert "--user" in target_run and "65534:65534" in target_run
     assert "--cap-drop" in target_run and "ALL" in target_run

--- a/tests/test_sandbox_runtime_docker.py
+++ b/tests/test_sandbox_runtime_docker.py
@@ -103,7 +103,9 @@ def test_real_stock_sandbox_contains_and_audits_egress_and_cleans_up():
             assert handle.egress_log.read_text(encoding="utf-8") == host_egress_before
             assert not handle.egress_log.is_relative_to(handle.output_dir)
             assert not any(
-                Path(mount["Source"]).resolve() == handle.egress_log.parent.resolve()
+                handle.egress_log.resolve().is_relative_to(
+                    Path(mount["Source"]).resolve()
+                )
                 for mount in inspect["Mounts"]
             )
             policy_write = subprocess.run(

--- a/tests/test_sandbox_runtime_docker.py
+++ b/tests/test_sandbox_runtime_docker.py
@@ -83,6 +83,29 @@ def test_real_stock_sandbox_contains_and_audits_egress_and_cleans_up():
                 text=True,
             )
             assert writable.returncode == 0, writable.stderr
+            # The target may write arbitrary files to its declared output mount,
+            # but that mount must not contain the host proxy's authoritative
+            # egress ledger. A forged lookalike must not alter host evidence.
+            host_egress_before = handle.egress_log.read_text(encoding="utf-8")
+            forged = subprocess.run(
+                [
+                    "docker", "exec", container, "sh", "-c",
+                    (
+                        "printf '%s\\n' '{\"decision\":\"allowed\",\"forged\":true}' "
+                        "> /sandbox/output/egress.jsonl"
+                    ),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            assert forged.returncode == 0, forged.stderr
+            assert handle.egress_log.read_text(encoding="utf-8") == host_egress_before
+            assert not handle.egress_log.is_relative_to(handle.output_dir)
+            assert not any(
+                Path(mount["Source"]).resolve() == handle.egress_log.parent.resolve()
+                for mount in inspect["Mounts"]
+            )
             policy_write = subprocess.run(
                 ["docker", "exec", container, "sh", "-c", "echo x >> /sandbox/policy.json"],
                 check=False,


### PR DESCRIPTION
## Problem

The stock sandbox wrote host-proxy network evidence under the same directory mounted read/write into the evaluated target. A target could overwrite or delete `egress.jsonl` before ASSERT consumed it.

## Fix

- keep the proxy-generated egress ledger in a sibling host-only `audit/` directory
- continue mounting only the target's declared `output/` directory
- document the host-owned network-evidence boundary
- add unit and real-Docker regressions proving a forged `/sandbox/output/egress.jsonl` cannot alter the host ledger

This PR fixes network-ledger mutability only. Moving tool-action capture out of the evaluated process is a separate architectural change.

## Verification

- Regression test was added first and failed against the previous path (`out/egress.jsonl` instead of host-only `audit/egress.jsonl`).
- `74 passed` across focused sandbox runtime/example/hostile-input tests.
- `1370 passed, 24 skipped, 840 subtests passed` across `tests/` after installing the viewer's locked dependencies.
- Live Docker probe: the target successfully created a forged lookalike under `/sandbox/output`, while the host ledger remained unchanged and its directory was absent from target mounts.
- The probe left no new sandbox containers or networks.

## Risk

Low and scoped to the stock container runtime's temporary-directory layout. Both directories remain owned by the same per-case temporary session and are removed together during session cleanup.
