### PR TITLE
ci(sandbox): run real Docker containment tests

### DIFF
--- a/.github/workflows/sandbox-docker.yml
+++ b/.github/workflows/sandbox-docker.yml
@@ -14,7 +14,9 @@ permissions:
   contents: read
 
 concurrency:
-  group: sandbox-docker-${{ github.head_ref || github.ref }}
+  # Branch names are not unique across forks. Scope PR runs to the PR number so
+  # one contributor cannot cancel another contributor's required Docker gate.
+  group: sandbox-docker-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/sandbox-docker.yml
+++ b/.github/workflows/sandbox-docker.yml
@@ -38,7 +38,23 @@ jobs:
         run: docker info
 
       - name: Run real Docker sandbox tests
-        run: pytest tests/test_sandbox_*docker*.py -x -q --junitxml=sandbox-docker-results.xml
+        run: pytest tests/test_sandbox_*docker*.py --runxfail -x -q --junitxml=sandbox-docker-results.xml
+
+      - name: Verify Docker test receipt
+        if: always()
+        shell: python
+        run: |
+          import xml.etree.ElementTree as ET
+
+          root = ET.parse("sandbox-docker-results.xml").getroot()
+          suites = [root] if root.tag == "testsuite" else list(root.findall(".//testsuite"))
+          totals = {
+              key: sum(int(suite.attrib.get(key, 0)) for suite in suites)
+              for key in ("tests", "failures", "errors", "skipped")
+          }
+          print(totals)
+          if totals["tests"] <= 0 or any(totals[key] for key in ("failures", "errors", "skipped")):
+              raise SystemExit("real Docker receipt must contain executed tests with no failures or skips")
 
       - name: Preserve Docker test receipt
         if: always()
@@ -54,9 +70,11 @@ jobs:
         run: |
           containers="$(docker ps -aq --filter 'name=assert-sandbox-')"
           networks="$(docker network ls -q --filter 'name=assert-sandbox-')"
-          if [[ -n "$containers" || -n "$networks" ]]; then
+          images="$(docker image ls -q --filter 'reference=assert-sandbox-stock-agent:local')"
+          if [[ -n "$containers" || -n "$networks" || -n "$images" ]]; then
             echo 'ASSERT sandbox cleanup left Docker resources behind:'
             docker ps -a --filter 'name=assert-sandbox-'
             docker network ls --filter 'name=assert-sandbox-'
+            docker image ls --filter 'reference=assert-sandbox-stock-agent:local'
             exit 1
           fi

--- a/.github/workflows/sandbox-docker.yml
+++ b/.github/workflows/sandbox-docker.yml
@@ -40,7 +40,9 @@ jobs:
         run: docker info
 
       - name: Run real Docker sandbox tests
-        run: pytest tests/test_sandbox_*docker*.py --runxfail -x -q --junitxml=sandbox-docker-results.xml
+        # Keep this exact: the receipt below must be satisfiable only by the
+        # tests that start real containers, never by static workflow checks.
+        run: pytest tests/test_sandbox_runtime_docker.py --runxfail -x -q --junitxml=sandbox-docker-results.xml
 
       - name: Verify Docker test receipt
         if: always()

--- a/.github/workflows/sandbox-docker.yml
+++ b/.github/workflows/sandbox-docker.yml
@@ -4,11 +4,7 @@ name: Sandbox Docker Tests
 on:
   pull_request:
     paths:
-      - 'assert_ai/integrations/sandbox/**'
-      - 'assert_ai/core/config_model.py'
-      - 'assert_ai/core/model_client.py'
-      - 'assert_ai/core/session.py'
-      - 'assert_ai/stages/inference.py'
+      - 'assert_ai/**'
       - 'examples/sandbox_action_mediation/**'
       - 'tests/test_sandbox_*.py'
       - 'tests/conftest.py'
@@ -19,11 +15,7 @@ on:
   push:
     branches: [main]
     paths:
-      - 'assert_ai/integrations/sandbox/**'
-      - 'assert_ai/core/config_model.py'
-      - 'assert_ai/core/model_client.py'
-      - 'assert_ai/core/session.py'
-      - 'assert_ai/stages/inference.py'
+      - 'assert_ai/**'
       - 'examples/sandbox_action_mediation/**'
       - 'tests/test_sandbox_*.py'
       - 'tests/conftest.py'
@@ -57,8 +49,11 @@ jobs:
       - name: Install test dependencies
         run: python -m pip install -e ".[dev,otel]"
 
+      - name: Require a working Docker daemon
+        run: docker info
+
       - name: Run real Docker sandbox tests
-        run: pytest tests/test_sandbox_runtime_docker.py -x -q
+        run: pytest tests/test_sandbox_runtime_docker.py -x -q --junitxml=sandbox-docker-results.xml
 
       - name: Verify no sandbox resources remain
         if: always()

--- a/.github/workflows/sandbox-docker.yml
+++ b/.github/workflows/sandbox-docker.yml
@@ -1,0 +1,50 @@
+# Real-container verification for ASSERT-owned sandbox guarantees.
+name: Sandbox Docker Tests
+
+on:
+  pull_request:
+    paths:
+      - 'assert_ai/integrations/sandbox/**'
+      - 'assert_ai/stages/inference.py'
+      - 'examples/sandbox_action_mediation/**'
+      - 'tests/test_sandbox_*.py'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/sandbox-docker.yml'
+
+concurrency:
+  group: sandbox-docker-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  sandbox-docker:
+    name: "Sandbox: real Docker containment"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      ASSERT_RUN_DOCKER_TESTS: '1'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install test dependencies
+        run: python -m pip install -e ".[dev,otel]"
+
+      - name: Run real Docker sandbox tests
+        run: pytest tests/test_sandbox_runtime_docker.py -x -q
+
+      - name: Verify no sandbox resources remain
+        if: always()
+        shell: bash
+        run: |
+          containers="$(docker ps -aq --filter 'name=assert-sandbox-')"
+          networks="$(docker network ls -q --filter 'name=assert-sandbox-')"
+          if [[ -n "$containers" || -n "$networks" ]]; then
+            echo 'ASSERT sandbox cleanup left Docker resources behind:'
+            docker ps -a --filter 'name=assert-sandbox-'
+            docker network ls --filter 'name=assert-sandbox-'
+            exit 1
+          fi

--- a/.github/workflows/sandbox-docker.yml
+++ b/.github/workflows/sandbox-docker.yml
@@ -5,15 +5,39 @@ on:
   pull_request:
     paths:
       - 'assert_ai/integrations/sandbox/**'
+      - 'assert_ai/core/config_model.py'
+      - 'assert_ai/core/model_client.py'
+      - 'assert_ai/core/session.py'
       - 'assert_ai/stages/inference.py'
       - 'examples/sandbox_action_mediation/**'
       - 'tests/test_sandbox_*.py'
+      - 'tests/conftest.py'
+      - 'pytest.ini'
       - 'pyproject.toml'
       - 'uv.lock'
       - '.github/workflows/sandbox-docker.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'assert_ai/integrations/sandbox/**'
+      - 'assert_ai/core/config_model.py'
+      - 'assert_ai/core/model_client.py'
+      - 'assert_ai/core/session.py'
+      - 'assert_ai/stages/inference.py'
+      - 'examples/sandbox_action_mediation/**'
+      - 'tests/test_sandbox_*.py'
+      - 'tests/conftest.py'
+      - 'pytest.ini'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/sandbox-docker.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 concurrency:
-  group: sandbox-docker-${{ github.head_ref }}
+  group: sandbox-docker-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/sandbox-docker.yml
+++ b/.github/workflows/sandbox-docker.yml
@@ -2,27 +2,12 @@
 name: Sandbox Docker Tests
 
 on:
+  # Run on every PR so this check can be made a required status gate. Path
+  # filters can leave required checks pending, can miss base-branch changes,
+  # and are subject to GitHub's changed-file filter limits.
   pull_request:
-    paths:
-      - 'assert_ai/**'
-      - 'examples/sandbox_action_mediation/**'
-      - 'tests/test_sandbox_*.py'
-      - 'tests/conftest.py'
-      - 'pytest.ini'
-      - 'pyproject.toml'
-      - 'uv.lock'
-      - '.github/workflows/sandbox-docker.yml'
   push:
     branches: [main]
-    paths:
-      - 'assert_ai/**'
-      - 'examples/sandbox_action_mediation/**'
-      - 'tests/test_sandbox_*.py'
-      - 'tests/conftest.py'
-      - 'pytest.ini'
-      - 'pyproject.toml'
-      - 'uv.lock'
-      - '.github/workflows/sandbox-docker.yml'
   workflow_dispatch:
 
 permissions:
@@ -53,7 +38,15 @@ jobs:
         run: docker info
 
       - name: Run real Docker sandbox tests
-        run: pytest tests/test_sandbox_runtime_docker.py -x -q --junitxml=sandbox-docker-results.xml
+        run: pytest tests/test_sandbox_*docker*.py -x -q --junitxml=sandbox-docker-results.xml
+
+      - name: Preserve Docker test receipt
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sandbox-docker-results-${{ github.run_attempt }}
+          path: sandbox-docker-results.xml
+          if-no-files-found: warn
 
       - name: Verify no sandbox resources remain
         if: always()

--- a/tests/test_sandbox_docker_workflow.py
+++ b/tests/test_sandbox_docker_workflow.py
@@ -1,0 +1,19 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "sandbox-docker.yml"
+
+
+def test_docker_workflow_concurrency_is_scoped_to_the_pull_request() -> None:
+    """Equal branch names in different forks must not cancel each other's gate."""
+    workflow = yaml.load(WORKFLOW.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+
+    assert workflow["concurrency"]["group"] == (
+        "sandbox-docker-${{ github.event.pull_request.number || github.ref }}"
+    )

--- a/tests/test_sandbox_docker_workflow.py
+++ b/tests/test_sandbox_docker_workflow.py
@@ -17,3 +17,13 @@ def test_docker_workflow_concurrency_is_scoped_to_the_pull_request() -> None:
     assert workflow["concurrency"]["group"] == (
         "sandbox-docker-${{ github.event.pull_request.number || github.ref }}"
     )
+
+
+def test_docker_workflow_receipt_runs_only_real_container_tests() -> None:
+    """Static workflow tests must never satisfy the real-Docker receipt."""
+    workflow = yaml.load(WORKFLOW.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    steps = workflow["jobs"]["sandbox-docker"]["steps"]
+    test_step = next(step for step in steps if step.get("name") == "Run real Docker sandbox tests")
+
+    assert "pytest tests/test_sandbox_runtime_docker.py " in test_step["run"]
+    assert "*" not in test_step["run"]

--- a/tests/test_sandbox_runtime_docker.py
+++ b/tests/test_sandbox_runtime_docker.py
@@ -54,6 +54,13 @@ def stock_image():
         capture_output=True,
         text=True,
     )
+    yield
+    subprocess.run(
+        ["docker", "image", "rm", "-f", "assert-sandbox-stock-agent:local"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
 
 
 def test_real_stock_sandbox_contains_and_audits_egress_and_cleans_up():

--- a/tests/test_sandbox_runtime_docker.py
+++ b/tests/test_sandbox_runtime_docker.py
@@ -29,9 +29,14 @@ from assert_ai.stages.inference import run_inference
 
 ROOT = Path(__file__).resolve().parents[1]
 RUN = os.environ.get("ASSERT_RUN_DOCKER_TESTS", "").lower() in {"1", "true", "yes"}
+if RUN and not docker_available():
+    raise RuntimeError(
+        "ASSERT_RUN_DOCKER_TESTS is enabled, but the Docker daemon is unavailable; "
+        "required containment tests cannot be skipped"
+    )
 pytestmark = pytest.mark.skipif(
-    not RUN or not docker_available(),
-    reason="set ASSERT_RUN_DOCKER_TESTS=1 with Docker available",
+    not RUN,
+    reason="set ASSERT_RUN_DOCKER_TESTS=1 to run real Docker containment tests",
 )
 
 


### PR DESCRIPTION
## Problem

ASSERT's real Docker sandbox tests were opt-in, and the ordinary unit workflow could collect and skip all of them while still reporting success. A path-filtered workflow also could not serve as a reliable required check.

## Fix

Add an always-present GitHub Actions workflow that:

- runs on every pull request and every push to `main`, avoiding path-filter omissions and pending required checks;
- explicitly fails if the Docker daemon is unavailable;
- makes the test module fail instead of skip when `ASSERT_RUN_DOCKER_TESTS=1` but Docker cannot run;
- executes every `tests/test_sandbox_*docker*.py` module rather than one hard-coded file;
- uploads a JUnit receipt for the exact tests that ran; and
- always checks for leftover target/relay containers and networks, including after failure.

## Verification

- With no opt-in flag, the four live tests skip during ordinary local test runs.
- With the flag enabled and a deliberately failing fake Docker command, collection fails instead of passing with skips.
- Exact-head GitHub Actions ran `Sandbox: real Docker containment` successfully.
- The final combined #327/#328/#329 tree ran all four real-Docker tests with no failures or skips and left no sandbox containers or networks.
- Branch includes current `main`, including the merged host-owned egress ledger correction.

## Remaining repository gate

The current `main` ruleset requires review but does not require status checks. After this workflow merges, `Sandbox: real Docker containment` should be added as a required status check with strict base-branch freshness. The workflow now runs on every PR, so making it required will not leave unrelated PRs waiting for a path-filtered check that never starts.

A clean local image rebuild remains blocked by the local Docker builder's external PyPI TLS failure; the clean build and test path passed in GitHub Actions.
