### PR TITLE
Bump LiteLLM to patched 1.84.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 dependencies = [
   "click>=8.0",
-  "litellm>=1.79.1",
+  "litellm>=1.84.1,<2",
   "matplotlib>=3.10.8",
   "opentelemetry-api>=1.39.0",
   "opentelemetry-sdk>=1.39.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2840,7 +2840,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.82.6"
+version = "1.84.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -2856,9 +2856,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/29/75/1c537aa458426a9127a92bc2273787b2f987f4e5044e21f01f2eed5244fd/litellm-1.82.6.tar.gz", hash = "sha256:2aa1c2da21fe940c33613aa447119674a3ad4d2ad5eb064e4d5ce5ee42420136", size = 17414147, upload-time = "2026-03-22T06:36:00.452Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/9e/ec7d92a10f3aacc7184c5531d67adc20ec0bfb180d6577fb68dc2e6f18f7/litellm-1.84.1.tar.gz", hash = "sha256:2d01b146e5206e49d1bccc224d31afc37b41b275823c27184b81afaba90464c3", size = 15105765, upload-time = "2026-05-21T02:08:02.742Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/6c/5327667e6dbe9e98cbfbd4261c8e91386a52e38f41419575854248bbab6a/litellm-1.82.6-py3-none-any.whl", hash = "sha256:164a3ef3e19f309e3cabc199bef3d2045212712fefdfa25fc7f75884a5b5b205", size = 15591595, upload-time = "2026-03-22T06:35:56.795Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/b0/11913b4b4d02f1fde11a2331b4122b090bd635a79cedbeeb70ef4f8f03b9/litellm-1.84.1-py3-none-any.whl", hash = "sha256:1f39e2d2d134bc0570577df846a987547efafd3c70765b00a83c456318fcdbe8", size = 16736900, upload-time = "2026-05-21T02:07:59.059Z" },
 ]
 
 [[package]]
@@ -4420,7 +4420,7 @@ requires-dist = [
     { name = "langchain-mcp-adapters", marker = "extra == 'examples'", specifier = ">=0.2.2" },
     { name = "langchain-openai", marker = "extra == 'langgraph'", specifier = ">=1.1.14" },
     { name = "langgraph", marker = "extra == 'langgraph'", specifier = ">=1.1.8" },
-    { name = "litellm", specifier = ">=1.79.1" },
+    { name = "litellm", specifier = ">=1.84.1,<2" },
     { name = "llama-index", marker = "extra == 'examples'", specifier = ">=0.14.21" },
     { name = "llama-index-core", marker = "extra == 'examples'", specifier = ">=0.14.21" },
     { name = "llama-index-llms-openai", marker = "extra == 'examples'", specifier = ">=0.7.5" },


### PR DESCRIPTION
## Summary
- raise the LiteLLM minimum to 1.84.1 and cap it below 2.0
- update the lock from 1.82.6 to 1.84.1 to clear known LiteLLM advisories

## Validation
- `uv audit --frozen --no-dev` reports no LiteLLM advisories
- targeted LiteLLM integration tests: 106 passed, 1 skipped