### PR TITLE
fix(cli): report installed package version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `assert-ai --version` now reads the installed distribution metadata instead of reporting a hard-coded stale version.
+
 ## [0.2.0] - 2026-08-14
 
 First release after the initial public launch. Adds an ACS guardrail

--- a/assert_ai/cli.py
+++ b/assert_ai/cli.py
@@ -847,7 +847,7 @@ def _behavior_category_metric_map(
         "  assert-ai results compare-suites suite-a/run-1 suite-b/run-1 suite-c/run-1"
     ),
 )
-@click.version_option(version="0.1.0", prog_name="assert-ai")
+@click.version_option(package_name="assert-ai", prog_name="assert-ai")
 @click.option("-v", "--verbose", is_flag=True, help="Enable debug-level logging.")
 @click.option("-q", "--quiet", is_flag=True, help="Suppress info-level output; show only warnings and errors.")
 @click.option(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,14 @@ class CliTest(unittest.TestCase):
     def setUp(self) -> None:
         self.runner = CliRunner()
 
+    def test_version_uses_installed_distribution_metadata(self) -> None:
+        with patch("importlib.metadata.version", return_value="9.9.9") as package_version:
+            result = self.runner.invoke(cli, ["--version"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(result.output, "assert-ai, version 9.9.9\n")
+        package_version.assert_called_once_with("assert-ai")
+
     def test_removed_commands_are_unavailable(self) -> None:
         for command in ["taxonomy", "test_set"]:
             with self.subTest(command=command):


### PR DESCRIPTION
## Summary

- replace the hard-coded CLI version with Click's installed-distribution lookup for `assert-ai`;
- add a regression test that supplies a future package version and verifies `--version` reports it;
- document the fix under the unreleased changelog.

The published `assert-ai==0.2.0` wheel currently reports `assert-ai, version 0.1.0`. With this change, the CLI reads the same package metadata used by installers, so a future `0.2.1` build will report `0.2.1` without another source edit.

## Validation

- regression test failed against the old hard-coded decorator (`0.1.0` instead of the injected future version) and passes with the fix;
- `tests/test_cli.py`: `12 passed, 3 skipped, 2 subtests passed`;
- full regression suite: `1,440 passed, 23 skipped, 840 subtests passed`;
- built and installed the wheel in a clean virtual environment; both `assert-ai --version` and `importlib.metadata.version("assert-ai")` returned `0.2.0`;
- `git diff --check` clean.
