### PR TITLE
fix(viewer): prevent results table and metric dropdown clipping

### DIFF
--- a/viewer/src/lib/PrimerDropdown.svelte
+++ b/viewer/src/lib/PrimerDropdown.svelte
@@ -36,6 +36,40 @@
   let highlightedIndex = $state(-1);
   let triggerButton: HTMLButtonElement;
   let menuList: HTMLUListElement;
+  // Anchor the fixed-position menu to the trigger so it can escape table
+  // scroll and clipping contexts without inflating their scroll width.
+  let menuStyle = $state('');
+
+  const VIEWPORT_MARGIN = 8;
+  const TRIGGER_GAP = 4;
+  const MIN_MENU_WIDTH = 192;
+
+  function positionMenu() {
+    if (!triggerButton || !menuList) return;
+    const anchor = triggerButton.getBoundingClientRect();
+    const menu = menuList.getBoundingClientRect();
+
+    let left = anchor.left;
+    if (left + menu.width > window.innerWidth - VIEWPORT_MARGIN) {
+      left = anchor.right - menu.width;
+    }
+    left = Math.max(
+      VIEWPORT_MARGIN,
+      Math.min(left, window.innerWidth - menu.width - VIEWPORT_MARGIN)
+    );
+
+    let top = anchor.bottom + TRIGGER_GAP;
+    const overflowsBottom = top + menu.height > window.innerHeight - VIEWPORT_MARGIN;
+    const fitsAbove = anchor.top - TRIGGER_GAP - menu.height >= VIEWPORT_MARGIN;
+    if (overflowsBottom && fitsAbove) {
+      top = anchor.top - TRIGGER_GAP - menu.height;
+    }
+    top = Math.max(VIEWPORT_MARGIN, top);
+
+    menuStyle =
+      `position: fixed; top: ${Math.round(top)}px; left: ${Math.round(left)}px; ` +
+      `min-width: ${Math.round(Math.max(MIN_MENU_WIDTH, anchor.width))}px;`;
+  }
 
   function handleSelect(value: string) {
     selected = value;
@@ -108,6 +142,25 @@
   });
 
   $effect(() => {
+    if (!open) {
+      menuStyle = '';
+      return;
+    }
+
+    positionMenu();
+    const frame = requestAnimationFrame(positionMenu);
+    const reposition = () => positionMenu();
+    window.addEventListener('scroll', reposition, true);
+    window.addEventListener('resize', reposition);
+
+    return () => {
+      cancelAnimationFrame(frame);
+      window.removeEventListener('scroll', reposition, true);
+      window.removeEventListener('resize', reposition);
+    };
+  });
+
+  $effect(() => {
     if (open && highlightedIndex >= 0 && menuList) {
       const items = menuList.querySelectorAll('[role="option"]');
       const item = items[highlightedIndex] as HTMLElement;
@@ -146,6 +199,7 @@
       bind:this={menuList}
       class="ActionList ActionMenu-list"
       role="listbox"
+      style={menuStyle}
       onkeydown={handleKeyDown}
       onblur={handleMenuBlur}
       tabindex={-1}

--- a/viewer/src/lib/server/data.ts
+++ b/viewer/src/lib/server/data.ts
@@ -109,7 +109,7 @@ interface CompareDimensionSummary {
 interface CompareRunSummary {
 	run_id: string;
 	display_name: string;
-	model: string;
+	target: string;
 	judge_model: string;
 	date: string;
 	total: number;
@@ -954,7 +954,7 @@ function buildCompareRunSummary(
 	return {
 		run_id: runId,
 		display_name: runId,
-		model: metrics.target,
+		target: metrics.target,
 		judge_model: metrics.judge_model,
 		date: formatRunDate(manifest),
 		total: metrics.total,

--- a/viewer/src/routes/suite/[suite_id]/+page.svelte
+++ b/viewer/src/routes/suite/[suite_id]/+page.svelte
@@ -819,21 +819,21 @@
 				<p class="text-sm text-text-secondary">No evaluation results yet.</p>
 			</div>
 		{:else}
-			<div class="overflow-hidden rounded-lg border border-border">
-				<table class="w-full text-left text-sm">
+			<div class="overflow-x-auto rounded-lg border border-border">
+				<table class="w-full table-fixed text-left text-sm">
 					<thead>
 						<tr class="border-b border-border bg-surface">
-							<th class="w-8 px-3 py-2 text-xs font-medium text-text-muted"></th>
-							<th class="px-3 py-2 text-xs font-medium text-text-muted">Run</th>
-						<th class="px-3 py-2 text-xs font-medium text-text-muted">
+							<th class="w-12 px-3 py-2 text-xs font-medium text-text-muted"></th>
+							<th class="w-[22rem] px-3 py-2 text-xs font-medium text-text-muted">Run</th>
+						<th class="w-24 px-3 py-2 text-xs font-medium text-text-muted">
 							<span class="inline-flex items-center gap-1">Type
 								<InfoTooltip direction="se" label="Direct prompts are single-turn requests. Multi-turn scenarios simulate longer user conversations against the target." />
 							</span>
 						</th>
-						<th class="px-3 py-2 text-xs font-medium text-text-muted">Run date</th>
-						<th class="px-3 py-2 text-xs font-medium text-text-muted">Run status</th>
+						<th class="w-28 px-3 py-2 text-xs font-medium text-text-muted">Run date</th>
+						<th class="w-28 px-3 py-2 text-xs font-medium text-text-muted">Run status</th>
 						{#each selectedMetricCols as colDim, colIdx (colIdx)}
-							<th class="w-32 px-3 py-2 text-left text-xs font-medium text-text-muted whitespace-nowrap">
+							<th class="metric-col px-3 py-2 text-left text-xs font-medium text-text-muted">
 								<PrimerDropdown
 									ariaLabel={`Metric column ${colIdx + 1}`}
 									selected={colDim ?? ''}
@@ -851,7 +851,7 @@
 								/>
 							</th>
 						{/each}
-						<th class="px-3 py-2 text-left text-xs font-medium text-text-muted">Total</th>
+						<th class="w-16 px-3 py-2 text-left text-xs font-medium text-text-muted">Total</th>
 					</tr>
 				</thead>
 				<tbody>
@@ -887,9 +887,9 @@
 											<svg class="h-3 w-3 transition-transform duration-150 {isExpanded ? 'rotate-90' : ''}" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M9 5l7 7-7 7"/></svg>
 										</button>
 									{/if}
-									<div class="min-w-0 flex flex-col">
-										<a href="/suite/{data.suite_id}/{run.prompt_run_id ?? run.audit_run_id ?? run.run_id}" class="text-sm font-medium text-interactive hover:underline">{run.run_id}</a>
-										<span class="font-mono text-[10px] text-text-muted truncate" title={runTarget(run)}>{runTarget(run)}</span>
+									<div class="flex min-w-0 max-w-[22rem] flex-col">
+										<a href="/suite/{data.suite_id}/{run.prompt_run_id ?? run.audit_run_id ?? run.run_id}" class="truncate text-sm font-medium text-interactive hover:underline">{run.run_id}</a>
+										<span class="truncate font-mono text-[10px] text-text-muted" title={runTarget(run)}>{runTarget(run)}</span>
 									</div>
 								</div>
 							</td>
@@ -965,6 +965,42 @@
 	{/if}
 </div>
 {/if}
+
+<style>
+	.metric-col {
+		width: 10rem;
+		white-space: normal;
+	}
+
+	.metric-col :global(.ActionMenu) {
+		display: block;
+	}
+
+	.metric-col :global(button.ActionMenu-button) {
+		width: 100%;
+		height: auto;
+		min-height: 0;
+		align-items: flex-start;
+		padding: 0.25rem 0.5rem;
+		font-size: 0.75rem;
+		line-height: 1.25;
+		white-space: normal;
+	}
+
+	.metric-col :global(.ActionMenu-button-content) {
+		display: block;
+		min-width: 0;
+	}
+
+	.metric-col :global(.ActionMenu-button-value) {
+		white-space: normal;
+		overflow-wrap: anywhere;
+	}
+
+	.metric-col :global(.ActionMenu-button-chevron) {
+		margin-top: 1px;
+	}
+</style>
 
 {#if activeStage === 'taxonomy'}
 <div class="mb-5 flex flex-wrap items-center justify-between gap-3">

--- a/viewer/src/routes/suite/[suite_id]/compare/+page.svelte
+++ b/viewer/src/routes/suite/[suite_id]/compare/+page.svelte
@@ -62,11 +62,18 @@ let activeMetric = $state(untrack(() => primaryMetricName(data.allMetrics ?? [])
 // Short label for a run's target. Callable targets ("module.path:function_name")
 // reduce to "function_name"; provider/model strings ("provider/model-name")
 // reduce to "model-name". Avoids overflowing column headers and per-run cards.
-function runLabel(model: string | null | undefined): string {
-	const m = model ?? '';
-	if (m.includes(':')) return m.split(':').pop() || m;
-	if (m.includes('/')) return m.split('/').pop() || m;
-	return m;
+function targetLabel(target: string | null | undefined): string {
+	const t = target ?? '';
+	if (t.includes(':')) return t.split(':').pop() || t;
+	if (t.includes('/')) return t.split('/').pop() || t;
+	return t;
+}
+
+// A run id and its target are independent names: the run id comes from the results
+// directory, the target from the config entrypoint. Panels that label runs by only one
+// of them carry both in hover text so the mapping stays recoverable.
+function runTitle(run: { display_name: string; target: string }): string {
+	return run.target ? `${run.display_name} (target: ${run.target})` : run.display_name;
 }
 
 // Re-sort comparisons by active metric's delta
@@ -336,8 +343,8 @@ function sampleGridMinWidth(runCount: number): string {
 						<span class="shrink-0 text-[12px] text-text-muted tabular-nums">{run.total} samples</span>
 					</div>
 
-					<!-- Model name -->
-					<div class="mt-1 font-mono text-xs text-text-muted truncate" title={run.model}>{runLabel(run.model)}</div>
+					<!-- Target entrypoint -->
+					<div class="mt-1 font-mono text-xs text-text-muted truncate" title={runTitle(run)}>{targetLabel(run.target)}</div>
 
 					<!-- Big number -->
 					<div class="mt-3 flex items-baseline gap-1.5">
@@ -427,7 +434,7 @@ function sampleGridMinWidth(runCount: number): string {
 					style="grid-template-columns: {comparisonGridTemplate(data.runs.length)};">
 					<span>Behavior</span>
 					{#each orderedRuns as run (run.run_id)}
-						<span class="text-center font-mono font-medium truncate" title={run.model} style="color: {runColor[run.run_id]}">{runLabel(run.model)}</span>
+						<span class="text-center font-mono font-medium truncate" title={runTitle(run)} style="color: {runColor[run.run_id]}">{run.display_name}</span>
 					{/each}
 				</div>
 
@@ -502,11 +509,11 @@ function sampleGridMinWidth(runCount: number): string {
 																{@const sample = pair.samples[run.run_id]}
 																{@const convo = conversationMessages(sample)}
 																<div class="p-3 space-y-2">
-																	<!-- Model + score -->
+																	<!-- Run + score -->
 																	<div class="flex items-center justify-between">
 																		<div class="flex items-center gap-1.5 min-w-0">
 																			<span class="h-1.5 w-1.5 rounded-full flex-shrink-0" style="background: {runColor[run.run_id]}"></span>
-																			<span class="text-xs font-mono truncate" title={run.model} style="color: {runColor[run.run_id]}">{runLabel(run.model)}</span>
+																			<span class="text-xs font-mono truncate" title={runTitle(run)} style="color: {runColor[run.run_id]}">{run.display_name}</span>
 																		</div>
 																		{#if sample}
 																			{@const sampleScore = getRecordFlag(sample, activeMetric)}
@@ -576,11 +583,11 @@ function sampleGridMinWidth(runCount: number): string {
 														{#each orderedRuns as run (run.run_id)}
 															{@const sample = pair.samples[run.run_id]}
 															<div class="p-3 space-y-2">
-														<!-- Model + score -->
+														<!-- Run + score -->
 														<div class="flex items-center justify-between">
 															<div class="flex items-center gap-1.5 min-w-0">
 																<span class="h-1.5 w-1.5 rounded-full flex-shrink-0" style="background: {runColor[run.run_id]}"></span>
-																<span class="text-xs font-mono truncate" title={run.model} style="color: {runColor[run.run_id]}">{runLabel(run.model)}</span>
+																<span class="text-xs font-mono truncate" title={runTitle(run)} style="color: {runColor[run.run_id]}">{run.display_name}</span>
 															</div>
 															{#if sample}
 																{@const sampleScore = getRecordFlag(sample, activeMetric)}


### PR DESCRIPTION
## Summary

- Keep the suite results table within its container with explicit column widths and wrapped metric labels.
- Truncate long run and target names instead of allowing them to expand the table.
- Position metric dropdown menus against the viewport so table overflow cannot clip their options.
- Retain horizontal scrolling as a fallback for narrower screens.

## Why

The clipping reported in #322 remains reproducible on current `main`. #324 contained an initial fix but closed without merging after the behavior was thought to be covered elsewhere. The suite results route still uses an `overflow-hidden` wrapper and non-wrapping metric controls, which can make the second metric and Total columns unreachable.

## Validation

- `npm ci`
- `npm run check` — 0 errors; existing accessibility warnings remain
- `npm run build`
- Browser reproduction with the 1200px results container: table `scrollWidth` equals `clientWidth`, and the second metric stays within the container
- Open second metric dropdown uses fixed positioning and remains fully within the viewport

## Scope

Viewer UI only. No evaluation artifacts, result values, configs, or runtime behavior changed.